### PR TITLE
Fix SonarLint and IDE diagnostics in cover normalizer and identifier …

### DIFF
--- a/src/main/java/net/findmybook/repository/BookQueryCoverNormalizer.java
+++ b/src/main/java/net/findmybook/repository/BookQueryCoverNormalizer.java
@@ -40,7 +40,7 @@ final class BookQueryCoverNormalizer {
     private static final String LOOPBACK_IP_PREFIX = "://127.0.0.1";
     private static final String ANY_LOCAL_IP_PREFIX = "://0.0.0.0";
     private static final String COVER_PATH_SEGMENT_PROPERTY = "app.cover.path.segment";
-    private static final String DEFAULT_COVER_PATH_SEGMENT = "/images/book-covers/";
+    private static final String DEFAULT_COVER_PATH_SEGMENT = "/images/book-covers/"; // NOSONAR S1075 -- overridable via system property app.cover.path.segment
     private static final String COVER_PATH_SEGMENT = resolveCoverPathSegment();
     private static final String COVER_PATH_SEGMENT_LOWER = COVER_PATH_SEGMENT.toLowerCase(Locale.ROOT);
 

--- a/src/main/java/net/findmybook/service/BookIdentifierResolver.java
+++ b/src/main/java/net/findmybook/service/BookIdentifierResolver.java
@@ -3,10 +3,9 @@ package net.findmybook.service;
 import net.findmybook.dto.BookDetail;
 import net.findmybook.repository.BookQueryRepository;
 import net.findmybook.util.UuidUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
 import org.springframework.util.StringUtils;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -22,8 +21,6 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class BookIdentifierResolver {
-
-    private static final Logger log = LoggerFactory.getLogger(BookIdentifierResolver.class);
 
     private final BookLookupService bookLookupService;
     private final BookQueryRepository bookQueryRepository;
@@ -47,7 +44,7 @@ public class BookIdentifierResolver {
     public Optional<UUID> resolveToUuid(String identifier) throws DataAccessException {
         return resolveCanonicalId(identifier)
             .map(UuidUtils::parseUuidOrNull)
-            .filter(uuid -> uuid != null);
+            .filter(Objects::nonNull);
     }
 
     /**


### PR DESCRIPTION
…resolver

- Suppress S1075 false positive on DEFAULT_COVER_PATH_SEGMENT; the value is already overridable via system property app.cover.path.segment
- Remove unused log field and SLF4J imports from BookIdentifierResolver
- Replace lambda with Objects::nonNull method reference

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No functional behavior changes beyond comments/cleanup; only affects static analysis noise and minor readability refactors.
> 
> **Overview**
> This PR is purely diagnostic/cleanup: it suppresses a SonarLint `S1075` false positive on the overridable `DEFAULT_COVER_PATH_SEGMENT` constant in `BookQueryCoverNormalizer`.
> 
> It also removes an unused SLF4J logger from `BookIdentifierResolver` and replaces a null-filtering lambda with `Objects::nonNull` for clarity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37d1950bb9f9fb40d44d8d261b623bb4eab93852. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->