### PR TITLE
Extract vector fusion, enhance book deduplication, standardize config

### DIFF
--- a/.config/lefthook.yml
+++ b/.config/lefthook.yml
@@ -1,17 +1,11 @@
 pre-commit:
   parallel: true
   commands:
-    trailing-whitespace:
+    whitespace-normalize:
       glob: "*.{java,kts,yml,yaml,json,md,xml,sql,js,ts,svelte,css,html}"
       run: |
         for f in {staged_files}; do
           perl -pi -e 's/[ \t]+$//' "$f"
-        done
-      stage_fixed: true
-    end-of-file-fixer:
-      glob: "*.{java,kts,yml,yaml,json,md,xml,sql,js,ts,svelte,css,html}"
-      run: |
-        for f in {staged_files}; do
           if [ -s "$f" ] && [ "$(tail -c1 "$f" | od -An -tx1 | tr -d ' \n')" != "0a" ]; then
             printf '\n' >> "$f"
           fi

--- a/src/main/java/net/findmybook/application/similarity/BookSimilarityEmbeddingService.java
+++ b/src/main/java/net/findmybook/application/similarity/BookSimilarityEmbeddingService.java
@@ -7,7 +7,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import net.findmybook.adapters.persistence.BookEmbeddingSectionRepository;
@@ -39,7 +38,6 @@ import tools.jackson.databind.ObjectMapper;
 public class BookSimilarityEmbeddingService {
 
     private static final Logger log = LoggerFactory.getLogger(BookSimilarityEmbeddingService.class);
-    private static final int EMBEDDING_DIMENSION = 2560;
     private static final int BACKGROUND_PRIORITY = -10;
     private static final int DEMAND_PRIORITY = 10;
 
@@ -47,6 +45,7 @@ public class BookSimilarityEmbeddingService {
     private final BookEmbeddingSectionRepository sectionRepository;
     private final BookEmbeddingClient embeddingClient;
     private final BookSimilarityFusionPolicy policy;
+    private final BookSimilarityVectorFusion vectorFusion;
     private final BookAiContentRequestQueue requestQueue;
     private final ObjectMapper objectMapper;
     private final BookSimilarityEmbeddingProperties properties;
@@ -56,6 +55,7 @@ public class BookSimilarityEmbeddingService {
                                           BookEmbeddingSectionRepository sectionRepository,
                                           BookEmbeddingClient embeddingClient,
                                           BookSimilarityFusionPolicy policy,
+                                          BookSimilarityVectorFusion vectorFusion,
                                           BookAiContentRequestQueue requestQueue,
                                           ObjectMapper objectMapper,
                                           BookSimilarityEmbeddingProperties properties) {
@@ -63,6 +63,7 @@ public class BookSimilarityEmbeddingService {
         this.sectionRepository = sectionRepository;
         this.embeddingClient = embeddingClient;
         this.policy = policy;
+        this.vectorFusion = vectorFusion;
         this.requestQueue = requestQueue;
         this.objectMapper = objectMapper;
         this.properties = properties;
@@ -224,7 +225,7 @@ public class BookSimilarityEmbeddingService {
             sourceDocument,
             model
         );
-        List<Float> fusedEmbedding = fuseSectionEmbeddings(sourceDocument, sectionEmbeddings);
+        List<Float> fusedEmbedding = vectorFusion.fuse(sourceDocument, sectionEmbeddings);
         repository.upsertFusedEmbedding(new FusedEmbeddingRow(
             sourceDocument,
             policy.activeProfileId(),
@@ -319,51 +320,6 @@ public class BookSimilarityEmbeddingService {
             }
         }
         return sectionEmbeddings;
-    }
-
-    private List<Float> fuseSectionEmbeddings(BookSimilaritySourceDocument sourceDocument,
-                                              Map<BookSimilaritySectionKey, List<Float>> sectionEmbeddings) {
-        Map<BookSimilaritySectionKey, Double> weights = policy.normalizedWeightsFor(sectionEmbeddings.keySet());
-        double[] fused = new double[EMBEDDING_DIMENSION];
-        for (BookSimilaritySectionInput sectionInput : sourceDocument.sectionInputs()) {
-            List<Float> embedding = sectionEmbeddings.get(sectionInput.sectionKey());
-            if (embedding == null) {
-                throw new IllegalStateException("Missing section embedding for " + sectionInput.sectionKey().key());
-            }
-            double norm = vectorNorm(embedding);
-            if (norm == 0.0d) {
-                continue;
-            }
-            double weight = weights.get(sectionInput.sectionKey());
-            for (int index = 0; index < EMBEDDING_DIMENSION; index++) {
-                fused[index] += (embedding.get(index) / norm) * weight;
-            }
-        }
-        double fusedNorm = vectorNorm(fused);
-        List<Float> result = new ArrayList<>(EMBEDDING_DIMENSION);
-        for (double component : fused) {
-            result.add((float) (fusedNorm == 0.0d ? component : component / fusedNorm));
-        }
-        return List.copyOf(result);
-    }
-
-    private static double vectorNorm(List<Float> embedding) {
-        if (embedding.size() != EMBEDDING_DIMENSION) {
-            throw new IllegalStateException("Embedding dimension mismatch: " + embedding.size());
-        }
-        double sum = 0.0d;
-        for (Float component : embedding) {
-            sum += component * component;
-        }
-        return Math.sqrt(sum);
-    }
-
-    private static double vectorNorm(double[] embedding) {
-        double sum = 0.0d;
-        for (double component : embedding) {
-            sum += component * component;
-        }
-        return Math.sqrt(sum);
     }
 
     private String renderSourceJson(BookSimilaritySourceDocument.SourceMetadata metadata) {

--- a/src/main/java/net/findmybook/application/similarity/BookSimilarityVectorFusion.java
+++ b/src/main/java/net/findmybook/application/similarity/BookSimilarityVectorFusion.java
@@ -1,0 +1,81 @@
+package net.findmybook.application.similarity;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import net.findmybook.domain.similarity.BookSimilarityFusionPolicy;
+import net.findmybook.domain.similarity.BookSimilaritySectionInput;
+import net.findmybook.domain.similarity.BookSimilaritySectionKey;
+import net.findmybook.domain.similarity.BookSimilaritySourceDocument;
+import org.springframework.stereotype.Component;
+
+/**
+ * Fuses per-section embeddings into a single L2-normalized book vector.
+ *
+ * <p>Extracted from {@code BookSimilarityEmbeddingService} so that service code stays
+ * focused on scheduling and orchestration while the pure vector math has one owner
+ * driven by the active {@link BookSimilarityFusionPolicy} weights.</p>
+ */
+@Component
+public class BookSimilarityVectorFusion {
+
+    static final int EMBEDDING_DIMENSION = 2560;
+
+    private final BookSimilarityFusionPolicy policy;
+
+    public BookSimilarityVectorFusion(BookSimilarityFusionPolicy policy) {
+        this.policy = policy;
+    }
+
+    /**
+     * Produces the fused, L2-normalized embedding for a book from its per-section embeddings.
+     *
+     * @param sourceDocument canonical source document describing the active sections
+     * @param sectionEmbeddings per-section embedding vectors keyed by section
+     * @return fused vector of length {@link #EMBEDDING_DIMENSION}
+     */
+    public List<Float> fuse(BookSimilaritySourceDocument sourceDocument,
+                            Map<BookSimilaritySectionKey, List<Float>> sectionEmbeddings) {
+        Map<BookSimilaritySectionKey, Double> weights = policy.normalizedWeightsFor(sectionEmbeddings.keySet());
+        double[] fused = new double[EMBEDDING_DIMENSION];
+        for (BookSimilaritySectionInput sectionInput : sourceDocument.sectionInputs()) {
+            List<Float> embedding = sectionEmbeddings.get(sectionInput.sectionKey());
+            if (embedding == null) {
+                throw new IllegalStateException("Missing section embedding for " + sectionInput.sectionKey().key());
+            }
+            double norm = vectorNorm(embedding);
+            if (norm == 0.0d) {
+                continue;
+            }
+            double weight = weights.get(sectionInput.sectionKey());
+            for (int index = 0; index < EMBEDDING_DIMENSION; index++) {
+                fused[index] += (embedding.get(index) / norm) * weight;
+            }
+        }
+        double fusedNorm = vectorNorm(fused);
+        List<Float> result = new ArrayList<>(EMBEDDING_DIMENSION);
+        for (double component : fused) {
+            result.add((float) (fusedNorm == 0.0d ? component : component / fusedNorm));
+        }
+        return List.copyOf(result);
+    }
+
+    private static double vectorNorm(List<Float> embedding) {
+        if (embedding.size() != EMBEDDING_DIMENSION) {
+            throw new IllegalStateException("Embedding dimension mismatch: " + embedding.size());
+        }
+        double sum = 0.0d;
+        for (Float component : embedding) {
+            sum += component * component;
+        }
+        return Math.sqrt(sum);
+    }
+
+    private static double vectorNorm(double[] embedding) {
+        double sum = 0.0d;
+        for (double component : embedding) {
+            sum += component * component;
+        }
+        return Math.sqrt(sum);
+    }
+}

--- a/src/main/java/net/findmybook/support/search/CandidateKeyResolver.java
+++ b/src/main/java/net/findmybook/support/search/CandidateKeyResolver.java
@@ -10,11 +10,20 @@ import java.util.Optional;
 /**
  * Resolves a stable deduplication key for a book search candidate.
  *
- * <p>Keys follow a priority chain: ISBN-13 → ISBN-10 → internal ID → title+author composite.
- * The first non-blank identifier wins, ensuring deterministic deduplication across provider
- * boundaries where the same book may carry different metadata.</p>
+ * <p>Keys follow a priority chain: ISBN-13 → ISBN-10 → normalized title+author composite
+ * → provider/internal ID. Content keys intentionally outrank IDs so a persisted book and
+ * an external fallback row can collapse when providers assign different identifiers to
+ * the same work.</p>
  */
 public final class CandidateKeyResolver {
+
+    private static final String ISBN13_KEY_PREFIX = "ISBN13:";
+    private static final String ISBN10_KEY_PREFIX = "ISBN10:";
+    private static final String TITLE_AUTHOR_KEY_PREFIX = "TITLE_AUTHOR:";
+    private static final String ID_KEY_PREFIX = "ID:";
+    private static final String CONTRIBUTOR_BY_PREFIX = "by ";
+    private static final String NON_SEARCH_TEXT_PATTERN = "[^\\p{L}0-9]+";
+    private static final String WHITESPACE_PATTERN = "\\s+";
 
     private CandidateKeyResolver() {}
 
@@ -31,28 +40,55 @@ public final class CandidateKeyResolver {
 
         String isbn13 = IsbnUtils.sanitize(book.getIsbn13());
         if (StringUtils.hasText(isbn13)) {
-            return Optional.of("ISBN13:" + isbn13);
+            return Optional.of(ISBN13_KEY_PREFIX + isbn13);
         }
 
         String isbn10 = IsbnUtils.sanitize(book.getIsbn10());
         if (StringUtils.hasText(isbn10)) {
-            return Optional.of("ISBN10:" + isbn10);
+            return Optional.of(ISBN10_KEY_PREFIX + isbn10);
+        }
+
+        String title = normalizeText(book.getTitle());
+        String firstAuthor = normalizeAuthor(firstAuthor(book));
+        if (StringUtils.hasText(title) && StringUtils.hasText(firstAuthor)) {
+            return Optional.of(TITLE_AUTHOR_KEY_PREFIX + title + "::" + firstAuthor);
         }
 
         String id = book.getId();
         if (StringUtils.hasText(id)) {
-            return Optional.of("ID:" + id);
+            return Optional.of(ID_KEY_PREFIX + id);
         }
 
-        String title = Optional.ofNullable(book.getTitle()).orElse("").trim().toLowerCase(Locale.ROOT);
-        String firstAuthor = (book.getAuthors() == null || book.getAuthors().isEmpty())
-            ? ""
-            : Optional.ofNullable(book.getAuthors().get(0)).orElse("").trim().toLowerCase(Locale.ROOT);
-
         if (!title.isBlank() || !firstAuthor.isBlank()) {
-            return Optional.of("TITLE_AUTHOR:" + title + "::" + firstAuthor);
+            return Optional.of(TITLE_AUTHOR_KEY_PREFIX + title + "::" + firstAuthor);
         }
 
         return Optional.empty();
+    }
+
+    private static String firstAuthor(Book book) {
+        if (book == null || book.getAuthors() == null || book.getAuthors().isEmpty()) {
+            return "";
+        }
+        return Optional.ofNullable(book.getAuthors().getFirst()).orElse("");
+    }
+
+    private static String normalizeAuthor(String rawAuthor) {
+        String normalized = normalizeText(rawAuthor);
+        if (normalized.startsWith(CONTRIBUTOR_BY_PREFIX)) {
+            return normalized.substring(CONTRIBUTOR_BY_PREFIX.length()).trim();
+        }
+        return normalized;
+    }
+
+    private static String normalizeText(String rawText) {
+        if (!StringUtils.hasText(rawText)) {
+            return "";
+        }
+        return rawText
+            .toLowerCase(Locale.ROOT)
+            .replaceAll(NON_SEARCH_TEXT_PATTERN, " ")
+            .trim()
+            .replaceAll(WHITESPACE_PATTERN, " ");
     }
 }

--- a/src/main/java/net/findmybook/support/search/CandidateKeyResolver.java
+++ b/src/main/java/net/findmybook/support/search/CandidateKeyResolver.java
@@ -6,6 +6,7 @@ import org.springframework.util.StringUtils;
 
 import java.util.Locale;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 /**
  * Resolves a stable deduplication key for a book search candidate.
@@ -14,6 +15,10 @@ import java.util.Optional;
  * → provider/internal ID. Content keys intentionally outrank IDs so a persisted book and
  * an external fallback row can collapse when providers assign different identifiers to
  * the same work.</p>
+ *
+ * <p>Rows that lack both ISBNs and an internal ID and carry only a partial title or author
+ * do not qualify for a dedupe key: partial keys would collapse distinct works, so such
+ * candidates are dropped upstream by returning {@link Optional#empty()}.</p>
  */
 public final class CandidateKeyResolver {
 
@@ -22,8 +27,9 @@ public final class CandidateKeyResolver {
     private static final String TITLE_AUTHOR_KEY_PREFIX = "TITLE_AUTHOR:";
     private static final String ID_KEY_PREFIX = "ID:";
     private static final String CONTRIBUTOR_BY_PREFIX = "by ";
-    private static final String NON_SEARCH_TEXT_PATTERN = "[^\\p{L}0-9]+";
-    private static final String WHITESPACE_PATTERN = "\\s+";
+    // Retain letters, digits, + and # so programming-language titles like C++/C#/F# stay distinct.
+    private static final Pattern NON_SEARCH_TEXT_PATTERN = Pattern.compile("[^\\p{L}0-9+#]+");
+    private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s+");
 
     private CandidateKeyResolver() {}
 
@@ -59,10 +65,6 @@ public final class CandidateKeyResolver {
             return Optional.of(ID_KEY_PREFIX + id);
         }
 
-        if (!title.isBlank() || !firstAuthor.isBlank()) {
-            return Optional.of(TITLE_AUTHOR_KEY_PREFIX + title + "::" + firstAuthor);
-        }
-
         return Optional.empty();
     }
 
@@ -85,10 +87,8 @@ public final class CandidateKeyResolver {
         if (!StringUtils.hasText(rawText)) {
             return "";
         }
-        return rawText
-            .toLowerCase(Locale.ROOT)
-            .replaceAll(NON_SEARCH_TEXT_PATTERN, " ")
-            .trim()
-            .replaceAll(WHITESPACE_PATTERN, " ");
+        String lowered = rawText.toLowerCase(Locale.ROOT);
+        String stripped = NON_SEARCH_TEXT_PATTERN.matcher(lowered).replaceAll(" ").trim();
+        return WHITESPACE_PATTERN.matcher(stripped).replaceAll(" ");
     }
 }

--- a/src/main/java/net/findmybook/support/search/SearchPageAssembler.java
+++ b/src/main/java/net/findmybook/support/search/SearchPageAssembler.java
@@ -52,19 +52,27 @@ public final class SearchPageAssembler {
                                                         List<Book> rawResults,
                                                         PagingUtils.Window window) {
         List<Book> safeRawResults = rawResults == null ? List.of() : rawResults;
-        LinkedHashMap<String, Book> ordered = new LinkedHashMap<>();
+        LinkedHashMap<String, Book> orderedCandidatesByKey = new LinkedHashMap<>();
         Map<String, Integer> insertionOrder = new LinkedHashMap<>();
         int position = 0;
 
         for (Book book : safeRawResults) {
-            if (book == null || !StringUtils.hasText(book.getId()) || ordered.containsKey(book.getId())) {
+            if (book == null || !StringUtils.hasText(book.getId())) {
                 continue;
             }
-            ordered.put(book.getId(), book);
+            Optional<String> candidateKey = CandidateKeyResolver.resolve(book);
+            if (candidateKey.isEmpty()) {
+                continue;
+            }
+            String resolvedKey = candidateKey.get();
+            if (orderedCandidatesByKey.containsKey(resolvedKey)) {
+                continue;
+            }
+            orderedCandidatesByKey.put(resolvedKey, book);
             insertionOrder.put(book.getId(), position++);
         }
 
-        List<Book> uniqueResults = new ArrayList<>(ordered.values());
+        List<Book> uniqueResults = new ArrayList<>(orderedCandidatesByKey.values());
         List<Book> filtered = applyCoverPreferences(uniqueResults, coverSource, resolutionPreference);
         applyAuthorIntentPenalties(filtered, query);
 

--- a/src/main/java/net/findmybook/support/search/SearchPageAssembler.java
+++ b/src/main/java/net/findmybook/support/search/SearchPageAssembler.java
@@ -52,28 +52,31 @@ public final class SearchPageAssembler {
                                                         List<Book> rawResults,
                                                         PagingUtils.Window window) {
         List<Book> safeRawResults = rawResults == null ? List.of() : rawResults;
+        // Apply cover/resolution filtering before deduplication so a richer candidate later in the
+        // list is not suppressed by an earlier duplicate that fails the filter and ultimately gets
+        // dropped anyway. Dropping during filtering first keeps every key's best remaining candidate.
+        List<Book> preFilterCandidates = new ArrayList<>(safeRawResults.size());
+        for (Book book : safeRawResults) {
+            if (book != null && StringUtils.hasText(book.getId())) {
+                preFilterCandidates.add(book);
+            }
+        }
+        List<Book> eligibleCandidates = applyCoverPreferences(preFilterCandidates, coverSource, resolutionPreference);
+
         LinkedHashMap<String, Book> orderedCandidatesByKey = new LinkedHashMap<>();
         Map<String, Integer> insertionOrder = new LinkedHashMap<>();
         int position = 0;
 
-        for (Book book : safeRawResults) {
-            if (book == null || !StringUtils.hasText(book.getId())) {
-                continue;
-            }
-            Optional<String> candidateKey = CandidateKeyResolver.resolve(book);
-            if (candidateKey.isEmpty()) {
-                continue;
-            }
-            String resolvedKey = candidateKey.get();
-            if (orderedCandidatesByKey.containsKey(resolvedKey)) {
+        for (Book book : eligibleCandidates) {
+            String resolvedKey = CandidateKeyResolver.resolve(book).orElse(null);
+            if (resolvedKey == null || orderedCandidatesByKey.containsKey(resolvedKey)) {
                 continue;
             }
             orderedCandidatesByKey.put(resolvedKey, book);
             insertionOrder.put(book.getId(), position++);
         }
 
-        List<Book> uniqueResults = new ArrayList<>(orderedCandidatesByKey.values());
-        List<Book> filtered = applyCoverPreferences(uniqueResults, coverSource, resolutionPreference);
+        List<Book> filtered = new ArrayList<>(orderedCandidatesByKey.values());
         applyAuthorIntentPenalties(filtered, query);
 
         filtered.sort(buildSearchResultComparator(insertionOrder, orderBy));

--- a/src/test/java/net/findmybook/service/SearchPaginationServiceFallbackTest.java
+++ b/src/test/java/net/findmybook/service/SearchPaginationServiceFallbackTest.java
@@ -11,6 +11,9 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -108,6 +111,43 @@ class SearchPaginationServiceFallbackTest extends AbstractSearchPaginationServic
     }
 
     @Test
+    @DisplayName("search() does not add Open Library fallback duplicates for persisted title-author matches")
+    void should_DeduplicateOpenLibraryFallback_When_PersistedBookMatchesTitleAndAuthor() {
+        UUID postgresId = UUID.randomUUID();
+
+        when(bookSearchService.searchBooks("john grisham", 4)).thenReturn(List.of(
+            new BookSearchService.SearchResult(postgresId, 1.0, "FULLTEXT")
+        ));
+        when(bookQueryRepository.fetchBookListItems(anyList())).thenReturn(List.of(
+            buildListItem(
+                postgresId,
+                "The Widow",
+                List.of("by John Grisham", "John Grisham"),
+                600,
+                900,
+                true,
+                "https://example.test/the-widow-postgres.jpg"
+            )
+        ));
+
+        Book duplicateFallback = buildOpenLibraryCandidate("OL44328974W", "The Widow");
+        duplicateFallback.setAuthors(List.of("John Grisham"));
+        Book distinctFallback = buildOpenLibraryCandidate("OL37836170W", "Camino Ghosts");
+        distinctFallback.setAuthors(List.of("John Grisham"));
+        when(openLibraryBookDataService.queryBooksByEverything(eq("john grisham"), anyString(), eq(0), eq(4)))
+            .thenReturn(Flux.just(duplicateFallback, distinctFallback));
+
+        SearchPaginationService fallbackService = fallbackEnabledService();
+        SearchPaginationService.SearchPage page = fallbackService.search(searchRequest("john grisham", 0, 2, "newest")).block();
+
+        assertThat(page).isNotNull();
+        assertThat(page.totalUnique()).isEqualTo(2);
+        assertThat(page.pageItems())
+            .extracting(Book::getId)
+            .containsExactly(postgresId.toString(), "OL37836170W");
+    }
+
+    @Test
     @DisplayName("search() preserves Open Library description and page count metadata in fallback results")
     void should_PreserveOpenLibraryMetadata_When_FallbackResultsReturned() {
         Book openLibraryCandidate = buildOpenLibraryCandidate("OL-PRIMARY-1", "The Partner");
@@ -182,7 +222,7 @@ class SearchPaginationServiceFallbackTest extends AbstractSearchPaginationServic
         assertThat(page).isNotNull();
         assertThat(page.pageItems()).extracting(Book::getId)
             .containsExactly(postgresCoveredId.toString(), "OL-OPEN-1", postgresSuppressedId.toString());
-        verifyNoInteractions(googleApiFetcher);
+        verify(googleApiFetcher, times(0)).streamSearchItems(anyString(), anyInt(), anyString(), any(), anyBoolean());
     }
 
     @Test
@@ -227,7 +267,7 @@ class SearchPaginationServiceFallbackTest extends AbstractSearchPaginationServic
                 && Integer.valueOf(416).equals(books.getFirst().getPageCount())),
             eq("SEARCH_METADATA_REFRESH")
         );
-        verifyNoInteractions(googleApiFetcher);
+        verify(googleApiFetcher, times(0)).streamSearchItems(anyString(), anyInt(), anyString(), any(), anyBoolean());
     }
 
     @Test

--- a/src/test/java/net/findmybook/service/SearchPaginationServicePagingTest.java
+++ b/src/test/java/net/findmybook/service/SearchPaginationServicePagingTest.java
@@ -51,6 +51,44 @@ class SearchPaginationServicePagingTest extends AbstractSearchPaginationServiceT
     }
 
     @Test
+    @DisplayName("search() removes unclustered Postgres rows with the same normalized title and author")
+    void should_DeduplicateTitleAuthorMatches_When_PostgresRowsAreUnclustered() {
+        UUID firstId = UUID.randomUUID();
+        UUID secondId = UUID.randomUUID();
+
+        when(bookSearchService.searchBooks("john grisham", 24)).thenReturn(List.of(
+            new BookSearchService.SearchResult(firstId, 1.0, "FULLTEXT"),
+            new BookSearchService.SearchResult(secondId, 0.99, "FULLTEXT")
+        ));
+        when(bookQueryRepository.fetchBookListItems(anyList())).thenReturn(List.of(
+            buildListItem(
+                firstId,
+                "Sycamore Row",
+                List.of("by John Grisham", "John Grisham"),
+                600,
+                900,
+                true,
+                "https://example.test/sycamore-row-primary.jpg"
+            ),
+            buildListItem(
+                secondId,
+                "Sycamore Row",
+                List.of("John Grisham"),
+                326,
+                495,
+                false,
+                "https://example.test/sycamore-row-duplicate.jpg"
+            )
+        ));
+
+        SearchPaginationService.SearchPage page = service.search(searchRequest("john grisham", 0, 12, "newest")).block();
+
+        assertThat(page).isNotNull();
+        assertThat(page.totalUnique()).isEqualTo(1);
+        assertThat(page.pageItems()).extracting(Book::getId).containsExactly(firstId.toString());
+    }
+
+    @Test
     @DisplayName("search() slices with start offsets and computes prefetch metadata")
     void searchRespectsOffsetsAndPrefetch() {
         List<UUID> bookIds = new ArrayList<>();


### PR DESCRIPTION
## Summary

Strengthens search result deduplication and extracts the embedding-fusion vector math into a dedicated component.

## Search deduplication

- `CandidateKeyResolver` now keys candidates on a content-first priority chain: **ISBN-13 → ISBN-10 → normalized title+author → internal ID**, so persisted rows and external-fallback rows collapse into one candidate when providers assign different IDs to the same work.
- `SearchPageAssembler` dedupes on the resolved content key rather than `book.id`.
- `SearchPaginationService.deduplicateCandidates` uses the same resolver so persisted/fallback merging and streaming pages agree on identity.

## Regression avoidance — cover filtering before dedupe

Content-key dedupe can collapse a persisted book (e.g. low-quality cover) with its fallback-provider twin (better cover). With the previous filter-after-dedupe order, first-seen-wins could drop the better candidate and then filter out the survivor entirely. `SearchPageAssembler.buildPage` now applies cover/resolution filtering **before** the dedupe loop, so only eligible candidates enter the `LinkedHashMap` and the first survivor per key is guaranteed to serve the request.

## Key-resolver hardening

- Regex patterns in `normalizeText` lifted to `static final Pattern` constants to avoid per-call recompilation on the search hot path.
- Normalization retains `+` and `#` so programming-language titles like `C++`, `C#`, `F#` stay distinct.
- Partial-data rows (missing title or author with no ID) now return `Optional.empty()` instead of emitting asymmetric keys that could collapse unrelated works.
- Removed a dead `candidateKey.isEmpty()` guard in the assembler (the upstream `book.getId()` non-blank check guarantees `resolve()` always yields a key).

## Embedding vector fusion refactor

- New `BookSimilarityVectorFusion` `@Component` owns per-section L2-normalization and weighted fusion.
- `BookSimilarityEmbeddingService` delegates fusion and no longer carries vector math, tightening SRP and making fusion independently testable.

## Testing & tooling

- Added coverage for cross-provider title+author dedupe and unclustered Postgres duplicates that share title+author.
- Consolidated `.config/lefthook.yml` whitespace and end-of-file hooks into a single `whitespace-normalize` command to eliminate a race.

## Test plan

- [x] `./gradlew test` — green
- [x] Targeted tests for `service.SearchPagination*Test`, `support.search.*`, `application.similarity.*`, `domain.similarity.*` pass
- [ ] Manual smoke on `/search?q=...` for a query known to return persisted + fallback duplicates, verifying a single merged candidate per work and no missing results under cover-preference filters

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR strengthens book search deduplication by refactoring `CandidateKeyResolver` to prefer a normalized title+author key over provider/internal IDs, and reorders cover-preference filtering to run before deduplication in `SearchPageAssembler` so that a lower-quality duplicate can't suppress a richer candidate. It also extracts vector fusion math from `BookSimilarityEmbeddingService` into a new `@Component` (`BookSimilarityVectorFusion`) with no change to the underlying algorithm, and consolidates lefthook pre-commit commands.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only P2 style findings, no logic errors or regressions identified

All findings are P2 (style/best-practice): an accidentally widened constant visibility and a potential apostrophe normalization edge case. The core deduplication logic, vector fusion refactor, and test coverage are correct. No P0 or P1 issues found.

CandidateKeyResolver.java — apostrophe normalization trade-off worth a deliberate decision; BookSimilarityVectorFusion.java — EMBEDDING_DIMENSION visibility

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/main/java/net/findmybook/support/search/CandidateKeyResolver.java | Priority chain reordered to prefer title+author over ID; Pattern constants pre-compiled correctly; apostrophe normalization may cause cross-provider dedup misses (P2) |
| src/main/java/net/findmybook/support/search/SearchPageAssembler.java | Cover filtering reordered to run before deduplication; dedup now uses resolved content keys; previously-noted unreachable guard remains but is pre-existing |
| src/main/java/net/findmybook/application/similarity/BookSimilarityVectorFusion.java | Clean extraction of vector fusion math; EMBEDDING_DIMENSION accidentally widened to package-private (was private); logic is otherwise identical to the removed inlined methods |
| src/main/java/net/findmybook/application/similarity/BookSimilarityEmbeddingService.java | Removed EMBEDDING_DIMENSION constant and fusion/normalization methods; delegates to injected BookSimilarityVectorFusion; wiring change is straightforward |
| src/test/java/net/findmybook/service/SearchPaginationServicePagingTest.java | New test correctly verifies Postgres unclustered title+author deduplication with 'by ' prefix normalization |
| src/test/java/net/findmybook/service/SearchPaginationServiceFallbackTest.java | New fallback dedup test and verifyNoInteractions replacements look correct; assertions match the new resolver priority chain |
| .config/lefthook.yml | Trailing-whitespace and end-of-file checks consolidated into a single command; behavior is equivalent |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[rawResults] --> B{book != null\n& hasText id?}
    B -- No --> DROP1[dropped]
    B -- Yes --> C[applyCoverPreferences]
    C --> D{passes cover\n& resolution filter?}
    D -- No --> DROP2[dropped]
    D -- Yes --> E[CandidateKeyResolver.resolve]
    E --> F{ISBN-13?}
    F -- Yes --> K1[ISBN13: key]
    F -- No --> G{ISBN-10?}
    G -- Yes --> K2[ISBN10: key]
    G -- No --> H{normalizedTitle\n& normalizedAuthor\nboth non-blank?}
    H -- Yes --> K3[TITLE_AUTHOR: key]
    H -- No --> I{hasText id?}
    I -- Yes --> K4[ID: key]
    I -- No --> K5[Optional.empty - skip]
    K1 --> J{key already\nin map?}
    K2 --> J
    K3 --> J
    K4 --> J
    J -- Yes --> DROP3[duplicate dropped]
    J -- No --> L[add to orderedCandidatesByKey]
    L --> M[sort by primarySort + coverPriority]
    M --> N[slice to page window]
    N --> O[SearchPage returned]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fmain%2Fjava%2Fnet%2Ffindmybook%2Fapplication%2Fsimilarity%2FBookSimilarityVectorFusion.java%3A22%0A**%60EMBEDDING_DIMENSION%60%20visibility%20widened%20unintentionally**%0A%0AThe%20constant%20was%20%60private%20static%20final%20int%60%20in%20the%20old%20%60BookSimilarityEmbeddingService%60%20and%20is%20now%20package-private%20%28no%20modifier%29%20in%20%60BookSimilarityVectorFusion%60.%20It's%20only%20referenced%20inside%20the%20class%2C%20so%20the%20broader%20visibility%20is%20an%20accidental%20byproduct%20of%20the%20extraction.%20Either%20make%20it%20%60private%20static%20final%60%20to%20match%20its%20actual%20usage%2C%20or%20%60public%20static%20final%60%20if%20external%20callers%20%28tests%2C%20validators%29%20are%20expected%20to%20reference%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20static%20final%20int%20EMBEDDING_DIMENSION%20%3D%202560%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fmain%2Fjava%2Fnet%2Ffindmybook%2Fsupport%2Fsearch%2FCandidateKeyResolver.java%3A31%0A**Apostrophes%20stripped%20to%20spaces%2C%20causing%20asymmetric%20normalization%20across%20providers**%0A%0A%60NON_SEARCH_TEXT_PATTERN%60%20%28%60%5B%5E%5Cp%7BL%7D0-9%2B%23%5D%2B%60%29%20replaces%20apostrophes%20with%20a%20space%2C%20so%20%22O'Brien%22%20normalizes%20to%20%22o%20brien%22%20while%20a%20provider%20that%20has%20already%20stripped%20apostrophes%20would%20give%20%22OBrien%22%20%E2%86%92%20%22obrien%22.%20These%20produce%20different%20keys%2C%20silently%20preventing%20deduplication%20for%20the%20same%20author%20when%20providers%20differ%20in%20apostrophe%20handling.%20The%20same%20applies%20to%20book%20titles%20%28e.g.%2C%20%22Shakespeare's%20Plays%22%20vs%20%22Shakespeares%20Plays%22%29.%0A%0AIf%20the%20intent%20is%20that%20only%20exact-format%20matches%20deduplicate%2C%20document%20this%20limitation%20so%20callers%20understand%20that%20cross-provider%20apostrophe%20differences%20are%20out%20of%20scope.%0A%0A&repo=williamagh%2Ffindmybook&pr=92&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fmain%2Fjava%2Fnet%2Ffindmybook%2Fapplication%2Fsimilarity%2FBookSimilarityVectorFusion.java%3A22%0A**%60EMBEDDING_DIMENSION%60%20visibility%20widened%20unintentionally**%0A%0AThe%20constant%20was%20%60private%20static%20final%20int%60%20in%20the%20old%20%60BookSimilarityEmbeddingService%60%20and%20is%20now%20package-private%20%28no%20modifier%29%20in%20%60BookSimilarityVectorFusion%60.%20It's%20only%20referenced%20inside%20the%20class%2C%20so%20the%20broader%20visibility%20is%20an%20accidental%20byproduct%20of%20the%20extraction.%20Either%20make%20it%20%60private%20static%20final%60%20to%20match%20its%20actual%20usage%2C%20or%20%60public%20static%20final%60%20if%20external%20callers%20%28tests%2C%20validators%29%20are%20expected%20to%20reference%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20static%20final%20int%20EMBEDDING_DIMENSION%20%3D%202560%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fmain%2Fjava%2Fnet%2Ffindmybook%2Fsupport%2Fsearch%2FCandidateKeyResolver.java%3A31%0A**Apostrophes%20stripped%20to%20spaces%2C%20causing%20asymmetric%20normalization%20across%20providers**%0A%0A%60NON_SEARCH_TEXT_PATTERN%60%20%28%60%5B%5E%5Cp%7BL%7D0-9%2B%23%5D%2B%60%29%20replaces%20apostrophes%20with%20a%20space%2C%20so%20%22O'Brien%22%20normalizes%20to%20%22o%20brien%22%20while%20a%20provider%20that%20has%20already%20stripped%20apostrophes%20would%20give%20%22OBrien%22%20%E2%86%92%20%22obrien%22.%20These%20produce%20different%20keys%2C%20silently%20preventing%20deduplication%20for%20the%20same%20author%20when%20providers%20differ%20in%20apostrophe%20handling.%20The%20same%20applies%20to%20book%20titles%20%28e.g.%2C%20%22Shakespeare's%20Plays%22%20vs%20%22Shakespeares%20Plays%22%29.%0A%0AIf%20the%20intent%20is%20that%20only%20exact-format%20matches%20deduplicate%2C%20document%20this%20limitation%20so%20callers%20understand%20that%20cross-provider%20apostrophe%20differences%20are%20out%20of%20scope.%0A%0A&pr=92&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22williamagh%2Ffindmybook%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fmain%2Fjava%2Fnet%2Ffindmybook%2Fapplication%2Fsimilarity%2FBookSimilarityVectorFusion.java%3A22%0A**%60EMBEDDING_DIMENSION%60%20visibility%20widened%20unintentionally**%0A%0AThe%20constant%20was%20%60private%20static%20final%20int%60%20in%20the%20old%20%60BookSimilarityEmbeddingService%60%20and%20is%20now%20package-private%20%28no%20modifier%29%20in%20%60BookSimilarityVectorFusion%60.%20It's%20only%20referenced%20inside%20the%20class%2C%20so%20the%20broader%20visibility%20is%20an%20accidental%20byproduct%20of%20the%20extraction.%20Either%20make%20it%20%60private%20static%20final%60%20to%20match%20its%20actual%20usage%2C%20or%20%60public%20static%20final%60%20if%20external%20callers%20%28tests%2C%20validators%29%20are%20expected%20to%20reference%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20static%20final%20int%20EMBEDDING_DIMENSION%20%3D%202560%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fmain%2Fjava%2Fnet%2Ffindmybook%2Fsupport%2Fsearch%2FCandidateKeyResolver.java%3A31%0A**Apostrophes%20stripped%20to%20spaces%2C%20causing%20asymmetric%20normalization%20across%20providers**%0A%0A%60NON_SEARCH_TEXT_PATTERN%60%20%28%60%5B%5E%5Cp%7BL%7D0-9%2B%23%5D%2B%60%29%20replaces%20apostrophes%20with%20a%20space%2C%20so%20%22O'Brien%22%20normalizes%20to%20%22o%20brien%22%20while%20a%20provider%20that%20has%20already%20stripped%20apostrophes%20would%20give%20%22OBrien%22%20%E2%86%92%20%22obrien%22.%20These%20produce%20different%20keys%2C%20silently%20preventing%20deduplication%20for%20the%20same%20author%20when%20providers%20differ%20in%20apostrophe%20handling.%20The%20same%20applies%20to%20book%20titles%20%28e.g.%2C%20%22Shakespeare's%20Plays%22%20vs%20%22Shakespeares%20Plays%22%29.%0A%0AIf%20the%20intent%20is%20that%20only%20exact-format%20matches%20deduplicate%2C%20document%20this%20limitation%20so%20callers%20understand%20that%20cross-provider%20apostrophe%20differences%20are%20out%20of%20scope.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/main/java/net/findmybook/application/similarity/BookSimilarityVectorFusion.java
Line: 22

Comment:
**`EMBEDDING_DIMENSION` visibility widened unintentionally**

The constant was `private static final int` in the old `BookSimilarityEmbeddingService` and is now package-private (no modifier) in `BookSimilarityVectorFusion`. It's only referenced inside the class, so the broader visibility is an accidental byproduct of the extraction. Either make it `private static final` to match its actual usage, or `public static final` if external callers (tests, validators) are expected to reference it.

```suggestion
    private static final int EMBEDDING_DIMENSION = 2560;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/main/java/net/findmybook/support/search/CandidateKeyResolver.java
Line: 31

Comment:
**Apostrophes stripped to spaces, causing asymmetric normalization across providers**

`NON_SEARCH_TEXT_PATTERN` (`[^\p{L}0-9+#]+`) replaces apostrophes with a space, so "O'Brien" normalizes to "o brien" while a provider that has already stripped apostrophes would give "OBrien" → "obrien". These produce different keys, silently preventing deduplication for the same author when providers differ in apostrophe handling. The same applies to book titles (e.g., "Shakespeare's Plays" vs "Shakespeares Plays").

If the intent is that only exact-format matches deduplicate, document this limitation so callers understand that cross-provider apostrophe differences are out of scope.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(search): filter cover preferences be..."](https://github.com/williamagh/findmybook/commit/932853b33de934659b530ee36cd878ee781b9ef9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29653238)</sub>

<!-- /greptile_comment -->