### PR TITLE
fix(frontend): patch Svelte SSR XSS via hydratable, fix async runtime stale-derived/eager-effect leaks, and correct devalue sparse-array allocation

### DIFF
--- a/.config/lefthook.yml
+++ b/.config/lefthook.yml
@@ -13,7 +13,7 @@ pre-commit:
       stage_fixed: true
     frontend-lint-fix:
       root: "frontend/"
-      glob: "*.{js,ts,svelte}"
+      glob: "src/**/*.{js,ts,svelte}"
       run: npx oxlint -c config/oxlintrc.json --fix {staged_files}
       stage_fixed: true
     no-commit-to-branch:

--- a/docs/api.md
+++ b/docs/api.md
@@ -64,6 +64,7 @@
   - Returns recommendation-card DTOs for the canonical book/work cluster.
   - Runtime behavior:
     - First checks persisted book similarity embedding neighbors for the active model/profile contract and returns them in vector rank.
+    - During an embedding input-contract backfill, if active rows cannot fill the requested limit, it may serve the previous same-profile section-fusion vector contract rather than dropping immediately to recommendation rows.
     - When embedding rows are unavailable, it checks persisted recommendation rows.
     - If active rows are missing/stale, it triggers recommendation regeneration and then returns refreshed cards when available.
     - If regeneration cannot immediately persist refreshed cards, it may return older persisted rows as an explicit fallback.

--- a/docs/api.md
+++ b/docs/api.md
@@ -63,8 +63,8 @@
   - `limit` (optional; defaults `5`)
   - Returns recommendation-card DTOs for the canonical book/work cluster.
   - Runtime behavior:
-    - First checks persisted book similarity embedding neighbors for the active model/profile contract and returns them in vector rank.
-    - During an embedding input-contract backfill, if active rows cannot fill the requested limit, it may serve the previous same-profile section-fusion vector contract rather than dropping immediately to recommendation rows.
+    - First checks persisted book similarity embedding neighbors for the active model/profile/source/input contract and returns them in vector rank.
+    - During an embedding contract backfill, if active rows cannot fill the requested limit, it may serve the previous same-profile section-fusion vector contract rather than dropping immediately to recommendation rows.
     - When embedding rows are unavailable, it checks persisted recommendation rows.
     - If active rows are missing/stale, it triggers recommendation regeneration and then returns refreshed cards when available.
     - If regeneration cannot immediately persist refreshed cards, it may return older persisted rows as an explicit fallback.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,8 +26,8 @@ Key variables in `.env`:
 | `APP_SIMILARITY_EMBEDDINGS_REFRESH_BATCH_SIZE` | Number of candidate books inspected per scheduler pass (default `25`) |
 | `APP_SIMILARITY_EMBEDDINGS_SCHEDULER_ENQUEUE_LIMIT` | Maximum embedding refresh tasks enqueued per scheduler pass (default `25`) |
 | `APP_SIMILARITY_EMBEDDINGS_SCHEDULER_MAX_PENDING` | Central AI queue pending-depth ceiling that pauses scheduled embedding enqueue (default `100`) |
-| `APP_SIMILARITY_EMBEDDINGS_MAX_SECTION_TEXT_CHARS` | Rendered section character ceiling before hashing; default `15000` bounds refresh work |
-| `APP_SIMILARITY_EMBEDDINGS_INPUT_TOKEN_COMFORT_LIMIT` | Conservative per-item estimated token budget before client-side embeddings splitting (default `8192`) |
+| `APP_SIMILARITY_EMBEDDINGS_MAX_SECTION_TEXT_CHARS` | Rendered section character ceiling before hashing; default `15000` bounds refresh work and participates in the vector model contract |
+| `APP_SIMILARITY_EMBEDDINGS_INPUT_TOKEN_COMFORT_LIMIT` | Conservative per-item estimated token budget before client-side embeddings splitting (default `8192`, capped at `8192`, participates in the section-cache contract) |
 | `APP_SIMILARITY_EMBEDDINGS_REQUEST_INPUT_BATCH_SIZE` | Maximum embeddings input array size per provider request; runtime may reduce this to preserve request-token headroom (default `32`) |
 | `APP_NYT_SCHEDULER_STANDALONE_ENABLED` | Enables standalone NYT `@Scheduled` execution when not using the weekly orchestrator |
 | `GOOGLE_BOOKS_API_KEY` | Book data source |
@@ -88,7 +88,7 @@ Startup now fails fast with a clear error when database-required profiles are ac
 - Missing/stale work is derived from Postgres source hashes and timestamps, so container restarts do not lose outstanding embedding work.
 - On-demand similar-book requests enqueue the source book for refresh, while the scheduler continuously backfills bounded missing/stale batches.
 - The scheduler pauses when central AI queue pending depth reaches `APP_SIMILARITY_EMBEDDINGS_SCHEDULER_MAX_PENDING`, preventing large backlogs from filling memory faster than work drains.
-- Similar-book reads prefer the active input-contract vector rows; while an input-contract backfill is incomplete, they may serve the previous same-profile section-fusion vector contract before using recommendation rows.
+- Similar-book reads prefer the active source/input-contract vector rows; while a contract backfill is incomplete, they may serve the previous same-profile section-fusion vector contract before using recommendation rows.
 - The embedding client keeps OpenAI-compatible array batching, but pre-splits each request item to the `APP_SIMILARITY_EMBEDDINGS_INPUT_TOKEN_COMFORT_LIMIT` budget using a conservative UTF-8 byte estimate capped at 8192. Oversized sections are embedded as bounded chunks and fused back into one section vector before persistence, so one long description cannot overflow qwen3-embedding-4b's 32k per-item context window.
 
 ## Weekly Catalog Refresh

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,6 +88,7 @@ Startup now fails fast with a clear error when database-required profiles are ac
 - Missing/stale work is derived from Postgres source hashes and timestamps, so container restarts do not lose outstanding embedding work.
 - On-demand similar-book requests enqueue the source book for refresh, while the scheduler continuously backfills bounded missing/stale batches.
 - The scheduler pauses when central AI queue pending depth reaches `APP_SIMILARITY_EMBEDDINGS_SCHEDULER_MAX_PENDING`, preventing large backlogs from filling memory faster than work drains.
+- Similar-book reads prefer the active input-contract vector rows; while an input-contract backfill is incomplete, they may serve the previous same-profile section-fusion vector contract before using recommendation rows.
 - The embedding client keeps OpenAI-compatible array batching, but pre-splits each request item to the `APP_SIMILARITY_EMBEDDINGS_INPUT_TOKEN_COMFORT_LIMIT` budget using a conservative UTF-8 byte estimate capped at 8192. Oversized sections are embedded as bounded chunks and fused back into one section vector before persistence, so one long description cannot overflow qwen3-embedding-4b's 32k per-item context window.
 
 ## Weekly Catalog Refresh

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,9 @@ Key variables in `.env`:
 | `APP_SIMILARITY_EMBEDDINGS_REFRESH_BATCH_SIZE` | Number of candidate books inspected per scheduler pass (default `25`) |
 | `APP_SIMILARITY_EMBEDDINGS_SCHEDULER_ENQUEUE_LIMIT` | Maximum embedding refresh tasks enqueued per scheduler pass (default `25`) |
 | `APP_SIMILARITY_EMBEDDINGS_SCHEDULER_MAX_PENDING` | Central AI queue pending-depth ceiling that pauses scheduled embedding enqueue (default `100`) |
+| `APP_SIMILARITY_EMBEDDINGS_MAX_SECTION_TEXT_CHARS` | Rendered section character ceiling before hashing; default `15000` bounds refresh work |
+| `APP_SIMILARITY_EMBEDDINGS_INPUT_TOKEN_COMFORT_LIMIT` | Conservative per-item estimated token budget before client-side embeddings splitting (default `8192`) |
+| `APP_SIMILARITY_EMBEDDINGS_REQUEST_INPUT_BATCH_SIZE` | Maximum embeddings input array size per provider request; runtime may reduce this to preserve request-token headroom (default `32`) |
 | `APP_NYT_SCHEDULER_STANDALONE_ENABLED` | Enables standalone NYT `@Scheduled` execution when not using the weekly orchestrator |
 | `GOOGLE_BOOKS_API_KEY` | Book data source |
 | `S3_*` | S3 storage (if used) |
@@ -85,6 +88,7 @@ Startup now fails fast with a clear error when database-required profiles are ac
 - Missing/stale work is derived from Postgres source hashes and timestamps, so container restarts do not lose outstanding embedding work.
 - On-demand similar-book requests enqueue the source book for refresh, while the scheduler continuously backfills bounded missing/stale batches.
 - The scheduler pauses when central AI queue pending depth reaches `APP_SIMILARITY_EMBEDDINGS_SCHEDULER_MAX_PENDING`, preventing large backlogs from filling memory faster than work drains.
+- The embedding client keeps OpenAI-compatible array batching, but pre-splits each request item to the `APP_SIMILARITY_EMBEDDINGS_INPUT_TOKEN_COMFORT_LIMIT` budget using a conservative UTF-8 byte estimate capped at 8192. Oversized sections are embedded as bounded chunks and fused back into one section vector before persistence, so one long description cannot overflow qwen3-embedding-4b's 32k per-item context window.
 
 ## Weekly Catalog Refresh
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -35,7 +35,7 @@ See [UML README](../src/main/resources/uml/README.md).
 - The canonical profile contract lives at `src/main/resources/similarity/book-similarity-profiles.json` and owns only active profile, section order, and weights.
 - Section embeddings are cached in `book_embedding_sections` by model/input-contract key, section key, input format, and input hash.
 - The embedding client preserves array batching for parallel gateway slots, but splits any oversized section into bounded per-item chunks before calling the provider and fuses those chunk vectors back into the cached section embedding.
-- Fused searchable vectors are stored in `book_similarity_vectors` with `source_text`, `source_json`, `source_hash`, `model_version`, and `qwen_4b_fp16 halfvec(2560)` so each result is reproducible and pgvector HNSW cosine search remains available.
+- Fused searchable vectors are stored in `book_similarity_vectors` with `source_text`, `source_json`, `source_hash`, `model_version`, and `qwen_4b_fp16 halfvec(2560)` so each result is reproducible and pgvector HNSW cosine search remains available. The `model_version` includes the active embedding chunking and source-text contracts so limit changes enqueue a real backfill instead of reusing stale vectors.
 - Refresh is hash-driven: if the rendered source contract hash matches the stored `source_hash`, the book is current; otherwise section cache misses are embedded and the fused vector row is replaced.
 - Similar-book requests enqueue demand refreshes, and a lightweight `@Scheduled` catch-up pass continuously enqueues bounded missing/stale batches through the central AI queue.
 - Manual bounded backfill:

--- a/docs/features.md
+++ b/docs/features.md
@@ -37,7 +37,7 @@ See [UML README](../src/main/resources/uml/README.md).
 - The embedding client preserves array batching for parallel gateway slots, but splits any oversized section into bounded per-item chunks before calling the provider and fuses those chunk vectors back into the cached section embedding.
 - Fused searchable vectors are stored in `book_similarity_vectors` with `source_text`, `source_json`, `source_hash`, `model_version`, and `qwen_4b_fp16 halfvec(2560)` so each result is reproducible and pgvector HNSW cosine search remains available.
 - Refresh is hash-driven: if the rendered source contract hash matches the stored `source_hash`, the book is current; otherwise section cache misses are embedded and the fused vector row is replaced.
-- Book upserts and similar-book requests enqueue demand refreshes, and a lightweight `@Scheduled` catch-up pass continuously enqueues bounded missing/stale batches through the central AI queue.
+- Similar-book requests enqueue demand refreshes, and a lightweight `@Scheduled` catch-up pass continuously enqueues bounded missing/stale batches through the central AI queue.
 - Manual bounded backfill:
   - `make book-similarity-backfill SIMILARITY_LIMIT=250`
   - `make book-similarity-anchor BOOK_IDENTIFIER=<uuid-or-slug-or-isbn>`

--- a/docs/features.md
+++ b/docs/features.md
@@ -33,7 +33,8 @@ See [UML README](../src/main/resources/uml/README.md).
 
 - Book similarity uses section-fused embeddings rather than a single flattened text prompt.
 - The canonical profile contract lives at `src/main/resources/similarity/book-similarity-profiles.json` and owns only active profile, section order, and weights.
-- Section embeddings are cached in `book_embedding_sections` by model, section key, input format, and input hash.
+- Section embeddings are cached in `book_embedding_sections` by model/input-contract key, section key, input format, and input hash.
+- The embedding client preserves array batching for parallel gateway slots, but splits any oversized section into bounded per-item chunks before calling the provider and fuses those chunk vectors back into the cached section embedding.
 - Fused searchable vectors are stored in `book_similarity_vectors` with `source_text`, `source_json`, `source_hash`, `model_version`, and `qwen_4b_fp16 halfvec(2560)` so each result is reproducible and pgvector HNSW cosine search remains available.
 - Refresh is hash-driven: if the rendered source contract hash matches the stored `source_hash`, the book is current; otherwise section cache misses are embedded and the fused vector row is replaced.
 - Book upserts and similar-book requests enqueue demand refreshes, and a lightweight `@Scheduled` catch-up pass continuously enqueues bounded missing/stale batches through the central AI queue.

--- a/frontend/config/oxlintrc.json
+++ b/frontend/config/oxlintrc.json
@@ -26,17 +26,16 @@
     "no-empty": ["error", { "allowEmptyCatch": false }],
 
     "import/no-cycle": "error",
-    "import/order": "off",
     "import/no-duplicates": "error",
 
     "typescript/no-explicit-any": "error",
     "typescript/no-non-null-assertion": "warn",
     "typescript/no-unsafe-type-assertion": "warn",
 
-    "promise/no-return-await": "error",
     "promise/catch-or-return": "warn",
 
     "unicorn/no-array-reduce": "warn",
+    "unicorn/no-unnecessary-await": "error",
     "unicorn/prefer-node-protocol": "warn",
 
     "zod/no-any-schema": "error",
@@ -48,7 +47,6 @@
     "zod/consistent-import-source": ["warn", { "sources": ["zod/v4"] }],
     "zod/require-error-message": "warn",
     "zod/prefer-enum-over-literal-union": "warn",
-    "zod/require-schema-suffix": "warn",
     "zod/prefer-meta": "warn",
     "zod/array-style": "warn",
     "zod/consistent-import": ["warn", { "syntax": "named" }]
@@ -77,9 +75,9 @@
         "vitest/no-disabled-tests": "off",
         "vitest/no-conditional-expect": "off",
         "vitest/expect-expect": "off",
+        "vitest/require-mock-type-parameters": "off",
         "no-console": "off",
         "unicorn/prefer-node-protocol": "off",
-        "zod/require-schema-suffix": "off",
         "zod/require-error-message": "off"
       }
     }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4467,9 +4467,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,31 +10,31 @@
       "dependencies": {
         "@lucide/svelte": "^0.563.1",
         "@stomp/stompjs": "^7.2.0",
-        "dompurify": "^3.4.0",
+        "dompurify": "^3.4.3",
         "sockjs-client": "^1.6.1",
-        "zod": "^4.3.6"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@ast-grep/cli": "^0.41.0",
-        "@sveltejs/vite-plugin-svelte": "^6.2.4",
-        "@tailwindcss/vite": "^4.1.18",
+        "@ast-grep/cli": "^0.42.2",
+        "@sveltejs/vite-plugin-svelte": "^7.1.2",
+        "@tailwindcss/vite": "^4.3.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/svelte": "^5.2.7",
         "@tsconfig/svelte": "^5.0.6",
         "@types/dompurify": "^3.0.5",
         "@types/node": "^22.17.0",
         "@types/sockjs-client": "^1.5.4",
-        "@vitest/coverage-v8": "^3.0.4",
-        "eslint": "^9.39.2",
-        "eslint-plugin-zod": "^3.1.0",
-        "happy-dom": "^20.8.9",
-        "oxlint": "^1.47.0",
+        "@vitest/coverage-v8": "^4.1.6",
+        "eslint": "^10.4.0",
+        "eslint-plugin-zod": "^4.4.0",
+        "happy-dom": "^20.9.0",
+        "oxlint": "^1.65.0",
         "svelte": "^5.55.7",
-        "svelte-check": "^4.3.5",
-        "tailwindcss": "^4.1.18",
+        "svelte-check": "^4.4.8",
+        "tailwindcss": "^4.3.0",
         "typescript": "^5.9.3",
-        "vite": "^7.3.2",
-        "vitest": "^3.0.4"
+        "vite": "^8.0.13",
+        "vitest": "^4.1.6"
       },
       "engines": {
         "node": "22.17.0"
@@ -47,26 +47,13 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@ast-grep/cli": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@ast-grep/cli/-/cli-0.41.0.tgz",
-      "integrity": "sha512-n0SMA1qHB8tSW/j8FunecKvHQNGzdSGOkd8oAcb5lrbYaGmvmSDtR8izw14cySANaWS5Jc7PJBKppw1ZKPF8jg==",
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli/-/cli-0.42.2.tgz",
+      "integrity": "sha512-TojScwpaM40UQyvV5n5oa8PfOPFfHSD8Xf0WppPXn1+lq73u/jwvDmP8M2Oxj5YgebIpgkDUPoMixThtqwpNBA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "detect-libc": "2.1.2"
       },
@@ -78,19 +65,19 @@
         "node": ">= 12.0.0"
       },
       "optionalDependencies": {
-        "@ast-grep/cli-darwin-arm64": "0.41.0",
-        "@ast-grep/cli-darwin-x64": "0.41.0",
-        "@ast-grep/cli-linux-arm64-gnu": "0.41.0",
-        "@ast-grep/cli-linux-x64-gnu": "0.41.0",
-        "@ast-grep/cli-win32-arm64-msvc": "0.41.0",
-        "@ast-grep/cli-win32-ia32-msvc": "0.41.0",
-        "@ast-grep/cli-win32-x64-msvc": "0.41.0"
+        "@ast-grep/cli-darwin-arm64": "0.42.2",
+        "@ast-grep/cli-darwin-x64": "0.42.2",
+        "@ast-grep/cli-linux-arm64-gnu": "0.42.2",
+        "@ast-grep/cli-linux-x64-gnu": "0.42.2",
+        "@ast-grep/cli-win32-arm64-msvc": "0.42.2",
+        "@ast-grep/cli-win32-ia32-msvc": "0.42.2",
+        "@ast-grep/cli-win32-x64-msvc": "0.42.2"
       }
     },
     "node_modules/@ast-grep/cli-darwin-arm64": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-arm64/-/cli-darwin-arm64-0.41.0.tgz",
-      "integrity": "sha512-nSOVlGx0qynniprYXedkQaHcuTs6i04DZumaXFXcjcbl18qEuAme5uWNa1H6BEugRzGXQqJJo0IDm5MPeLYSyw==",
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-arm64/-/cli-darwin-arm64-0.42.2.tgz",
+      "integrity": "sha512-li1RsB2fO5/qchdZHny+meg1I03xD+A5rug8axxOdqull8hdFUqxymZ5hg/tKh+/C04gyccEBgqcuJAsghuPXw==",
       "cpu": [
         "arm64"
       ],
@@ -105,9 +92,9 @@
       }
     },
     "node_modules/@ast-grep/cli-darwin-x64": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-x64/-/cli-darwin-x64-0.41.0.tgz",
-      "integrity": "sha512-Jp8wLwkS2bpaxpms5w0MI5FpdrmPd1ReK8GJ+dXgIl/iyTFzXxgZYllY5tH69MFoBDxonmAZADppcBIyeSp7Xw==",
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-x64/-/cli-darwin-x64-0.42.2.tgz",
+      "integrity": "sha512-oKR1bRYsmc0G287q9Xj29m3SrxohEXhArKt647MswDYbG751LHG3aaEf6TtYjcxq+jKB4XaVJ5+q1jlIgKbVWQ==",
       "cpu": [
         "x64"
       ],
@@ -122,13 +109,16 @@
       }
     },
     "node_modules/@ast-grep/cli-linux-arm64-gnu": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-0.41.0.tgz",
-      "integrity": "sha512-z9etSzPP1x737H4JHitH03V8aEeRO55Mn0fo9KOZBsVlApMFjtjf9SZClM+oTNGlPCidjypYHtRsx/JdZhvkUQ==",
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-0.42.2.tgz",
+      "integrity": "sha512-dfgQcTR2SI47J1yz/MMQuA3cFu/pzsum07aLgv+QcouCJY+AJcgjZTNUd26vZ/352wTXfJ/wpfziwbbI/Z4EEA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -139,13 +129,16 @@
       }
     },
     "node_modules/@ast-grep/cli-linux-x64-gnu": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-x64-gnu/-/cli-linux-x64-gnu-0.41.0.tgz",
-      "integrity": "sha512-FTJVheESkQEFeBKx+trHIGFYOg+n9FjeArOjtrs89eYe6n3oSp3nfLeJNZwTG5Lv3NNTu2oXL/gg9UtE6D/3eg==",
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-x64-gnu/-/cli-linux-x64-gnu-0.42.2.tgz",
+      "integrity": "sha512-ygkLM/RLEKw8btFgFIl/BrU2ji2sH79YnxIzjVIC5np9NMWWvqZ/jy2++s0YYI8Y9XLmfa1+Pi8F5zFK+3qDww==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -156,9 +149,9 @@
       }
     },
     "node_modules/@ast-grep/cli-win32-arm64-msvc": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-0.41.0.tgz",
-      "integrity": "sha512-mjVDDneU4E+BHohVv/jjSKe0nkwtnjWFsSaC3D9WKR6oNQ+F4kdBbaA5pziCdY6EvYCMsxww1LvE1OVtlPjk7w==",
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-0.42.2.tgz",
+      "integrity": "sha512-fThbaAvwUFfW1kAYw7xAzX/VvWMcyfeyyKyHfwQWHbkT5bjqdbnb5yFPLu0Q2Qo3bHUudYYP4WLakegkRyHSkQ==",
       "cpu": [
         "arm64"
       ],
@@ -173,9 +166,9 @@
       }
     },
     "node_modules/@ast-grep/cli-win32-ia32-msvc": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-0.41.0.tgz",
-      "integrity": "sha512-nhmonUwp+lRQ62IgPC8O52ra/TktLJpTH8D8bwbiVN4vo/MRGdN37NgwlGX9DkQ+NBBhD+FdPG+a29tT+ZZUng==",
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-0.42.2.tgz",
+      "integrity": "sha512-W7S+Hao/FMsXc8ZZny7YqA16J5C9O9b6UvT+0xpiWda6nNhOv0ebQHzjhtuSC/+SlV7S29uwjr+jT/T6+XmV0Q==",
       "cpu": [
         "ia32"
       ],
@@ -190,9 +183,9 @@
       }
     },
     "node_modules/@ast-grep/cli-win32-x64-msvc": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-x64-msvc/-/cli-win32-x64-msvc-0.41.0.tgz",
-      "integrity": "sha512-xTlt7vR1yqHnPo0SG77Art2iDihKFk5o4lEFXG3UoMV3+Ugd2d9wmJCoMx4uT4n67ITLej8jzZM6P+I0rYC/bg==",
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-x64-msvc/-/cli-win32-x64-msvc-0.42.2.tgz",
+      "integrity": "sha512-EPMQyUIvl4P3wqOAs9V+2LIUaLZNUQyHkLXqP+PKtGT+tS/c+IBv+/FiQ2psMHs2u4PM8tg2rnQBQ8sU0Nr+Gw==",
       "cpu": [
         "x64"
       ],
@@ -242,9 +235,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -258,9 +251,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -291,446 +284,38 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
-      "cpu": [
-        "ppc64"
-      ],
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -752,6 +337,19 @@
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
       }
     },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.2",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
@@ -762,176 +360,118 @@
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
-    "node_modules/@eslint/config-array": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
-        "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+    "node_modules/@eslint-zod/utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint-zod/utils/-/utils-1.2.0.tgz",
+      "integrity": "sha512-NvDjDqhjBpOZ3yh5brSqt7iS+fgB61S6CRYenEGU9MPrMJ4ZbHqXYKBgyUTFfIbgiGTEVzfyTcsioT0JkRE3Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "@typescript-eslint/utils": "^8.57.0"
       },
       "engines": {
-        "node": "*"
+        "node": "^20 || ^22 || >=24"
       }
     },
-    "node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0"
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
-      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@eslint/js": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -962,34 +502,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1046,10 +558,39 @@
         "svelte": "^5"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.47.0.tgz",
-      "integrity": "sha512-UHqo3te9K/fh29brCuQdHjN+kfpIi9cnTPABuD5S9wb9ykXYRGTOOMVuSV/CK43sOhU4wwb2nT1RVjcbrrQjFw==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.65.0.tgz",
+      "integrity": "sha512-jDVaGNURT5pEA9qcabh6WusIoBNybOMMDPCx+EFt+gxo6rVvoUf0+73Xy5x81+ZrxU+ewk5uRBYifjy5pgkcnA==",
       "cpu": [
         "arm"
       ],
@@ -1064,9 +605,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.47.0.tgz",
-      "integrity": "sha512-xh02lsTF1TAkR+SZrRMYHR/xCx8Wg2MAHxJNdHVpAKELh9/yE9h4LJeqAOBbIb3YYn8o/D97U9VmkvkfJfrHfw==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.65.0.tgz",
+      "integrity": "sha512-v0z80IWNA7c9RhUydq9YprBxCVZrQ6Ixls2tdxUC1F/1FFqSfa7xTX+EJf0mj6+BKRg2zWXqWfcbJUnETlLlIw==",
       "cpu": [
         "arm64"
       ],
@@ -1081,9 +622,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.47.0.tgz",
-      "integrity": "sha512-OSOfNJqabOYbkyQDGT5pdoL+05qgyrmlQrvtCO58M4iKGEQ/xf3XkkKj7ws+hO+k8Y4VF4zGlBsJlwqy7qBcHA==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.65.0.tgz",
+      "integrity": "sha512-pL/mG/5gMzBwp1gdc5+Cwi87F9j3XRnPxHGyVj5Zd+dCEV5YkKt0L70PB3EGmEEHxgn4H+jnMS3xLuXs6mZW/Q==",
       "cpu": [
         "arm64"
       ],
@@ -1098,9 +639,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.47.0.tgz",
-      "integrity": "sha512-hP2bOI4IWNS+F6pVXWtRshSTuJ1qCRZgDgVUg6EBUqsRy+ExkEPJkx+YmIuxgdCduYK1LKptLNFuQLJP8voPbQ==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.65.0.tgz",
+      "integrity": "sha512-jVTneaeuHtqTrKYnhrdH1buhnSorinvpy1sv43ayclfWx/e/DfdRWv+h1fopJcHQbYr5WMcZMmDvnfEBkPZ+1A==",
       "cpu": [
         "x64"
       ],
@@ -1115,9 +656,9 @@
       }
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.47.0.tgz",
-      "integrity": "sha512-F55jIEH5xmGu7S661Uho8vGiLFk0bY3A/g4J8CTKiLJnYu/PSMZ2WxFoy5Hji6qvFuujrrM9Q8XXbMO0fKOYPg==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.65.0.tgz",
+      "integrity": "sha512-8lJQ7B6RloYDUhwVdbSpwT2eKsCN5KP1Scn18ly1tytCuhXhbs0nkfKHT4jWWZBJqmynWuzd+78bF7wILrj6pw==",
       "cpu": [
         "x64"
       ],
@@ -1132,9 +673,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.47.0.tgz",
-      "integrity": "sha512-wxmOn/wns/WKPXUC1fo5mu9pMZPVOu8hsynaVDrgmmXMdHKS7on6bA5cPauFFN9tJXNdsjW26AK9lpfu3IfHBQ==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.65.0.tgz",
+      "integrity": "sha512-EgmZY+DeWhLLEnNl70/49j3ltA8I6X9kxMfexupWi2Vwfp6RonGsBaHtGoedLolaU37ne7eDUgoxa3CFB95GZA==",
       "cpu": [
         "arm"
       ],
@@ -1149,9 +690,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.47.0.tgz",
-      "integrity": "sha512-KJTmVIA/GqRlM2K+ZROH30VMdydEU7bDTY35fNg3tOPzQRIs2deLZlY/9JWwdWo1F/9mIYmpbdCmPqtKhWNOPg==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.65.0.tgz",
+      "integrity": "sha512-OJMWmAYRVBCPPxnYr3j5sXRwHPh1bAuMlTStGco1Z8q3HkvSH4h+A10E9MiRNYmLhUuli5a2P5wmfj8cagiF5Q==",
       "cpu": [
         "arm"
       ],
@@ -1166,13 +707,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.47.0.tgz",
-      "integrity": "sha512-PF7ELcFg1GVlS0X0ZB6aWiXobjLrAKer3T8YEkwIoO8RwWiAMkL3n3gbleg895BuZkHVlJ2kPRUwfrhHrVkD1A==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.65.0.tgz",
+      "integrity": "sha512-D8uNi50LsYKgS0vGARZDRx05TBZeSxAVdLGddSEqQLSU7xsiqdImHPEw55xq8sKA5rCc/4au/5uS7FQALWdLCg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1183,13 +727,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.47.0.tgz",
-      "integrity": "sha512-4BezLRO5cu0asf0Jp1gkrnn2OHiXrPPPEfBTxq1k5/yJ2zdGGTmZxHD2KF2voR23wb8Elyu3iQawXo7wvIZq0Q==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.65.0.tgz",
+      "integrity": "sha512-IpbA8QGbwFehQhO+YaHwmoI81f93xvywpspf8HrdPCWOIeKwYfM1dhVhO4YKfZewTRRQEPY/JFjTOXTgkwhKrA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1200,13 +747,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.47.0.tgz",
-      "integrity": "sha512-aI5ds9jq2CPDOvjeapiIj48T/vlWp+f4prkxs+FVzrmVN9BWIj0eqeJ/hV8WgXg79HVMIz9PU6deI2ki09bR1w==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.65.0.tgz",
+      "integrity": "sha512-ZSe8HgaZdgyHSv2+/pTG68z10+OarB18CkFKQOhRs3lmmP/p2vuigedK2e9d0ztoG2DU/duJzhxXBSjy/492HQ==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1217,13 +767,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.47.0.tgz",
-      "integrity": "sha512-mO7ycp9Elvgt5EdGkQHCwJA6878xvo9tk+vlMfT1qg++UjvOMB8INsOCQIOH2IKErF/8/P21LULkdIrocMw9xA==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.65.0.tgz",
+      "integrity": "sha512-DcTERf++v6HyPHukKAr0JFTRqB+YeDEvqzRgNDMaz7jITPf+tlJIwRxodlAqoXMYhNVEZhXdQM5RAAYH8/oPuw==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1234,13 +787,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.47.0.tgz",
-      "integrity": "sha512-24D0wsYT/7hDFn3Ow32m3/+QT/1ZwrUhShx4/wRDAmz11GQHOZ1k+/HBuK/MflebdnalmXWITcPEy4BWTi7TCA==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.65.0.tgz",
+      "integrity": "sha512-xjhMwuFJwRh40NOBzol4gM5gqAa0xPCJU+GQLM6BydV8TbfkIA7JeyCFNhyfbE9Q/5EWcKYTx62R0cRcjP7DAA==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1251,13 +807,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.47.0.tgz",
-      "integrity": "sha512-8tPzPne882mtML/uy3mApvdCyuVOpthJ7xUv3b67gVfz63hOOM/bwO0cysSkPyYYFDFRn6/FnUb7Jhmsesntvg==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.65.0.tgz",
+      "integrity": "sha512-lrWSXb8JzboPWYBG6Kunt/eemvjo2oCFXktShsm3yMToY7HjzKLjxh7CljSvGnnZH9oohNFHOKc9xYpGKCPm6w==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1268,13 +827,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.47.0.tgz",
-      "integrity": "sha512-q58pIyGIzeffEBhEgbRxLFHmHfV9m7g1RnkLiahQuEvyjKNiJcvdHOwKH2BdgZxdzc99Cs6hF5xTa86X40WzPw==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.65.0.tgz",
+      "integrity": "sha512-A7xfghw250m4a1sPV+q44Mow2G5bhiC9FBvhAuIhJS6QovWnqzuL5AFQPEuwOB+PM4DhABkqxVa3Iwe3Y/nFlQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1285,13 +847,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.47.0.tgz",
-      "integrity": "sha512-e7DiLZtETZUCwTa4EEHg9G+7g3pY+afCWXvSeMG7m0TQ29UHHxMARPaEQUE4mfKgSqIWnJaUk2iZzRPMRdga5g==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.65.0.tgz",
+      "integrity": "sha512-reqOun1+pWO3fW6cv7bsa8hHG0TN3t/82qPdaoJo90FwugXiMjKhZMChmH5Z01cFNRHmxN4+543Fy8478cM/iA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1302,9 +867,9 @@
       }
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.47.0.tgz",
-      "integrity": "sha512-3AFPfQ0WKMleT/bKd7zsks3xoawtZA6E/wKf0DjwysH7wUiMMJkNKXOzYq1R/00G98JFgSU1AkrlOQrSdNNhlg==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.65.0.tgz",
+      "integrity": "sha512-KQpqOb/juDBO0xyloDkVDhOVxDUgAfZ2OAAVq99TJScJDzT319xry1QzB9LQohV9QGnA7p6m/XATZkMXc84lwA==",
       "cpu": [
         "arm64"
       ],
@@ -1319,9 +884,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.47.0.tgz",
-      "integrity": "sha512-cLMVVM6TBxp+N7FldQJ2GQnkcLYEPGgiuEaXdvhgvSgODBk9ov3jed+khIXSAWtnFOW0wOnG3RjwqPh0rCuheA==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.65.0.tgz",
+      "integrity": "sha512-xfqcOc3nJFeAd1kDY4T9d3XeJIhr00twaaW0kOAzGPyUHkruXtNJv6zz1Ra9fRtSek5VpW2Yoj5AcwPIlT0ZiQ==",
       "cpu": [
         "arm64"
       ],
@@ -1336,9 +901,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.47.0.tgz",
-      "integrity": "sha512-VpFOSzvTnld77/Edje3ZdHgZWnlTb5nVWXyTgjD3/DKF/6t5bRRbwn3z77zOdnGy44xAMvbyAwDNOSeOdVUmRA==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.65.0.tgz",
+      "integrity": "sha512-JV+pXm45p8sdgs3c7LOPAohW23optCNZETFOXUcjn6cS4PYZhEU/RI54Z5dHdMudab3nw7T48PZILthM+Q0COQ==",
       "cpu": [
         "ia32"
       ],
@@ -1353,9 +918,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.47.0.tgz",
-      "integrity": "sha512-+q8IWptxXx2HMTM6JluR67284t0h8X/oHJgqpxH1siowxPMqZeIpAcWCUq+tY+Rv2iQK8TUugjZnSBQAVV5CmA==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.65.0.tgz",
+      "integrity": "sha512-D7L/oBbskLss21bYrRbFuIs81AiSQV+wRzwck54dOkHIlq2qu1xjLz8u6jCqGH8Fltk8bB5DLBpVhE7v/fA8XQ==",
       "cpu": [
         "x64"
       ],
@@ -1369,49 +934,27 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
+      "cpu": [
+        "arm64"
+      ],
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "os": [
+        "android"
+      ],
       "engines": {
-        "node": ">=14"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
       "cpu": [
         "arm64"
       ],
@@ -1420,12 +963,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
       "cpu": [
         "x64"
       ],
@@ -1434,26 +980,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
       "cpu": [
         "x64"
       ],
@@ -1462,12 +997,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
       "cpu": [
         "arm"
       ],
@@ -1476,194 +1014,135 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
-      "cpu": [
-        "loong64"
+      "libc": [
+        "musl"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
-      "cpu": [
-        "loong64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
-      "cpu": [
-        "ppc64"
+      "libc": [
+        "glibc"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
-      "cpu": [
-        "riscv64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
-      "cpu": [
-        "x64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
       "cpu": [
         "arm64"
       ],
@@ -1672,12 +1151,34 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
       "cpu": [
         "arm64"
       ],
@@ -1686,26 +1187,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
-      "cpu": [
-        "ia32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
       "cpu": [
         "x64"
       ],
@@ -1714,21 +1204,24 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
-      "cpu": [
-        "x64"
       ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@stomp/stompjs": {
       "version": "7.3.0",
@@ -1737,97 +1230,78 @@
       "license": "Apache-2.0"
     },
     "node_modules/@sveltejs/acorn-typescript": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.8.tgz",
-      "integrity": "sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
+      "integrity": "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==",
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-6.2.4.tgz",
-      "integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-7.1.2.tgz",
+      "integrity": "sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
         "deepmerge": "^4.3.1",
         "magic-string": "^0.30.21",
         "obug": "^2.1.0",
-        "vitefu": "^1.1.1"
+        "vitefu": "^1.1.2"
       },
       "engines": {
         "node": "^20.19 || ^22.12 || >=24"
       },
       "peerDependencies": {
-        "svelte": "^5.0.0",
-        "vite": "^6.3.0 || ^7.0.0"
-      }
-    },
-    "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-5.0.2.tgz",
-      "integrity": "sha512-TZzRTcEtZffICSAoZGkPSl6Etsj2torOVrx6Uw0KpXxrec9Gg6jFWQ60Q3+LmNGfZSxHRCZL7vXVZIWmuV50Ig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "obug": "^2.1.0"
-      },
-      "engines": {
-        "node": "^20.19 || ^22.12 || >=24"
-      },
-      "peerDependencies": {
-        "@sveltejs/vite-plugin-svelte": "^6.0.0-next.0",
-        "svelte": "^5.0.0",
-        "vite": "^6.3.0 || ^7.0.0"
+        "svelte": "^5.46.4",
+        "vite": "^8.0.0-beta.7 || ^8.0.0"
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.18.tgz",
-      "integrity": "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/remapping": "^2.3.4",
-        "enhanced-resolve": "^5.18.3",
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.21.0",
         "jiti": "^2.6.1",
-        "lightningcss": "1.30.2",
+        "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.1.18"
+        "tailwindcss": "4.3.0"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.18.tgz",
-      "integrity": "sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.1.18",
-        "@tailwindcss/oxide-darwin-arm64": "4.1.18",
-        "@tailwindcss/oxide-darwin-x64": "4.1.18",
-        "@tailwindcss/oxide-freebsd-x64": "4.1.18",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.18",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.18",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.1.18",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.1.18",
-        "@tailwindcss/oxide-linux-x64-musl": "4.1.18",
-        "@tailwindcss/oxide-wasm32-wasi": "4.1.18",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.18",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.1.18"
+        "@tailwindcss/oxide-android-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-x64": "4.3.0",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.18.tgz",
-      "integrity": "sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
       "cpu": [
         "arm64"
       ],
@@ -1838,13 +1312,13 @@
         "android"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.18.tgz",
-      "integrity": "sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
       "cpu": [
         "arm64"
       ],
@@ -1855,13 +1329,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.18.tgz",
-      "integrity": "sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
       "cpu": [
         "x64"
       ],
@@ -1872,13 +1346,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.18.tgz",
-      "integrity": "sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
       "cpu": [
         "x64"
       ],
@@ -1889,13 +1363,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.18.tgz",
-      "integrity": "sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
       "cpu": [
         "arm"
       ],
@@ -1906,81 +1380,93 @@
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.18.tgz",
-      "integrity": "sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.18.tgz",
-      "integrity": "sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.18.tgz",
-      "integrity": "sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.18.tgz",
-      "integrity": "sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.18.tgz",
-      "integrity": "sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -1996,30 +1482,30 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@emnapi/wasi-threads": "^1.1.0",
-        "@napi-rs/wasm-runtime": "^1.1.0",
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
         "@tybys/wasm-util": "^0.10.1",
-        "tslib": "^2.4.0"
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.7.1",
+      "version": "1.10.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.7.1",
+      "version": "1.10.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2029,7 +1515,7 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
+      "version": "1.2.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2039,15 +1525,21 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.0",
+      "version": "1.1.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
         "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
@@ -2068,9 +1560,9 @@
       "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
-      "integrity": "sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
       "cpu": [
         "arm64"
       ],
@@ -2081,13 +1573,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.18.tgz",
-      "integrity": "sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
       "cpu": [
         "x64"
       ],
@@ -2098,22 +1590,22 @@
         "win32"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/vite": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.18.tgz",
-      "integrity": "sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.0.tgz",
+      "integrity": "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tailwindcss/node": "4.1.18",
-        "@tailwindcss/oxide": "4.1.18",
-        "tailwindcss": "4.1.18"
+        "@tailwindcss/node": "4.3.0",
+        "@tailwindcss/oxide": "4.3.0",
+        "tailwindcss": "4.3.0"
       },
       "peerDependencies": {
-        "vite": "^5.2.0 || ^6 || ^7"
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -2214,11 +1706,22 @@
       }
     },
     "node_modules/@tsconfig/svelte": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.7.tgz",
-      "integrity": "sha512-NOtJF9LQnV7k6bpzcXwL/rXdlFHvAT9e0imrftiMc6/+FUNBHRZ8UngDrM+jciA6ENzFYNoFs8rfwumuGF+Dhw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.8.tgz",
+      "integrity": "sha512-UkNnw1/oFEfecR8ypyHIQuWYdkPvHiwcQ78sh+ymIiYoF+uc5H1UBetbjyqT+vgGJ3qQN6nhucJviX6HesWtKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
@@ -2255,10 +1758,17 @@
         "@types/trusted-types": "*"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -2269,9 +1779,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.9.tgz",
-      "integrity": "sha512-PD03/U8g1F9T9MI+1OBisaIARhSzeidsUjQaf51fOxrfjeiKN9bLVO06lHuHYjxdnqLWJijJHfqXPSJri2EM2A==",
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2309,14 +1819,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.55.0.tgz",
-      "integrity": "sha512-zRcVVPFUYWa3kNnjaZGXSu3xkKV1zXy8M4nO/pElzQhFweb7PPtluDLQtKArEOGmjXoRjnUZ29NjOiF0eCDkcQ==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
+      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
+        "@typescript-eslint/tsconfig-utils": "^8.59.3",
+        "@typescript-eslint/types": "^8.59.3",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2327,18 +1837,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.55.0.tgz",
-      "integrity": "sha512-fVu5Omrd3jeqeQLiB9f1YsuK/iHFOwb04bCtY4BSCLgjNbOD33ZdV6KyEqplHr+IlpgT0QTZ/iJ+wT7hvTx49Q==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
+      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.55.0",
-        "@typescript-eslint/visitor-keys": "8.55.0"
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2349,9 +1859,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.55.0.tgz",
-      "integrity": "sha512-1R9cXqY7RQd7WuqSN47PK9EDpgFUK3VqdmbYrvWJZYDd0cavROGn+74ktWBlmJ13NXUQKlZ/iAEQHI/V0kKe0Q==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
+      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2362,13 +1872,13 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.55.0.tgz",
-      "integrity": "sha512-ujT0Je8GI5BJWi+/mMoR0wxwVEQaxM+pi30xuMiJETlX80OPovb2p9E8ss87gnSVtYXtJoU9U1Cowcr6w2FE0w==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -2380,21 +1890,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.55.0.tgz",
-      "integrity": "sha512-EwrH67bSWdx/3aRQhCoxDaHM+CrZjotc2UCCpEDVqfCE+7OjKAGWNY2HsCSTEVvWH2clYQK8pdeLp42EVs+xQw==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
+      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.55.0",
-        "@typescript-eslint/tsconfig-utils": "8.55.0",
-        "@typescript-eslint/types": "8.55.0",
-        "@typescript-eslint/visitor-keys": "8.55.0",
+        "@typescript-eslint/project-service": "8.59.3",
+        "@typescript-eslint/tsconfig-utils": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "debug": "^4.4.3",
-        "minimatch": "^9.0.5",
+        "minimatch": "^10.2.2",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2404,20 +1914,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.55.0.tgz",
-      "integrity": "sha512-BqZEsnPGdYpgyEIkDC1BadNY8oMwckftxBT+C8W0g1iKPdeqKZBtTfnvcq0nf60u7MkjFO8RBvpRGZBPw4L2ow==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
+      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.55.0",
-        "@typescript-eslint/types": "8.55.0",
-        "@typescript-eslint/typescript-estree": "8.55.0"
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2427,19 +1937,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.55.0.tgz",
-      "integrity": "sha512-AxNRwEie8Nn4eFS1FzDMJWIISMGoXMb037sgCBJ3UR6o0fQTzr2tqN9WT+DkWJPhIdQCfV7T6D387566VtnCJA==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
+      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.55.0",
-        "eslint-visitor-keys": "^4.2.1"
+        "@typescript-eslint/types": "8.59.3",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2449,46 +1959,30 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/@vitest/coverage-v8": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
-      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
+      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.3.0",
         "@bcoe/v8-coverage": "^1.0.2",
-        "ast-v8-to-istanbul": "^0.3.3",
-        "debug": "^4.4.1",
+        "@vitest/utils": "4.1.6",
+        "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
-        "istanbul-lib-source-maps": "^5.0.6",
-        "istanbul-reports": "^3.1.7",
-        "magic-string": "^0.30.17",
-        "magicast": "^0.3.5",
-        "std-env": "^3.9.0",
-        "test-exclude": "^7.0.1",
-        "tinyrainbow": "^2.0.0"
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "3.2.4",
-        "vitest": "3.2.4"
+        "@vitest/browser": "4.1.6",
+        "vitest": "4.1.6"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -2497,39 +1991,40 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "4.1.6",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
+        "magic-string": "^0.30.21"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -2541,42 +2036,42 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^2.0.0"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
-        "pathe": "^2.0.3",
-        "strip-literal": "^3.0.0"
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "magic-string": "^0.30.17",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2584,37 +2079,34 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -2634,9 +2126,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2673,13 +2165,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -2701,9 +2186,9 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.11.tgz",
-      "integrity": "sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2729,100 +2214,36 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "license": "MIT",
+        "balanced-match": "^4.0.2"
+      },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2850,30 +2271,10 @@
         "node": ">=6"
       }
     },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2915,16 +2316,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -2978,37 +2369,23 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.3.tgz",
+      "integrity": "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.4",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
-      "integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
+      "version": "5.21.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.3.tgz",
+      "integrity": "sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -3028,53 +2405,11 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
-      }
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3090,33 +2425,30 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
-      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+      "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.1",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.2",
-        "@eslint/plugin-kit": "^0.4.1",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "ajv": "^6.12.4",
-        "chalk": "^4.0.0",
+        "ajv": "^6.14.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -3126,8 +2458,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^10.2.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -3135,7 +2466,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -3150,93 +2481,66 @@
       }
     },
     "node_modules/eslint-plugin-zod": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-zod/-/eslint-plugin-zod-3.1.0.tgz",
-      "integrity": "sha512-9XemRkKexNSXP31yDGNlghr0c42hWJaqgmQ1tQx+u4ZawxObVlSQyKTTATXmN7Cr4BXH2uUrKYiZoEhLhoAXrg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-zod/-/eslint-plugin-zod-4.4.0.tgz",
+      "integrity": "sha512-DRlcaTkxsgmp9oeyPTF7oPLXoMxLHrydDWKUx9Aigv30Pf7U/h7yFXgVxFNwMgRT1xWYLUp04GRRvhBfBOE8VA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^8.50.0",
+        "@eslint-zod/utils": "1.2.0",
+        "@typescript-eslint/utils": "^8.57.0",
         "esquery": "^1.6.0"
       },
       "engines": {
         "node": "^20 || ^22 || >=24"
       },
       "peerDependencies": {
-        "eslint": "^9",
+        "eslint": "^9 || ^10",
+        "oxlint": "^1.59.0",
         "zod": "^4"
       },
       "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        },
+        "oxlint": {
+          "optional": true
+        },
         "zod": {
           "optional": true
         }
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/esm-env": {
@@ -3246,31 +2550,18 @@
       "license": "MIT"
     },
     "node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "eslint-visitor-keys": "^5.0.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -3470,23 +2761,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3502,28 +2776,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3537,19 +2789,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3558,9 +2797,9 @@
       "license": "ISC"
     },
     "node_modules/happy-dom": {
-      "version": "20.8.9",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.9.tgz",
-      "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3608,23 +2847,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -3659,16 +2881,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -3725,21 +2937,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-source-maps": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
-      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.23",
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/istanbul-reports": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
@@ -3754,26 +2951,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3786,19 +2967,6 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -3846,9 +3014,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
-      "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -3862,23 +3030,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.30.2",
-        "lightningcss-darwin-arm64": "1.30.2",
-        "lightningcss-darwin-x64": "1.30.2",
-        "lightningcss-freebsd-x64": "1.30.2",
-        "lightningcss-linux-arm-gnueabihf": "1.30.2",
-        "lightningcss-linux-arm64-gnu": "1.30.2",
-        "lightningcss-linux-arm64-musl": "1.30.2",
-        "lightningcss-linux-x64-gnu": "1.30.2",
-        "lightningcss-linux-x64-musl": "1.30.2",
-        "lightningcss-win32-arm64-msvc": "1.30.2",
-        "lightningcss-win32-x64-msvc": "1.30.2"
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
-      "integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
       ],
@@ -3897,9 +3065,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz",
-      "integrity": "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
       ],
@@ -3918,9 +3086,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
-      "integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
       ],
@@ -3939,9 +3107,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
-      "integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
       ],
@@ -3960,9 +3128,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
-      "integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
       ],
@@ -3981,13 +3149,16 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
-      "integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4002,13 +3173,16 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
-      "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4023,13 +3197,16 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
-      "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4044,13 +3221,16 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
-      "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4065,9 +3245,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
-      "integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
       ],
@@ -4086,9 +3266,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
-      "integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
       ],
@@ -4128,27 +3308,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -4169,15 +3328,15 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
-      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.25.4",
-        "@babel/types": "^7.25.4",
-        "source-map-js": "^1.2.0"
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/make-dir": {
@@ -4207,29 +3366,19 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mri": {
@@ -4249,9 +3398,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -4304,9 +3453,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.47.0.tgz",
-      "integrity": "sha512-v7xkK1iv1qdvTxJGclM97QzN8hHs5816AneFAQ0NGji1BMUquhiDAhXpMwp8+ls16uRVJtzVHxP9pAAXblDeGA==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.65.0.tgz",
+      "integrity": "sha512-ChUuE3Q7XnAbscvT4XLMsH7HFJmLgLVv9lu+RRgFL5wSXnDqUOzTp5IS8qWDBGd/ZDSzQ2tbX8fjAmijlGLC7A==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4319,28 +3468,28 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.47.0",
-        "@oxlint/binding-android-arm64": "1.47.0",
-        "@oxlint/binding-darwin-arm64": "1.47.0",
-        "@oxlint/binding-darwin-x64": "1.47.0",
-        "@oxlint/binding-freebsd-x64": "1.47.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.47.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.47.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.47.0",
-        "@oxlint/binding-linux-arm64-musl": "1.47.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.47.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.47.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.47.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.47.0",
-        "@oxlint/binding-linux-x64-gnu": "1.47.0",
-        "@oxlint/binding-linux-x64-musl": "1.47.0",
-        "@oxlint/binding-openharmony-arm64": "1.47.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.47.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.47.0",
-        "@oxlint/binding-win32-x64-msvc": "1.47.0"
+        "@oxlint/binding-android-arm-eabi": "1.65.0",
+        "@oxlint/binding-android-arm64": "1.65.0",
+        "@oxlint/binding-darwin-arm64": "1.65.0",
+        "@oxlint/binding-darwin-x64": "1.65.0",
+        "@oxlint/binding-freebsd-x64": "1.65.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.65.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.65.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.65.0",
+        "@oxlint/binding-linux-arm64-musl": "1.65.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.65.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.65.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.65.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.65.0",
+        "@oxlint/binding-linux-x64-gnu": "1.65.0",
+        "@oxlint/binding-linux-x64-musl": "1.65.0",
+        "@oxlint/binding-openharmony-arm64": "1.65.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.65.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.65.0",
+        "@oxlint/binding-win32-x64-msvc": "1.65.0"
       },
       "peerDependencies": {
-        "oxlint-tsgolint": ">=0.11.2"
+        "oxlint-tsgolint": ">=0.22.1"
       },
       "peerDependenciesMeta": {
         "oxlint-tsgolint": {
@@ -4380,26 +3529,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0"
-    },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4420,39 +3549,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4585,59 +3687,38 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "license": "MIT"
     },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/rollup": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+    "node_modules/rolldown": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@oxc-project/types": "=0.130.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.59.0",
-        "@rollup/rollup-android-arm64": "4.59.0",
-        "@rollup/rollup-darwin-arm64": "4.59.0",
-        "@rollup/rollup-darwin-x64": "4.59.0",
-        "@rollup/rollup-freebsd-arm64": "4.59.0",
-        "@rollup/rollup-freebsd-x64": "4.59.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
-        "@rollup/rollup-linux-arm64-musl": "4.59.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
-        "@rollup/rollup-linux-loong64-musl": "4.59.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-musl": "4.59.0",
-        "@rollup/rollup-openbsd-x64": "4.59.0",
-        "@rollup/rollup-openharmony-arm64": "4.59.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
-        "@rollup/rollup-win32-x64-gnu": "4.59.0",
-        "@rollup/rollup-win32-x64-msvc": "4.59.0",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.0.1",
+        "@rolldown/binding-darwin-arm64": "1.0.1",
+        "@rolldown/binding-darwin-x64": "1.0.1",
+        "@rolldown/binding-freebsd-x64": "1.0.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
+        "@rolldown/binding-linux-arm64-musl": "1.0.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-musl": "1.0.1",
+        "@rolldown/binding-openharmony-arm64": "1.0.1",
+        "@rolldown/binding-wasm32-wasi": "1.0.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
+        "@rolldown/binding-win32-x64-msvc": "1.0.1"
       }
     },
     "node_modules/sade": {
@@ -4674,9 +3755,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4715,19 +3796,6 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/sockjs-client": {
       "version": "1.6.1",
@@ -4775,108 +3843,11 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/string-width-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -4890,39 +3861,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/strip-literal": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/strip-literal/node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -4965,9 +3903,9 @@
       }
     },
     "node_modules/svelte-check": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.3.6.tgz",
-      "integrity": "sha512-uBkz96ElE3G4pt9E1Tw0xvBfIUQkeH794kDQZdAUk795UVMr+NJZpuFSS62vcmO/DuSalK83LyOwhgWq8YGU1Q==",
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.4.8.tgz",
+      "integrity": "sha512-67adfgBox5eNSNIvIIwgFizKGdcRrGpiMoNO2obHcYuLz7iTa8Xgm/NGU3ntMFnNm8K1grFOIG6HhMLX/vcN8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4998,16 +3936,16 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
-      "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5018,21 +3956,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/test-exclude": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
-      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@istanbuljs/schema": "^0.1.2",
-        "glob": "^10.4.1",
-        "minimatch": "^9.0.4"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -5041,21 +3964,24 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -5064,30 +3990,10 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
     "node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tinyspy": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5095,9 +4001,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5106,6 +4012,14 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5162,18 +4076,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.1",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -5189,9 +4102,10 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -5204,13 +4118,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -5236,33 +4153,10 @@
         }
       }
     },
-    "node_modules/vite-node": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.4.1",
-        "es-module-lexer": "^1.7.0",
-        "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/vitefu": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.1.tgz",
-      "integrity": "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -5271,7 +4165,7 @@
         "tests/projects/workspace/packages/*"
       ],
       "peerDependencies": {
-        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0"
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "vite": {
@@ -5280,65 +4174,79 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.1",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.4",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@types/debug": {
+        "@opentelemetry/api": {
           "optional": true
         },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser": {
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {
@@ -5349,6 +4257,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
@@ -5428,111 +4339,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5571,9 +4381,9 @@
       "license": "MIT"
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,7 +29,7 @@
         "eslint-plugin-zod": "^3.1.0",
         "happy-dom": "^20.8.9",
         "oxlint": "^1.47.0",
-        "svelte": "^5.53.6",
+        "svelte": "^5.55.7",
         "svelte-check": "^4.3.5",
         "tailwindcss": "^4.1.18",
         "typescript": "^5.9.3",
@@ -129,9 +129,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -149,9 +146,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2375,7 +2369,7 @@
       "version": "8.55.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.55.0.tgz",
       "integrity": "sha512-ujT0Je8GI5BJWi+/mMoR0wxwVEQaxM+pi30xuMiJETlX80OPovb2p9E8ss87gnSVtYXtJoU9U1Cowcr6w2FE0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2971,9 +2965,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
-      "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
     "node_modules/dom-accessibility-api": {
@@ -3296,12 +3290,20 @@
       }
     },
     "node_modules/esrap": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.2.tgz",
-      "integrity": "sha512-zA6497ha+qKvoWIK+WM9NAh5ni17sKZKhbS5B3PoYbBvaYHZWoS33zmFybmyqpn07RLUxSmn+RCls2/XF+d0oQ==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.8.tgz",
+      "integrity": "sha512-MPweq2EvEGj8jwOI7Hgycw/QIHzqA1EbAM8lG7p+FBfZbZq/hQ6h3AMsqnu/djzisH1KVWNzbb7LSgIVtMlPSg==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
       }
     },
     "node_modules/esrecurse": {
@@ -4936,9 +4938,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.53.6",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.53.6.tgz",
-      "integrity": "sha512-lP5DGF3oDDI9fhHcSpaBiJEkFLuS16h92DhM1L5K1lFm0WjOmUh1i2sNkBBk8rkxJRpob0dBE75jRfUzGZUOGA==",
+      "version": "5.55.7",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.7.tgz",
+      "integrity": "sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
@@ -4950,9 +4952,9 @@
         "aria-query": "5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
-        "devalue": "^5.6.3",
+        "devalue": "^5.8.1",
         "esm-env": "^1.2.1",
-        "esrap": "^2.2.2",
+        "esrap": "^2.2.4",
         "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
         "magic-string": "^0.30.11",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -129,9 +129,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -149,9 +146,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2971,9 +2965,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
-      "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
     "node_modules/dom-accessibility-api": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "eslint-plugin-zod": "^3.1.0",
     "happy-dom": "^20.8.9",
     "oxlint": "^1.47.0",
-    "svelte": "^5.53.6",
+    "svelte": "^5.55.7",
     "svelte-check": "^4.3.5",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.9.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,30 +24,30 @@
   "dependencies": {
     "@lucide/svelte": "^0.563.1",
     "@stomp/stompjs": "^7.2.0",
-    "dompurify": "^3.4.0",
+    "dompurify": "^3.4.3",
     "sockjs-client": "^1.6.1",
-    "zod": "^4.3.6"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@ast-grep/cli": "^0.41.0",
-    "@sveltejs/vite-plugin-svelte": "^6.2.4",
-    "@tailwindcss/vite": "^4.1.18",
+    "@ast-grep/cli": "^0.42.2",
+    "@sveltejs/vite-plugin-svelte": "^7.1.2",
+    "@tailwindcss/vite": "^4.3.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/svelte": "^5.2.7",
     "@tsconfig/svelte": "^5.0.6",
     "@types/dompurify": "^3.0.5",
     "@types/node": "^22.17.0",
     "@types/sockjs-client": "^1.5.4",
-    "@vitest/coverage-v8": "^3.0.4",
-    "eslint": "^9.39.2",
-    "eslint-plugin-zod": "^3.1.0",
-    "happy-dom": "^20.8.9",
-    "oxlint": "^1.47.0",
+    "@vitest/coverage-v8": "^4.1.6",
+    "eslint": "^10.4.0",
+    "eslint-plugin-zod": "^4.4.0",
+    "happy-dom": "^20.9.0",
+    "oxlint": "^1.65.0",
     "svelte": "^5.55.7",
-    "svelte-check": "^4.3.5",
-    "tailwindcss": "^4.1.18",
+    "svelte-check": "^4.4.8",
+    "tailwindcss": "^4.3.0",
     "typescript": "^5.9.3",
-    "vite": "^7.3.2",
-    "vitest": "^3.0.4"
+    "vite": "^8.0.13",
+    "vitest": "^4.1.6"
   }
 }

--- a/frontend/src/lib/components/BookAiContentPanel.test.ts
+++ b/frontend/src/lib/components/BookAiContentPanel.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/svelte";
 import BookAiContentPanel from "$lib/components/BookAiContentPanel.svelte";
-import type { BookAiErrorCode } from "$lib/validation/schemas";
+import type { Book, BookAiErrorCode } from "$lib/validation/schemas";
 
 const {
   getBookAiContentQueueStatsMock,
@@ -34,6 +34,27 @@ describe("BookAiContentPanel production behavior", () => {
     return streamError;
   }
 
+  function createBookFixture(overrides: Partial<Book>): Book {
+    return {
+      id: "book-fixture",
+      slug: "book-fixture",
+      title: "Book Fixture",
+      description: null,
+      descriptionContent: { raw: null, format: "UNKNOWN", html: "", text: "" },
+      publication: { publishedDate: null, language: null, pageCount: null, publisher: null },
+      authors: [],
+      categories: [],
+      collections: [],
+      tags: [],
+      cover: null,
+      editions: [],
+      recommendationIds: [],
+      extras: {},
+      aiContent: null,
+      ...overrides,
+    };
+  }
+
   beforeEach(() => {
     getBookAiContentQueueStatsMock.mockReset();
     vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -64,14 +85,13 @@ describe("BookAiContentPanel production behavior", () => {
     render(BookAiContentPanel, {
       props: {
         identifier: "short-description-book",
-        book: {
+        book: createBookFixture({
           id: "book-short",
           slug: "book-short",
           title: "Short Description Fixture",
           description: "tiny",
-          descriptionContent: { text: "tiny" },
-          aiContent: null,
-        } as any,
+          descriptionContent: { raw: "tiny", format: "PLAIN_TEXT", html: "tiny", text: "tiny" },
+        }),
         onAiContentUpdate,
       },
     });
@@ -105,14 +125,13 @@ describe("BookAiContentPanel production behavior", () => {
     render(BookAiContentPanel, {
       props: {
         identifier: "short-description-book",
-        book: {
+        book: createBookFixture({
           id: "book-short",
           slug: "book-short",
           title: "Short Description Fixture",
           description: "tiny",
-          descriptionContent: { text: "tiny" },
-          aiContent: null,
-        } as any,
+          descriptionContent: { raw: "tiny", format: "PLAIN_TEXT", html: "tiny", text: "tiny" },
+        }),
         onAiContentUpdate,
       },
     });
@@ -140,13 +159,16 @@ describe("BookAiContentPanel production behavior", () => {
     render(BookAiContentPanel, {
       props: {
         identifier: "degenerate-summary-book",
-        book: {
+        book: createBookFixture({
           id: "book-degenerate",
           slug: "book-degenerate",
           title: "Degenerate Summary Fixture",
           description:
             "This description is long enough for AI generation and should allow regeneration attempts.",
           descriptionContent: {
+            raw: "This description is long enough for AI generation and should allow regeneration attempts.",
+            format: "PLAIN_TEXT",
+            html: "This description is long enough for AI generation and should allow regeneration attempts.",
             text: "This description is long enough for AI generation and should allow regeneration attempts.",
           },
           aiContent: {
@@ -156,7 +178,7 @@ describe("BookAiContentPanel production behavior", () => {
             readerFit: null,
             context: null,
           },
-        } as any,
+        }),
         onAiContentUpdate,
       },
     });

--- a/frontend/src/lib/pages/BookPage.svelte
+++ b/frontend/src/lib/pages/BookPage.svelte
@@ -8,9 +8,9 @@
     getAffiliateLinks,
     getBook,
     getSimilarBooks,
-    persistRenderedCover,
     DEFAULT_SIMILAR_BOOKS_LIMIT,
   } from "$lib/services/books";
+  import { persistRenderedCover } from "$lib/services/coverPersistence";
   import {
     mergePersistedCoverIntoBook,
     normalizeCoverUrl,

--- a/frontend/src/lib/pages/SearchPage.svelte
+++ b/frontend/src/lib/pages/SearchPage.svelte
@@ -5,9 +5,10 @@
   import SearchPageStatus from "$lib/components/SearchPageStatus.svelte";
   import SearchResultsPanel from "$lib/components/SearchResultsPanel.svelte";
   import { navigate, type SearchRouteName } from "$lib/router/router";
-  import { searchBooks, normalizeRealtimeSearchHits, mergeSearchHits, type SearchParams } from "$lib/services/books";
+  import { searchBooks, type SearchParams } from "$lib/services/books";
   import { getCategoryFacets, getHomePagePayload, type PopularWindow } from "$lib/services/pages";
   import { subscribeToSearchTopics } from "$lib/services/realtime";
+  import { mergeSearchHits, normalizeRealtimeSearchHits } from "$lib/services/searchHitNormalization";
   import { EXPLORE_DEFAULT_POPULAR_WINDOW, EXPLORE_POPULAR_LIMIT, buildExplorePopularSearchResponse, popularWindowLabel } from "$lib/services/explorePopular";
   import { PAGE_SIZE, PREFETCH_WINDOW_SIZE, CATEGORY_FACET_LIMIT, CATEGORY_MIN_BOOKS, pageFromStartIndex, type CoverOption, type ResolutionOption, type SortOption } from "$lib/services/searchConfig";
   import { buildBookDetailHref, buildExploreDefaultUrl, buildSearchRouteUrl, createSearchParams, mapSearchHitToBookCard, readSearchPageRouteState, searchParamsCacheKey } from "$lib/services/searchPageViewModel";

--- a/frontend/src/lib/router/router.book-page.cover-relay.test.ts
+++ b/frontend/src/lib/router/router.book-page.cover-relay.test.ts
@@ -21,8 +21,11 @@ vi.mock("$lib/services/books", () => ({
   getBook: getBookMock,
   getSimilarBooks: getSimilarBooksMock,
   getAffiliateLinks: getAffiliateLinksMock,
-  persistRenderedCover: persistRenderedCoverMock,
   DEFAULT_SIMILAR_BOOKS_LIMIT: 8,
+}));
+
+vi.mock("$lib/services/coverPersistence", () => ({
+  persistRenderedCover: persistRenderedCoverMock,
 }));
 
 vi.mock("$lib/services/realtime", () => ({

--- a/frontend/src/lib/router/router.book-page.similar-books.test.ts
+++ b/frontend/src/lib/router/router.book-page.similar-books.test.ts
@@ -19,8 +19,11 @@ vi.mock("$lib/services/books", () => ({
   getBook: getBookMock,
   getSimilarBooks: getSimilarBooksMock,
   getAffiliateLinks: getAffiliateLinksMock,
-  persistRenderedCover: vi.fn(),
   DEFAULT_SIMILAR_BOOKS_LIMIT: 8,
+}));
+
+vi.mock("$lib/services/coverPersistence", () => ({
+  persistRenderedCover: vi.fn(),
 }));
 
 vi.mock("$lib/services/realtime", () => ({

--- a/frontend/src/lib/router/router.book-page.test.ts
+++ b/frontend/src/lib/router/router.book-page.test.ts
@@ -18,8 +18,11 @@ vi.mock("$lib/services/books", () => ({
   getBook: getBookMock,
   getSimilarBooks: getSimilarBooksMock,
   getAffiliateLinks: getAffiliateLinksMock,
-  persistRenderedCover: vi.fn(),
   DEFAULT_SIMILAR_BOOKS_LIMIT: 8,
+}));
+
+vi.mock("$lib/services/coverPersistence", () => ({
+  persistRenderedCover: vi.fn(),
 }));
 
 vi.mock("$lib/services/realtime", () => ({

--- a/frontend/src/lib/router/router.page-loaders.test.ts
+++ b/frontend/src/lib/router/router.page-loaders.test.ts
@@ -20,6 +20,9 @@ const {
 
 vi.mock("$lib/services/books", () => ({
   searchBooks: searchBooksMock,
+}));
+
+vi.mock("$lib/services/searchHitNormalization", () => ({
   normalizeRealtimeSearchHits: normalizeRealtimeSearchHitsMock,
   mergeSearchHits: mergeSearchHitsMock,
 }));
@@ -226,7 +229,7 @@ describe("SearchPage loading state", () => {
           relevanceScore: null,
         },
       ],
-    } as any);
+    });
 
     const currentUrl = new URL(
       "https://findmybook.net/search?query=doug%20turnbull&page=1&orderBy=newest&view=grid&coverSource=ANY&resolution=HIGH_FIRST",

--- a/frontend/src/lib/router/routerHistoryState.ts
+++ b/frontend/src/lib/router/routerHistoryState.ts
@@ -21,19 +21,18 @@ export function normalizeInternalPath(candidate: string | null): string | null {
   if (!candidate) {
     return null;
   }
-  try {
-    const parsed = new URL(candidate, browserOrigin());
-    if (parsed.origin !== browserOrigin()) {
-      return null;
-    }
-    if (!parsed.pathname.startsWith("/")) {
-      return null;
-    }
-    return pathWithQueryAndHash(parsed);
-  } catch (error) {
-    console.warn("[router] Failed to normalize internal path:", candidate, error);
+  const origin = browserOrigin();
+  if (!URL.canParse(candidate, origin)) {
     return null;
   }
+  const parsed = new URL(candidate, origin);
+  if (parsed.origin !== origin) {
+    return null;
+  }
+  if (!parsed.pathname.startsWith("/")) {
+    return null;
+  }
+  return pathWithQueryAndHash(parsed);
 }
 
 export function buildSpaHistoryState(previousPath: string | null): SpaHistoryState {

--- a/frontend/src/lib/services/bookAiContentStream.ts
+++ b/frontend/src/lib/services/bookAiContentStream.ts
@@ -45,7 +45,7 @@ function createBookAiContentStreamError(
   return streamError;
 }
 
-function parseSseMessage(raw: string): { event: string; data: string } | null {
+function parseSseMessage(raw: string): { event: string; payloadText: string } | null {
   const lines = raw.split("\n");
   let event = "message";
   const dataLines: string[] = [];
@@ -60,20 +60,20 @@ function parseSseMessage(raw: string): { event: string; data: string } | null {
     }
   }
 
-  const data = dataLines.join("\n").trim();
-  if (!data) {
+  const payloadText = dataLines.join("\n").trim();
+  if (!payloadText) {
     return null;
   }
-  return { event, data };
+  return { event, payloadText };
 }
 
 function normalizeSseLineEndings(value: string): string {
   return value.replaceAll("\r\n", "\n").replaceAll("\r", "\n");
 }
 
-function safeParseJson(data: string, eventType: string): unknown {
+function safeParseJson(payloadText: string, eventType: string): unknown {
   try {
-    return JSON.parse(data);
+    return JSON.parse(payloadText);
   } catch (parseError) {
     const detail = parseError instanceof Error ? parseError.message : String(parseError);
     throw new Error(`Malformed JSON in SSE '${eventType}' event: ${detail}`);
@@ -108,9 +108,9 @@ async function readBookAiContentSseStream(
   let buffer = "";
   let pendingCarriageReturn = false;
 
-  const processMessage = (message: { event: string; data: string }): StreamBookAiContentResult | null => {
+  const processMessage = (message: { event: string; payloadText: string }): StreamBookAiContentResult | null => {
     if (message.event === "error") {
-      const parsed = safeParseJson(message.data, "error");
+      const parsed = safeParseJson(message.payloadText, "error");
       const streamError = validateWithSchema(
         BookAiContentStreamErrorSchema,
         parsed,
@@ -129,7 +129,7 @@ async function readBookAiContentSseStream(
     }
 
     if (message.event === "queued" || message.event === "queue" || message.event === "started") {
-      const parsed = safeParseJson(message.data, message.event);
+      const parsed = safeParseJson(message.payloadText, message.event);
       const queueUpdate = validateWithSchema(
         BookAiContentQueueUpdateSchema,
         { ...(parsed as Record<string, unknown>), event: message.event },
@@ -142,7 +142,7 @@ async function readBookAiContentSseStream(
     }
 
     if (message.event === "message_start" || message.event === "message_delta" || message.event === "message_done") {
-      const parsed = safeParseJson(message.data, message.event);
+      const parsed = safeParseJson(message.payloadText, message.event);
       const streamUpdate = validateWithSchema(
         BookAiContentModelStreamUpdateSchema,
         { event: message.event, data: parsed },
@@ -155,7 +155,7 @@ async function readBookAiContentSseStream(
     }
 
     if (message.event === "done") {
-      const parsed = safeParseJson(message.data, "done");
+      const parsed = safeParseJson(message.payloadText, "done");
       const done = validateWithSchema(BookAiContentStreamDoneSchema, parsed, "bookAiContentStreamDone");
       if (!done.success) {
         throw new Error("Book AI stream done payload was invalid");

--- a/frontend/src/lib/services/books.ts
+++ b/frontend/src/lib/services/books.ts
@@ -2,8 +2,6 @@
  * Book data access layer — search, detail, similar books, and affiliate links.
  *
  * All data flows through the backend HTTP API with typed Zod validation at the boundary.
- * Cover persistence and realtime search-hit normalization live in dedicated modules;
- * re-exported here for backward compatibility with existing importers.
  */
 import { getJson } from "$lib/services/http";
 import type { SortOption, TimeWindow } from "$lib/services/searchConfig";
@@ -17,9 +15,6 @@ import {
   SimilarBooksSchema,
   AffiliateLinksSchema,
 } from "$lib/validation/schemas";
-
-export { persistRenderedCover, type PersistRenderedCoverRequest } from "$lib/services/coverPersistence";
-export { normalizeRealtimeSearchHits, mergeSearchHits } from "$lib/services/searchHitNormalization";
 
 export const DEFAULT_SIMILAR_BOOKS_LIMIT = 8;
 const inFlightSearchRequests = new Map<string, Promise<SearchResponse>>();

--- a/frontend/src/lib/services/coverRelayPersistence.ts
+++ b/frontend/src/lib/services/coverRelayPersistence.ts
@@ -17,17 +17,15 @@ export function normalizeCoverUrl(candidateUrl: string): string | null {
     return null;
   }
 
-  try {
-    const baseOrigin = typeof location === "undefined" ? undefined : location.origin;
-    const parsed = baseOrigin ? new URL(candidateUrl, baseOrigin) : new URL(candidateUrl);
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-      return null;
-    }
-    return parsed.href;
-  } catch (error) {
-    console.warn("[normalizeCoverUrl] Invalid URL:", candidateUrl, error);
+  const baseOrigin = typeof location === "undefined" ? undefined : location.origin;
+  if (!URL.canParse(candidateUrl, baseOrigin)) {
     return null;
   }
+  const parsed = new URL(candidateUrl, baseOrigin);
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return null;
+  }
+  return parsed.href;
 }
 
 function hasPersistedS3Cover(book: Book): boolean {

--- a/frontend/src/lib/services/http.ts
+++ b/frontend/src/lib/services/http.ts
@@ -4,6 +4,18 @@ import type { z } from "zod/v4";
 const CSRF_COOKIE = "XSRF-TOKEN";
 const CSRF_HEADER = "X-XSRF-TOKEN";
 
+type DecodedCookieToken =
+  | { success: true; token: string }
+  | { success: false; error: unknown };
+
+function decodeCookieToken(token: string): DecodedCookieToken {
+  try {
+    return { success: true, token: decodeURIComponent(token) };
+  } catch (error) {
+    return { success: false, error };
+  }
+}
+
 function getCookie(cookieName: string): string | null {
   if (typeof document === "undefined") {
     return null;
@@ -18,12 +30,12 @@ function getCookie(cookieName: string): string | null {
   }
 
   const token = entry.substring(cookieName.length + 1);
-  try {
-    return decodeURIComponent(token);
-  } catch (error) {
-    console.warn(`[http] Failed to decode ${cookieName} cookie value; discarding corrupt token`, error);
+  const decoded = decodeCookieToken(token);
+  if (!decoded.success) {
+    console.warn(`[http] Failed to decode ${cookieName} cookie value; discarding corrupt token`, decoded.error);
     return null;
   }
+  return decoded.token;
 }
 
 function withCsrf(init: RequestInit): RequestInit {

--- a/frontend/src/lib/services/realtime.ts
+++ b/frontend/src/lib/services/realtime.ts
@@ -27,6 +27,10 @@ type ConnectionState =
   | { status: "connecting"; pending: Promise<Client> }
   | { status: "connected"; client: Client };
 
+type ParsedMessage =
+  | { success: true; payload: unknown }
+  | { success: false; error: unknown };
+
 let connection: ConnectionState = { status: "idle" };
 
 function buildClient(): Client {
@@ -38,16 +42,21 @@ function buildClient(): Client {
   });
 }
 
-function parseMessagePayload<T>(messageBody: string, recordId: string, schema: z.ZodType<T>): T | null {
-  let payload: unknown;
+function parseJsonMessagePayload(messageBody: string): ParsedMessage {
   try {
-    payload = JSON.parse(messageBody);
+    return { success: true, payload: JSON.parse(messageBody) };
   } catch (error) {
-    console.warn(`Failed to parse ${recordId} payload`, error);
+    return { success: false, error };
+  }
+}
+
+function parseMessagePayload<T>(messageBody: string, recordId: string, schema: z.ZodType<T>): T | null {
+  const parsed = parseJsonMessagePayload(messageBody);
+  if (!parsed.success) {
+    console.warn(`Failed to parse ${recordId} payload`, parsed.error);
     return null;
   }
-
-  const validation = validateWithSchema(schema, payload, recordId);
+  const validation = validateWithSchema(schema, parsed.payload, recordId);
   if (!validation.success) {
     return null;
   }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -18,6 +18,9 @@ function proxyConfig(target: string, websocket = false): ProxyOptions {
 export default defineConfig(({ mode }) => ({
   plugins: [svelte(), tailwindcss(), svelteTesting()],
   base: mode === "development" ? "/" : "/frontend/",
+  define: {
+    global: "globalThis",
+  },
   build: {
     outDir: OUTPUT_DIR,
     emptyOutDir: true,

--- a/src/main/java/net/findmybook/application/similarity/BookEmbeddingClient.java
+++ b/src/main/java/net/findmybook/application/similarity/BookEmbeddingClient.java
@@ -323,7 +323,6 @@ public class BookEmbeddingClient {
     }
 
     record EmbeddingInputPlan(List<EmbeddingChunk> chunks) {
-
         EmbeddingInputPlan {
             if (chunks == null || chunks.isEmpty()) {
                 throw new IllegalArgumentException("chunks are required");
@@ -333,7 +332,6 @@ public class BookEmbeddingClient {
     }
 
     record EmbeddingChunk(String text, int estimatedTokens) {
-
         EmbeddingChunk {
             if (text == null || text.isBlank()) {
                 throw new IllegalArgumentException("chunk text is required");

--- a/src/main/java/net/findmybook/application/similarity/BookEmbeddingClient.java
+++ b/src/main/java/net/findmybook/application/similarity/BookEmbeddingClient.java
@@ -20,6 +20,7 @@ import net.findmybook.boot.OpenAiProperties;
 import net.findmybook.support.llm.LlmGatewayTier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
@@ -53,6 +54,7 @@ public class BookEmbeddingClient {
      * @param openAiProperties provider and model settings
      * @param embeddingProperties book similarity embedding request limits
      */
+    @Autowired
     public BookEmbeddingClient(OpenAiProperties openAiProperties, BookSimilarityEmbeddingProperties embeddingProperties) {
         this.model = openAiProperties.embeddingsModel();
         this.requestTimeoutSeconds = openAiProperties.requestTimeoutSeconds();

--- a/src/main/java/net/findmybook/application/similarity/BookEmbeddingClient.java
+++ b/src/main/java/net/findmybook/application/similarity/BookEmbeddingClient.java
@@ -36,9 +36,7 @@ import org.springframework.stereotype.Component;
 public class BookEmbeddingClient {
 
     private static final Logger log = LoggerFactory.getLogger(BookEmbeddingClient.class);
-    private static final int INPUT_TOKEN_COMFORT_LIMIT = 8_192;
     private static final int REQUEST_TOKEN_BUDGET = 262_144;
-    private static final String EMBEDDING_INPUT_CONTRACT = "chunked_8192_v1";
 
     private final Map<LlmGatewayTier, BatchEmbeddingRequester> requestersByTier;
     private final boolean available;
@@ -47,6 +45,7 @@ public class BookEmbeddingClient {
     private final long readTimeoutSeconds;
     private final int inputTokenComfortLimit;
     private final int requestInputBatchSize;
+    private final String embeddingInputContract;
 
     /**
      * Creates one SDK client per tier so the {@code X-Tier} header is fixed per connection.
@@ -59,11 +58,12 @@ public class BookEmbeddingClient {
         this.model = openAiProperties.embeddingsModel();
         this.requestTimeoutSeconds = openAiProperties.requestTimeoutSeconds();
         this.readTimeoutSeconds = openAiProperties.readTimeoutSeconds();
-        this.inputTokenComfortLimit = Math.min(embeddingProperties.inputTokenComfortLimit(), INPUT_TOKEN_COMFORT_LIMIT);
+        this.inputTokenComfortLimit = embeddingProperties.inputTokenComfortLimit();
         this.requestInputBatchSize = Math.min(
             embeddingProperties.requestInputBatchSize(),
             Math.max(1, REQUEST_TOKEN_BUDGET / this.inputTokenComfortLimit)
         );
+        this.embeddingInputContract = embeddingProperties.embeddingInputContract();
         if (openAiProperties.isEmbeddingsConfigured()) {
             EnumMap<LlmGatewayTier, BatchEmbeddingRequester> requesters = new EnumMap<>(LlmGatewayTier.class);
             for (LlmGatewayTier tier : LlmGatewayTier.values()) {
@@ -99,11 +99,12 @@ public class BookEmbeddingClient {
         this.model = model;
         this.requestTimeoutSeconds = requestTimeoutSeconds;
         this.readTimeoutSeconds = readTimeoutSeconds;
-        this.inputTokenComfortLimit = Math.min(Math.max(1, configuredInputTokenLimit), INPUT_TOKEN_COMFORT_LIMIT);
+        this.inputTokenComfortLimit = BookSimilarityEmbeddingProperties.normalizedInputTokenComfortLimit(configuredInputTokenLimit);
         this.requestInputBatchSize = Math.min(
             Math.max(1, configuredRequestInputBatchSize),
             Math.max(1, REQUEST_TOKEN_BUDGET / this.inputTokenComfortLimit)
         );
+        this.embeddingInputContract = BookSimilarityEmbeddingProperties.embeddingInputContract(configuredInputTokenLimit);
         this.requestersByTier = Map.copyOf(requestersByTier);
         this.available = !this.requestersByTier.isEmpty();
     }
@@ -135,7 +136,7 @@ public class BookEmbeddingClient {
         if (model == null || model.isBlank()) {
             return "";
         }
-        return model.trim() + ":" + EMBEDDING_INPUT_CONTRACT;
+        return model.trim() + ":" + embeddingInputContract;
     }
 
     /**
@@ -225,7 +226,7 @@ public class BookEmbeddingClient {
 
     static List<EmbeddingInputPlan> planEmbeddingInputs(List<String> sectionTexts, int maxEstimatedTokens) {
         List<EmbeddingInputPlan> inputPlans = new ArrayList<>(sectionTexts.size());
-        int effectiveTokenLimit = Math.max(1, Math.min(maxEstimatedTokens, INPUT_TOKEN_COMFORT_LIMIT));
+        int effectiveTokenLimit = BookSimilarityEmbeddingProperties.normalizedInputTokenComfortLimit(maxEstimatedTokens);
         for (int inputIndex = 0; inputIndex < sectionTexts.size(); inputIndex++) {
             String sectionText = sectionTexts.get(inputIndex);
             if (sectionText == null || sectionText.isBlank()) {

--- a/src/main/java/net/findmybook/application/similarity/BookEmbeddingClient.java
+++ b/src/main/java/net/findmybook/application/similarity/BookEmbeddingClient.java
@@ -285,7 +285,7 @@ public class BookEmbeddingClient {
             throw new IllegalStateException("Embedding chunk count did not match request plan");
         }
         if (chunkEmbeddings.size() == 1) {
-            return List.copyOf(chunkEmbeddings.getFirst());
+            return BookSimilarityVectorFusion.fuseWeighted(chunkEmbeddings, List.of(1.0d));
         }
         double totalWeight = chunks.stream()
             .mapToDouble(EmbeddingChunk::estimatedTokens)

--- a/src/main/java/net/findmybook/application/similarity/BookEmbeddingClient.java
+++ b/src/main/java/net/findmybook/application/similarity/BookEmbeddingClient.java
@@ -9,11 +9,13 @@ import com.openai.models.embeddings.CreateEmbeddingResponse;
 import com.openai.models.embeddings.Embedding;
 import com.openai.models.embeddings.EmbeddingCreateParams;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import net.findmybook.application.ai.BookAiGenerationException;
+import net.findmybook.boot.BookSimilarityEmbeddingProperties;
 import net.findmybook.boot.OpenAiProperties;
 import net.findmybook.support.llm.LlmGatewayTier;
 import org.slf4j.Logger;
@@ -33,46 +35,75 @@ import org.springframework.stereotype.Component;
 public class BookEmbeddingClient {
 
     private static final Logger log = LoggerFactory.getLogger(BookEmbeddingClient.class);
-    private static final int EXPECTED_DIMENSION = 2560;
+    private static final int INPUT_TOKEN_COMFORT_LIMIT = 8_192;
+    private static final int REQUEST_TOKEN_BUDGET = 262_144;
+    private static final String EMBEDDING_INPUT_CONTRACT = "chunked_8192_v1";
 
-    private final Map<LlmGatewayTier, OpenAIClient> clientsByTier;
+    private final Map<LlmGatewayTier, BatchEmbeddingRequester> requestersByTier;
     private final boolean available;
     private final String model;
     private final long requestTimeoutSeconds;
     private final long readTimeoutSeconds;
+    private final int inputTokenComfortLimit;
+    private final int requestInputBatchSize;
 
     /**
      * Creates one SDK client per tier so the {@code X-Tier} header is fixed per connection.
      *
      * @param openAiProperties provider and model settings
+     * @param embeddingProperties book similarity embedding request limits
      */
-    public BookEmbeddingClient(OpenAiProperties openAiProperties) {
+    public BookEmbeddingClient(OpenAiProperties openAiProperties, BookSimilarityEmbeddingProperties embeddingProperties) {
         this.model = openAiProperties.embeddingsModel();
         this.requestTimeoutSeconds = openAiProperties.requestTimeoutSeconds();
         this.readTimeoutSeconds = openAiProperties.readTimeoutSeconds();
+        this.inputTokenComfortLimit = Math.min(embeddingProperties.inputTokenComfortLimit(), INPUT_TOKEN_COMFORT_LIMIT);
+        this.requestInputBatchSize = Math.min(
+            embeddingProperties.requestInputBatchSize(),
+            Math.max(1, REQUEST_TOKEN_BUDGET / this.inputTokenComfortLimit)
+        );
         if (openAiProperties.isEmbeddingsConfigured()) {
-            EnumMap<LlmGatewayTier, OpenAIClient> clients = new EnumMap<>(LlmGatewayTier.class);
+            EnumMap<LlmGatewayTier, BatchEmbeddingRequester> requesters = new EnumMap<>(LlmGatewayTier.class);
             for (LlmGatewayTier tier : LlmGatewayTier.values()) {
-                clients.put(tier, OpenAIOkHttpClient.builder()
+                OpenAIClient tieredClient = OpenAIOkHttpClient.builder()
                     .apiKey(openAiProperties.apiKey())
                     .baseUrl(openAiProperties.baseUrl())
                     .maxRetries(0)
                     .putHeader(LlmGatewayTier.HEADER_NAME, tier.headerValue())
-                    .build());
+                    .build();
+                requesters.put(tier, createOpenAiRequester(tieredClient));
             }
-            this.clientsByTier = Map.copyOf(clients);
+            this.requestersByTier = Map.copyOf(requesters);
             this.available = true;
             log.info(
                 "Book embedding client configured (model={}, baseUrl={}, tiers={})",
                 model,
                 openAiProperties.baseUrl(),
-                clients.keySet()
+                requesters.keySet()
             );
             return;
         }
-        this.clientsByTier = Map.of();
+        this.requestersByTier = Map.of();
         this.available = false;
         log.warn("Book embedding client is disabled: missing OPENAI_API_KEY, OPENAI_BASE_URL, or OPENAI_EMBEDDINGS_MODEL");
+    }
+
+    BookEmbeddingClient(String model,
+                        long requestTimeoutSeconds,
+                        long readTimeoutSeconds,
+                        int configuredInputTokenLimit,
+                        int configuredRequestInputBatchSize,
+                        Map<LlmGatewayTier, BatchEmbeddingRequester> requestersByTier) {
+        this.model = model;
+        this.requestTimeoutSeconds = requestTimeoutSeconds;
+        this.readTimeoutSeconds = readTimeoutSeconds;
+        this.inputTokenComfortLimit = Math.min(Math.max(1, configuredInputTokenLimit), INPUT_TOKEN_COMFORT_LIMIT);
+        this.requestInputBatchSize = Math.min(
+            Math.max(1, configuredRequestInputBatchSize),
+            Math.max(1, REQUEST_TOKEN_BUDGET / this.inputTokenComfortLimit)
+        );
+        this.requestersByTier = Map.copyOf(requestersByTier);
+        this.available = !this.requestersByTier.isEmpty();
     }
 
     /**
@@ -94,41 +125,60 @@ public class BookEmbeddingClient {
     }
 
     /**
+     * Returns the cache identity for the active embedding input contract.
+     *
+     * @return model key that invalidates section caches when client chunking changes
+     */
+    public String cacheModel() {
+        if (model == null || model.isBlank()) {
+            return "";
+        }
+        return model.trim() + ":" + EMBEDDING_INPUT_CONTRACT;
+    }
+
+    /**
      * Embeds a batch of section texts at the supplied gateway tier.
      *
-     * @param inputs section texts in desired output order
+     * @param sectionTexts section texts in desired output order
      * @param tier gateway priority tier; must be non-null
      * @return embeddings in input order
      */
-    public List<List<Float>> embedSections(List<String> inputs, LlmGatewayTier tier) {
+    public List<List<Float>> embedSections(List<String> sectionTexts, LlmGatewayTier tier) {
         ensureAvailable();
         if (tier == null) {
             throw new IllegalArgumentException("tier is required");
         }
-        if (inputs == null || inputs.isEmpty()) {
+        if (sectionTexts == null || sectionTexts.isEmpty()) {
             throw new IllegalArgumentException("inputs are required");
         }
-        OpenAIClient tieredClient = clientsByTier.get(tier);
-        if (tieredClient == null) {
+        BatchEmbeddingRequester requester = requestersByTier.get(tier);
+        if (requester == null) {
             throw new IllegalStateException("No embedding client configured for tier " + tier);
         }
-        EmbeddingCreateParams params = EmbeddingCreateParams.builder()
-            .model(model)
-            .inputOfArrayOfStrings(inputs)
-            .build();
-        RequestOptions options = RequestOptions.builder()
-            .timeout(Timeout.builder()
-                .request(Duration.ofSeconds(requestTimeoutSeconds))
-                .read(Duration.ofSeconds(readTimeoutSeconds))
-                .build())
-            .build();
+        List<EmbeddingInputPlan> inputPlans = planEmbeddingInputs(sectionTexts, inputTokenComfortLimit);
+        List<EmbeddingChunk> requestChunks = flattenRequestChunks(inputPlans);
+        RequestOptions options = requestOptions();
+        List<List<Float>> chunkEmbeddings = new ArrayList<>(requestChunks.size());
+        int fromIndex = 0;
+        while (fromIndex < requestChunks.size()) {
+            int toIndex = Math.min(fromIndex + requestInputBatchSize, requestChunks.size());
+            List<EmbeddingChunk> batchChunks = requestChunks.subList(fromIndex, toIndex);
+            chunkEmbeddings.addAll(embedChunkBatch(batchChunks, requester, options, tier));
+            fromIndex = toIndex;
+        }
+        return collapseChunkEmbeddings(inputPlans, chunkEmbeddings);
+    }
+
+    private List<List<Float>> embedChunkBatch(List<EmbeddingChunk> batchChunks,
+                                              BatchEmbeddingRequester requester,
+                                              RequestOptions options,
+                                              LlmGatewayTier tier) {
+        List<String> batchTexts = batchChunks.stream()
+            .map(EmbeddingChunk::text)
+            .toList();
         try {
-            CreateEmbeddingResponse response = tieredClient.embeddings().create(params, options);
-            List<List<Float>> embeddings = response.data().stream()
-                .sorted(Comparator.comparingLong(Embedding::index))
-                .map(Embedding::embedding)
-                .toList();
-            validateEmbeddingResponse(inputs.size(), embeddings);
+            List<List<Float>> embeddings = requester.embed(batchTexts, options);
+            validateEmbeddingResponse(batchTexts.size(), embeddings);
             return embeddings;
         } catch (OpenAIException openAiException) {
             throw new BookEmbeddingApiException(
@@ -142,10 +192,105 @@ public class BookEmbeddingClient {
         }
     }
 
+    private BatchEmbeddingRequester createOpenAiRequester(OpenAIClient tieredClient) {
+        return (batchTexts, options) -> {
+            EmbeddingCreateParams params = EmbeddingCreateParams.builder()
+                .model(model)
+                .inputOfArrayOfStrings(batchTexts)
+                .build();
+            CreateEmbeddingResponse response = tieredClient.embeddings().create(params, options);
+            return response.data().stream()
+                .sorted(Comparator.comparingLong(Embedding::index))
+                .map(Embedding::embedding)
+                .toList();
+        };
+    }
+
+    private RequestOptions requestOptions() {
+        return RequestOptions.builder()
+            .timeout(Timeout.builder()
+                .request(Duration.ofSeconds(requestTimeoutSeconds))
+                .read(Duration.ofSeconds(readTimeoutSeconds))
+                .build())
+            .build();
+    }
+
     private void ensureAvailable() {
-        if (!available || clientsByTier.isEmpty()) {
+        if (!available || requestersByTier.isEmpty()) {
             throw new IllegalStateException("Book embedding client is not configured");
         }
+    }
+
+    static List<EmbeddingInputPlan> planEmbeddingInputs(List<String> sectionTexts, int maxEstimatedTokens) {
+        List<EmbeddingInputPlan> inputPlans = new ArrayList<>(sectionTexts.size());
+        int effectiveTokenLimit = Math.max(1, Math.min(maxEstimatedTokens, INPUT_TOKEN_COMFORT_LIMIT));
+        for (int inputIndex = 0; inputIndex < sectionTexts.size(); inputIndex++) {
+            String sectionText = sectionTexts.get(inputIndex);
+            if (sectionText == null || sectionText.isBlank()) {
+                throw new IllegalArgumentException("embedding input[" + inputIndex + "] is required");
+            }
+            inputPlans.add(new EmbeddingInputPlan(splitIntoChunks(sectionText, effectiveTokenLimit)));
+        }
+        return List.copyOf(inputPlans);
+    }
+
+    private static List<EmbeddingChunk> splitIntoChunks(String sectionText, int maxEstimatedTokens) {
+        List<EmbeddingChunk> chunks = new ArrayList<>();
+        StringBuilder chunkBuilder = new StringBuilder(Math.min(sectionText.length(), maxEstimatedTokens));
+        int chunkEstimatedTokens = 0;
+        for (int offset = 0; offset < sectionText.length();) {
+            int codePoint = sectionText.codePointAt(offset);
+            int codePointEstimatedTokens = utf8ByteLength(codePoint);
+            if (chunkEstimatedTokens > 0 && chunkEstimatedTokens + codePointEstimatedTokens > maxEstimatedTokens) {
+                chunks.add(new EmbeddingChunk(chunkBuilder.toString(), chunkEstimatedTokens));
+                chunkBuilder.setLength(0);
+                chunkEstimatedTokens = 0;
+            }
+            chunkBuilder.appendCodePoint(codePoint);
+            chunkEstimatedTokens += codePointEstimatedTokens;
+            offset += Character.charCount(codePoint);
+        }
+        if (!chunkBuilder.isEmpty()) {
+            chunks.add(new EmbeddingChunk(chunkBuilder.toString(), chunkEstimatedTokens));
+        }
+        return List.copyOf(chunks);
+    }
+
+    private static List<EmbeddingChunk> flattenRequestChunks(List<EmbeddingInputPlan> inputPlans) {
+        List<EmbeddingChunk> requestChunks = new ArrayList<>();
+        for (EmbeddingInputPlan inputPlan : inputPlans) {
+            requestChunks.addAll(inputPlan.chunks());
+        }
+        return List.copyOf(requestChunks);
+    }
+
+    private static List<List<Float>> collapseChunkEmbeddings(List<EmbeddingInputPlan> inputPlans,
+                                                            List<List<Float>> chunkEmbeddings) {
+        List<List<Float>> sectionEmbeddings = new ArrayList<>(inputPlans.size());
+        int chunkIndex = 0;
+        for (EmbeddingInputPlan inputPlan : inputPlans) {
+            int nextChunkIndex = chunkIndex + inputPlan.chunks().size();
+            List<List<Float>> inputChunkEmbeddings = chunkEmbeddings.subList(chunkIndex, nextChunkIndex);
+            sectionEmbeddings.add(fuseInputChunks(inputChunkEmbeddings, inputPlan.chunks()));
+            chunkIndex = nextChunkIndex;
+        }
+        return List.copyOf(sectionEmbeddings);
+    }
+
+    static List<Float> fuseInputChunks(List<List<Float>> chunkEmbeddings, List<EmbeddingChunk> chunks) {
+        if (chunkEmbeddings.size() != chunks.size()) {
+            throw new IllegalStateException("Embedding chunk count did not match request plan");
+        }
+        if (chunkEmbeddings.size() == 1) {
+            return List.copyOf(chunkEmbeddings.getFirst());
+        }
+        double totalWeight = chunks.stream()
+            .mapToDouble(EmbeddingChunk::estimatedTokens)
+            .sum();
+        List<Double> chunkWeights = chunks.stream()
+            .map(chunk -> chunk.estimatedTokens() / totalWeight)
+            .toList();
+        return BookSimilarityVectorFusion.fuseWeighted(chunkEmbeddings, chunkWeights);
     }
 
     private static void validateEmbeddingResponse(int inputCount, List<List<Float>> embeddings) {
@@ -153,11 +298,52 @@ public class BookEmbeddingClient {
             throw new IllegalStateException("Embedding response count did not match input count");
         }
         for (List<Float> embedding : embeddings) {
-            if (embedding.size() != EXPECTED_DIMENSION) {
+            if (embedding.size() != BookSimilarityVectorFusion.EMBEDDING_DIMENSION) {
                 throw new IllegalStateException(
-                    "Embedding dimension mismatch: expected " + EXPECTED_DIMENSION + " but received " + embedding.size()
+                    "Embedding dimension mismatch: expected " + BookSimilarityVectorFusion.EMBEDDING_DIMENSION
+                        + " but received " + embedding.size()
                 );
             }
         }
+    }
+
+    private static int utf8ByteLength(int codePoint) {
+        if (codePoint <= 0x7F) {
+            return 1;
+        }
+        if (codePoint <= 0x7FF) {
+            return 2;
+        }
+        if (codePoint <= 0xFFFF) {
+            return 3;
+        }
+        return 4;
+    }
+
+    record EmbeddingInputPlan(List<EmbeddingChunk> chunks) {
+
+        EmbeddingInputPlan {
+            if (chunks == null || chunks.isEmpty()) {
+                throw new IllegalArgumentException("chunks are required");
+            }
+            chunks = List.copyOf(chunks);
+        }
+    }
+
+    record EmbeddingChunk(String text, int estimatedTokens) {
+
+        EmbeddingChunk {
+            if (text == null || text.isBlank()) {
+                throw new IllegalArgumentException("chunk text is required");
+            }
+            if (estimatedTokens <= 0) {
+                throw new IllegalArgumentException("estimatedTokens must be positive");
+            }
+        }
+    }
+
+    @FunctionalInterface
+    interface BatchEmbeddingRequester {
+        List<List<Float>> embed(List<String> batchTexts, RequestOptions options);
     }
 }

--- a/src/main/java/net/findmybook/application/similarity/BookSimilarityEmbeddingService.java
+++ b/src/main/java/net/findmybook/application/similarity/BookSimilarityEmbeddingService.java
@@ -123,7 +123,7 @@ public class BookSimilarityEmbeddingService {
             );
             return 0;
         }
-        String modelVersion = policy.modelVersion(embeddingClient.model());
+        String modelVersion = policy.modelVersion(embeddingClient.cacheModel());
         List<UUID> candidates = repository.findRefreshCandidates(modelVersion, policy.profileHash(), candidateLimit);
         int enqueued = 0;
         int effectiveEnqueueLimit = Math.min(enqueueLimit, pendingRoom);
@@ -154,7 +154,7 @@ public class BookSimilarityEmbeddingService {
             log.info("Skipping book similarity backfill: embedding client unavailable or feature disabled.");
             return 0;
         }
-        String modelVersion = policy.modelVersion(embeddingClient.model());
+        String modelVersion = policy.modelVersion(embeddingClient.cacheModel());
         List<UUID> candidates = repository.findRefreshCandidates(modelVersion, policy.profileHash(), Math.max(1, candidateLimit));
         int refreshed = 0;
         for (UUID bookId : candidates) {
@@ -181,11 +181,11 @@ public class BookSimilarityEmbeddingService {
         if (sourceBookId == null || limit <= 0 || !properties.isEnabled()) {
             return List.of();
         }
-        String model = embeddingClient.model();
-        if (!StringUtils.hasText(model)) {
+        String cacheModel = embeddingClient.cacheModel();
+        if (!StringUtils.hasText(cacheModel)) {
             return List.of();
         }
-        String modelVersion = policy.modelVersion(model);
+        String modelVersion = policy.modelVersion(cacheModel);
         return repository.findNearestBooks(sourceBookId, modelVersion, policy.profileHash(), limit).stream()
             .map(row -> new SimilarBookMatch(row.bookId(), row.similarity()))
             .toList();
@@ -206,7 +206,8 @@ public class BookSimilarityEmbeddingService {
         BookSimilarityBookSource source = repository.fetchBookSource(bookId)
             .orElseThrow(() -> new IllegalStateException("Book source unavailable for similarity embedding: " + bookId));
         String model = embeddingClient.model();
-        String modelVersion = policy.modelVersion(model);
+        String cacheModel = embeddingClient.cacheModel();
+        String modelVersion = policy.modelVersion(cacheModel);
         BookSimilaritySourceDocument sourceDocument = BookSimilaritySourceDocument.create(
             source,
             policy,
@@ -223,7 +224,7 @@ public class BookSimilarityEmbeddingService {
         }
         EnumMap<BookSimilaritySectionKey, List<Float>> sectionEmbeddings = loadOrCreateSectionEmbeddings(
             sourceDocument,
-            model
+            cacheModel
         );
         List<Float> fusedEmbedding = vectorFusion.fuse(sourceDocument, sectionEmbeddings);
         repository.upsertFusedEmbedding(new FusedEmbeddingRow(
@@ -281,16 +282,16 @@ public class BookSimilarityEmbeddingService {
     }
 
     private boolean isVectorAlreadyFresh(UUID bookId) {
-        String model = embeddingClient.model();
-        if (!StringUtils.hasText(model)) {
+        String cacheModel = embeddingClient.cacheModel();
+        if (!StringUtils.hasText(cacheModel)) {
             return false;
         }
-        return repository.isVectorFresh(bookId, policy.modelVersion(model), policy.profileHash());
+        return repository.isVectorFresh(bookId, policy.modelVersion(cacheModel), policy.profileHash());
     }
 
     private EnumMap<BookSimilaritySectionKey, List<Float>> loadOrCreateSectionEmbeddings(
         BookSimilaritySourceDocument sourceDocument,
-        String model
+        String cacheModel
     ) {
         EnumMap<BookSimilaritySectionKey, List<Float>> sectionEmbeddings = new EnumMap<>(BookSimilaritySectionKey.class);
         List<BookSimilaritySectionInput> missingInputs = new ArrayList<>();
@@ -298,7 +299,7 @@ public class BookSimilarityEmbeddingService {
             Optional<List<Float>> cachedEmbedding = sectionRepository.fetchSectionEmbedding(
                 sourceDocument.bookId(),
                 sectionInput.sectionKey(),
-                model,
+                cacheModel,
                 sectionInput.inputHash()
             );
             if (cachedEmbedding.isPresent()) {
@@ -315,7 +316,7 @@ public class BookSimilarityEmbeddingService {
             for (int index = 0; index < missingInputs.size(); index++) {
                 BookSimilaritySectionInput sectionInput = missingInputs.get(index);
                 List<Float> embedding = generatedEmbeddings.get(index);
-                sectionRepository.upsertSectionEmbedding(sourceDocument.bookId(), sectionInput, model, embedding);
+                sectionRepository.upsertSectionEmbedding(sourceDocument.bookId(), sectionInput, cacheModel, embedding);
                 sectionEmbeddings.put(sectionInput.sectionKey(), embedding);
             }
         }

--- a/src/main/java/net/findmybook/application/similarity/BookSimilarityEmbeddingService.java
+++ b/src/main/java/net/findmybook/application/similarity/BookSimilarityEmbeddingService.java
@@ -21,11 +21,9 @@ import net.findmybook.domain.similarity.BookSimilaritySourceDocument;
 import net.findmybook.support.ai.BookAiContentRequestQueue;
 import net.findmybook.support.ai.BookAiQueueCapacityExceededException;
 import net.findmybook.support.llm.LlmGatewayTier;
-import net.findmybook.service.event.BookUpsertEvent;
 import net.findmybook.util.HashUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import tools.jackson.core.JacksonException;
@@ -81,24 +79,6 @@ public class BookSimilarityEmbeddingService {
      */
     public boolean enqueueDemandRefresh(UUID bookId) {
         return enqueueRefresh(bookId, DEMAND_PRIORITY, "demand");
-    }
-
-    /**
-     * Enqueues an idempotent refresh when canonical book source data changes.
-     *
-     * @param event persisted book upsert notification
-     */
-    @EventListener
-    public void handleBookUpsert(BookUpsertEvent event) {
-        if (event == null || !StringUtils.hasText(event.getBookId())) {
-            log.warn("Skipping similarity embedding refresh enqueue: missing bookId in BookUpsertEvent");
-            return;
-        }
-        try {
-            enqueueDemandRefresh(UUID.fromString(event.getBookId()));
-        } catch (IllegalArgumentException invalidBookId) {
-            log.warn("Skipping similarity embedding refresh enqueue for non-UUID bookId '{}'", event.getBookId(), invalidBookId);
-        }
     }
 
     /**
@@ -185,10 +165,27 @@ public class BookSimilarityEmbeddingService {
         if (!StringUtils.hasText(cacheModel)) {
             return List.of();
         }
-        String modelVersion = policy.modelVersion(cacheModel);
-        return repository.findNearestBooks(sourceBookId, modelVersion, policy.profileHash(), limit).stream()
-            .map(row -> new SimilarBookMatch(row.bookId(), row.similarity()))
-            .toList();
+        String currentModelVersion = policy.modelVersion(cacheModel);
+        List<SimilarBookMatch> currentMatches =
+            findNearestBooksForModelVersion(sourceBookId, currentModelVersion, limit);
+        if (currentMatches.size() >= limit) {
+            return currentMatches;
+        }
+
+        String legacyModel = embeddingClient.model();
+        if (!StringUtils.hasText(legacyModel)) {
+            return currentMatches;
+        }
+        String legacyModelVersion = policy.modelVersion(legacyModel);
+        if (legacyModelVersion.equals(currentModelVersion)) {
+            return currentMatches;
+        }
+        List<SimilarBookMatch> legacyMatches =
+            findNearestBooksForModelVersion(sourceBookId, legacyModelVersion, limit);
+        if (!legacyMatches.isEmpty()) {
+            return legacyMatches;
+        }
+        return currentMatches;
     }
 
     /**
@@ -243,7 +240,10 @@ public class BookSimilarityEmbeddingService {
         if (bookId == null || !embeddingClient.isAvailable() || !properties.isEnabled()) {
             return false;
         }
-        if (priority == DEMAND_PRIORITY && isVectorAlreadyFresh(bookId)) {
+        String cacheModel = embeddingClient.cacheModel();
+        if (priority == DEMAND_PRIORITY
+            && StringUtils.hasText(cacheModel)
+            && repository.isVectorFresh(bookId, policy.modelVersion(cacheModel), policy.profileHash())) {
             return false;
         }
         if (recentRefreshAttempts.asMap().putIfAbsent(bookId, Boolean.TRUE) != null) {
@@ -281,12 +281,10 @@ public class BookSimilarityEmbeddingService {
         }
     }
 
-    private boolean isVectorAlreadyFresh(UUID bookId) {
-        String cacheModel = embeddingClient.cacheModel();
-        if (!StringUtils.hasText(cacheModel)) {
-            return false;
-        }
-        return repository.isVectorFresh(bookId, policy.modelVersion(cacheModel), policy.profileHash());
+    private List<SimilarBookMatch> findNearestBooksForModelVersion(UUID sourceBookId, String modelVersion, int limit) {
+        return repository.findNearestBooks(sourceBookId, modelVersion, policy.profileHash(), limit).stream()
+            .map(row -> new SimilarBookMatch(row.bookId(), row.similarity()))
+            .toList();
     }
 
     private EnumMap<BookSimilaritySectionKey, List<Float>> loadOrCreateSectionEmbeddings(

--- a/src/main/java/net/findmybook/application/similarity/BookSimilarityEmbeddingService.java
+++ b/src/main/java/net/findmybook/application/similarity/BookSimilarityEmbeddingService.java
@@ -103,7 +103,7 @@ public class BookSimilarityEmbeddingService {
             );
             return 0;
         }
-        String modelVersion = policy.modelVersion(embeddingClient.cacheModel());
+        String modelVersion = activeModelVersion(embeddingClient.cacheModel());
         List<UUID> candidates = repository.findRefreshCandidates(modelVersion, policy.profileHash(), candidateLimit);
         int enqueued = 0;
         int effectiveEnqueueLimit = Math.min(enqueueLimit, pendingRoom);
@@ -134,7 +134,7 @@ public class BookSimilarityEmbeddingService {
             log.info("Skipping book similarity backfill: embedding client unavailable or feature disabled.");
             return 0;
         }
-        String modelVersion = policy.modelVersion(embeddingClient.cacheModel());
+        String modelVersion = activeModelVersion(embeddingClient.cacheModel());
         List<UUID> candidates = repository.findRefreshCandidates(modelVersion, policy.profileHash(), Math.max(1, candidateLimit));
         int refreshed = 0;
         for (UUID bookId : candidates) {
@@ -165,27 +165,25 @@ public class BookSimilarityEmbeddingService {
         if (!StringUtils.hasText(cacheModel)) {
             return List.of();
         }
-        String currentModelVersion = policy.modelVersion(cacheModel);
+        String currentModelVersion = activeModelVersion(cacheModel);
         List<SimilarBookMatch> currentMatches =
             findNearestBooksForModelVersion(sourceBookId, currentModelVersion, limit);
         if (currentMatches.size() >= limit) {
             return currentMatches;
         }
 
+        List<SimilarBookMatch> previousMatches =
+            findNearestBooksForModelVersion(sourceBookId, policy.modelVersion(cacheModel), limit);
+        if (!previousMatches.isEmpty()) {
+            return previousMatches;
+        }
         String legacyModel = embeddingClient.model();
         if (!StringUtils.hasText(legacyModel)) {
             return currentMatches;
         }
-        String legacyModelVersion = policy.modelVersion(legacyModel);
-        if (legacyModelVersion.equals(currentModelVersion)) {
-            return currentMatches;
-        }
         List<SimilarBookMatch> legacyMatches =
-            findNearestBooksForModelVersion(sourceBookId, legacyModelVersion, limit);
-        if (!legacyMatches.isEmpty()) {
-            return legacyMatches;
-        }
-        return currentMatches;
+            findNearestBooksForModelVersion(sourceBookId, policy.modelVersion(legacyModel), limit);
+        return legacyMatches.isEmpty() ? currentMatches : legacyMatches;
     }
 
     /**
@@ -204,7 +202,7 @@ public class BookSimilarityEmbeddingService {
             .orElseThrow(() -> new IllegalStateException("Book source unavailable for similarity embedding: " + bookId));
         String model = embeddingClient.model();
         String cacheModel = embeddingClient.cacheModel();
-        String modelVersion = policy.modelVersion(cacheModel);
+        String modelVersion = activeModelVersion(cacheModel);
         BookSimilaritySourceDocument sourceDocument = BookSimilaritySourceDocument.create(
             source,
             policy,
@@ -241,9 +239,9 @@ public class BookSimilarityEmbeddingService {
             return false;
         }
         String cacheModel = embeddingClient.cacheModel();
+        String modelVersion = activeModelVersion(cacheModel);
         if (priority == DEMAND_PRIORITY
-            && StringUtils.hasText(cacheModel)
-            && repository.isVectorFresh(bookId, policy.modelVersion(cacheModel), policy.profileHash())) {
+            && repository.isVectorFresh(bookId, modelVersion, policy.profileHash())) {
             return false;
         }
         if (recentRefreshAttempts.asMap().putIfAbsent(bookId, Boolean.TRUE) != null) {
@@ -285,6 +283,10 @@ public class BookSimilarityEmbeddingService {
         return repository.findNearestBooks(sourceBookId, modelVersion, policy.profileHash(), limit).stream()
             .map(row -> new SimilarBookMatch(row.bookId(), row.similarity()))
             .toList();
+    }
+
+    private String activeModelVersion(String cacheModel) {
+        return policy.modelVersion(cacheModel + ":" + properties.sourceTextContract());
     }
 
     private EnumMap<BookSimilaritySectionKey, List<Float>> loadOrCreateSectionEmbeddings(

--- a/src/main/java/net/findmybook/application/similarity/BookSimilarityVectorFusion.java
+++ b/src/main/java/net/findmybook/application/similarity/BookSimilarityVectorFusion.java
@@ -37,17 +37,34 @@ public class BookSimilarityVectorFusion {
     public List<Float> fuse(BookSimilaritySourceDocument sourceDocument,
                             Map<BookSimilaritySectionKey, List<Float>> sectionEmbeddings) {
         Map<BookSimilaritySectionKey, Double> weights = policy.normalizedWeightsFor(sectionEmbeddings.keySet());
-        double[] fused = new double[EMBEDDING_DIMENSION];
+        List<List<Float>> weightedEmbeddings = new ArrayList<>();
+        List<Double> embeddingWeights = new ArrayList<>();
         for (BookSimilaritySectionInput sectionInput : sourceDocument.sectionInputs()) {
             List<Float> embedding = sectionEmbeddings.get(sectionInput.sectionKey());
             if (embedding == null) {
                 throw new IllegalStateException("Missing section embedding for " + sectionInput.sectionKey().key());
             }
+            weightedEmbeddings.add(embedding);
+            embeddingWeights.add(weights.get(sectionInput.sectionKey()));
+        }
+        return fuseWeighted(weightedEmbeddings, embeddingWeights);
+    }
+
+    static List<Float> fuseWeighted(List<List<Float>> weightedEmbeddings, List<Double> embeddingWeights) {
+        if (weightedEmbeddings == null || weightedEmbeddings.isEmpty()) {
+            throw new IllegalArgumentException("weightedEmbeddings are required");
+        }
+        if (embeddingWeights == null || embeddingWeights.size() != weightedEmbeddings.size()) {
+            throw new IllegalArgumentException("embeddingWeights must match weightedEmbeddings");
+        }
+        double[] fused = new double[EMBEDDING_DIMENSION];
+        for (int embeddingIndex = 0; embeddingIndex < weightedEmbeddings.size(); embeddingIndex++) {
+            List<Float> embedding = weightedEmbeddings.get(embeddingIndex);
             double norm = vectorNorm(embedding);
             if (norm == 0.0d) {
                 continue;
             }
-            double weight = weights.get(sectionInput.sectionKey());
+            double weight = embeddingWeights.get(embeddingIndex);
             for (int index = 0; index < EMBEDDING_DIMENSION; index++) {
                 fused[index] += (embedding.get(index) / norm) * weight;
             }

--- a/src/main/java/net/findmybook/boot/BookSimilarityEmbeddingProperties.java
+++ b/src/main/java/net/findmybook/boot/BookSimilarityEmbeddingProperties.java
@@ -11,12 +11,16 @@ import org.springframework.stereotype.Component;
 public class BookSimilarityEmbeddingProperties {
 
     private static final int DEFAULT_MAX_SECTION_TEXT_CHARS = 15_000;
+    private static final int DEFAULT_INPUT_TOKEN_COMFORT_LIMIT = 8_192;
+    private static final int DEFAULT_REQUEST_INPUT_BATCH_SIZE = 32;
 
     private boolean enabled = true;
     private int refreshBatchSize = 25;
     private int schedulerEnqueueLimit = 25;
     private int schedulerMaxPending = 100;
     private int maxSectionTextChars = DEFAULT_MAX_SECTION_TEXT_CHARS;
+    private int inputTokenComfortLimit = DEFAULT_INPUT_TOKEN_COMFORT_LIMIT;
+    private int requestInputBatchSize = DEFAULT_REQUEST_INPUT_BATCH_SIZE;
 
     /**
      * Indicates whether scheduled background refresh is enabled.
@@ -93,24 +97,63 @@ public class BookSimilarityEmbeddingProperties {
     /**
      * Returns the maximum character length for each embedding section input.
      *
-     * <p>Longer raw section text is truncated before hashing so the combined
-     * batch stays within the embedding model's per-request context window
-     * (qwen3-embedding-4b and comparable models cap total request tokens at
-     * 32_768). The default leaves ample headroom across all configured
-     * sections even at ~3 chars-per-token.</p>
+     * <p>When enabled, longer rendered section text is truncated before hashing
+     * to bound the persisted source contract. Provider token-window safety is
+     * handled later by the embedding client, which splits oversized embedding
+     * inputs before outbound requests.</p>
      *
-     * @return per-section character ceiling, always at least one
+     * @return per-section character ceiling; values less than one disable truncation
      */
     public int maxSectionTextChars() {
-        return Math.max(1, maxSectionTextChars);
+        return maxSectionTextChars;
     }
 
     /**
      * Binds the per-section character ceiling.
      *
-     * @param maxSectionTextChars configured value (clamped to a minimum of one)
+     * @param maxSectionTextChars configured value; values less than one disable truncation
      */
     public void setMaxSectionTextChars(int maxSectionTextChars) {
-        this.maxSectionTextChars = Math.max(1, maxSectionTextChars);
+        this.maxSectionTextChars = maxSectionTextChars;
+    }
+
+    /**
+     * Returns the conservative per-input token budget used before embedding calls.
+     *
+     * <p>The client estimates tokens by UTF-8 byte length, which intentionally
+     * overestimates ordinary English text and keeps each array element well below
+     * qwen3-embedding-4b's 32_768-token hard limit.</p>
+     *
+     * @return per-request-item estimated token budget
+     */
+    public int inputTokenComfortLimit() {
+        return Math.max(1, inputTokenComfortLimit);
+    }
+
+    /**
+     * Binds the conservative per-input token budget.
+     *
+     * @param inputTokenComfortLimit maximum estimated tokens per embeddings input item
+     */
+    public void setInputTokenComfortLimit(int inputTokenComfortLimit) {
+        this.inputTokenComfortLimit = Math.max(1, inputTokenComfortLimit);
+    }
+
+    /**
+     * Returns how many embeddings input items may be sent in one provider request.
+     *
+     * @return request array size ceiling
+     */
+    public int requestInputBatchSize() {
+        return Math.max(1, requestInputBatchSize);
+    }
+
+    /**
+     * Binds the embeddings request array size ceiling.
+     *
+     * @param requestInputBatchSize maximum input items per embeddings API request
+     */
+    public void setRequestInputBatchSize(int requestInputBatchSize) {
+        this.requestInputBatchSize = Math.max(1, requestInputBatchSize);
     }
 }

--- a/src/main/java/net/findmybook/boot/BookSimilarityEmbeddingProperties.java
+++ b/src/main/java/net/findmybook/boot/BookSimilarityEmbeddingProperties.java
@@ -10,9 +10,11 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties(prefix = "app.similarity.embeddings")
 public class BookSimilarityEmbeddingProperties {
 
+    public static final int MAX_INPUT_TOKEN_COMFORT_LIMIT = 8_192;
     private static final int DEFAULT_MAX_SECTION_TEXT_CHARS = 15_000;
-    private static final int DEFAULT_INPUT_TOKEN_COMFORT_LIMIT = 8_192;
+    private static final int DEFAULT_INPUT_TOKEN_COMFORT_LIMIT = MAX_INPUT_TOKEN_COMFORT_LIMIT;
     private static final int DEFAULT_REQUEST_INPUT_BATCH_SIZE = 32;
+    private static final String CONTRACT_VERSION = "v1";
 
     private boolean enabled = true;
     private int refreshBatchSize = 25;
@@ -118,6 +120,18 @@ public class BookSimilarityEmbeddingProperties {
     }
 
     /**
+     * Returns the source-text contract segment for vector freshness and reads.
+     *
+     * @return stable contract identity for the effective section source-text limit
+     */
+    public String sourceTextContract() {
+        if (maxSectionTextChars <= 0) {
+            return "source_full_" + CONTRACT_VERSION;
+        }
+        return "source_chars_" + maxSectionTextChars + "_" + CONTRACT_VERSION;
+    }
+
+    /**
      * Returns the conservative per-input token budget used before embedding calls.
      *
      * <p>The client estimates tokens by UTF-8 byte length, which intentionally
@@ -127,7 +141,7 @@ public class BookSimilarityEmbeddingProperties {
      * @return per-request-item estimated token budget
      */
     public int inputTokenComfortLimit() {
-        return Math.max(1, inputTokenComfortLimit);
+        return normalizedInputTokenComfortLimit(inputTokenComfortLimit);
     }
 
     /**
@@ -137,6 +151,35 @@ public class BookSimilarityEmbeddingProperties {
      */
     public void setInputTokenComfortLimit(int inputTokenComfortLimit) {
         this.inputTokenComfortLimit = Math.max(1, inputTokenComfortLimit);
+    }
+
+    /**
+     * Returns the embedding input contract segment for section-cache keys.
+     *
+     * @return stable contract identity for the effective input chunk size
+     */
+    public String embeddingInputContract() {
+        return embeddingInputContract(inputTokenComfortLimit);
+    }
+
+    /**
+     * Normalizes configured embedding chunk limits to the supported runtime range.
+     *
+     * @param configuredInputTokenLimit configured estimated token budget
+     * @return effective per-input token budget
+     */
+    public static int normalizedInputTokenComfortLimit(int configuredInputTokenLimit) {
+        return Math.min(Math.max(1, configuredInputTokenLimit), MAX_INPUT_TOKEN_COMFORT_LIMIT);
+    }
+
+    /**
+     * Returns the section-cache contract for a configured embedding chunk limit.
+     *
+     * @param configuredInputTokenLimit configured estimated token budget
+     * @return stable contract identity for the effective input chunk size
+     */
+    public static String embeddingInputContract(int configuredInputTokenLimit) {
+        return "chunked_" + normalizedInputTokenComfortLimit(configuredInputTokenLimit) + "_" + CONTRACT_VERSION;
     }
 
     /**

--- a/src/main/java/net/findmybook/domain/similarity/BookSimilaritySourceDocument.java
+++ b/src/main/java/net/findmybook/domain/similarity/BookSimilaritySourceDocument.java
@@ -59,8 +59,7 @@ public record BookSimilaritySourceDocument(
      * @param model configured embeddings model
      * @param modelVersion computed model version
      * @param maxSectionTextChars per-section character ceiling applied before hashing
-     *     so the embedding batch stays within the provider's request token window;
-     *     values less than one disable truncation
+     *     to bound the persisted source contract; values less than one disable truncation
      * @param hashFactory deterministic hash function
      * @param sourceJsonRenderer deterministic source-json renderer
      * @return auditable source document

--- a/src/main/java/net/findmybook/service/RecentlyViewedService.java
+++ b/src/main/java/net/findmybook/service/RecentlyViewedService.java
@@ -1,13 +1,13 @@
 /**
  * Service responsible for tracking, managing, and providing recently viewed books
- * 
+ *
  * This component provides functionality for:
  * - Maintaining a thread-safe list of recently viewed books
  * - Handling canonical book ID resolution to prevent duplicates
  * - Providing fallback recommendations when history is empty
  * - Supporting both synchronous and reactive APIs
  * - Ensuring memory efficiency through size limits
- * 
+ *
  * Used throughout the application to enhance user experience by enabling
  * "recently viewed" sections and personalized recommendations
  *
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
 
 /**
  * Service for tracking and managing recently viewed books
- * 
+ *
  * Features:
  * - Maintains a thread-safe list of recently viewed books
  * - Limits the number of books in the history to avoid memory issues
@@ -77,21 +77,26 @@ public class RecentlyViewedService {
      */
     public void addToRecentlyViewed(Book book) {
         if (book == null) {
-            log.warn("RECENT_VIEWS_DEBUG: Attempted to add a null book to recently viewed.");
+            log.debug("Attempted to add a null book to recently viewed.");
             return;
         }
 
         String originalBookId = book.getId();
-        log.info("RECENT_VIEWS_DEBUG: Attempting to add book. Original ID: '{}', Title: '{}'", originalBookId, book.getTitle());
+        log.debug(
+            "Attempting to add recently viewed book. Original ID: '{}', Title: '{}'",
+            originalBookId,
+            book.getTitle()
+        );
 
         String canonicalId = resolveCanonicalBookId(originalBookId);
         if (!Objects.equals(originalBookId, canonicalId)) {
-            log.info("RECENT_VIEWS_DEBUG: Resolved original ID '{}' to canonical ID '{}' for book title '{}'",
+            log.debug("Resolved recently viewed original ID '{}' to canonical ID '{}' for book title '{}'",
                 originalBookId, canonicalId, book.getTitle());
         }
-        
+
         if (!StringUtils.hasText(canonicalId)) {
-            log.warn("RECENT_VIEWS_DEBUG: Null or empty canonical ID determined for book title '{}' (original ID '{}'). Skipping add.", book.getTitle(), originalBookId);
+            log.warn("Null or empty canonical recently viewed ID for book title '{}' (original ID '{}'). Skipping add.",
+                book.getTitle(), originalBookId);
             return;
         }
 
@@ -102,7 +107,11 @@ public class RecentlyViewedService {
         // create a new Book object (or clone) for storage in the list with the canonical ID
         // This avoids modifying the original 'book' object which might be used elsewhere
         if (!Objects.equals(originalBookId, finalCanonicalId)) {
-            log.info("RECENT_VIEWS_DEBUG: Book ID mismatch. Original: '{}', Canonical: '{}'. Creating new Book instance for recent views.", originalBookId, finalCanonicalId);
+            log.debug(
+                "Recently viewed book ID mismatch. Original: '{}', Canonical: '{}'. Creating a stored copy.",
+                originalBookId,
+                finalCanonicalId
+            );
             bookToAdd = new Book();
             // Copy essential properties for display in recent views
             bookToAdd.setId(finalCanonicalId);
@@ -125,13 +134,17 @@ public class RecentlyViewedService {
 
         // Add to front
         recentlyViewedBooks.addFirst(bookToAdd);
-        log.info("RECENT_VIEWS_DEBUG: Added book with canonical ID '{}'. List size now: {}", finalCanonicalId, recentlyViewedBooks.size());
+        log.debug(
+            "Added recently viewed book with canonical ID '{}'. List size now: {}",
+            finalCanonicalId,
+            recentlyViewedBooks.size()
+        );
 
         // Trim to max size
         while (recentlyViewedBooks.size() > MAX_RECENT_BOOKS) {
             Book removedLastBook = recentlyViewedBooks.pollLast();
             if (removedLastBook != null) {
-                log.debug("RECENT_VIEWS_DEBUG: Trimmed book. ID: '{}'", removedLastBook.getId());
+                log.debug("Trimmed recently viewed book. ID: '{}'", removedLastBook.getId());
             }
         }
 
@@ -160,9 +173,9 @@ public class RecentlyViewedService {
     /**
      * Gets list of recently viewed book IDs for use with BookQueryRepository.
      * This is THE SINGLE SOURCE for recently viewed book IDs.
-     * 
+     *
      * Performance: Returns only UUIDs, caller fetches as BookCard DTOs with single query.
-     * 
+     *
      * @param limit Maximum number of book IDs to return
      * @return List of book UUIDs (as Strings) for recently viewed books
      */
@@ -170,9 +183,9 @@ public class RecentlyViewedService {
         // Check repository first (persistent storage)
         if (recentBookViewRepository != null && recentBookViewRepository.isEnabled()) {
             try {
-                List<RecentBookViewRepository.ViewStats> stats = 
+                List<RecentBookViewRepository.ViewStats> stats =
                     recentBookViewRepository.fetchMostRecentViews(limit);
-                
+
                 if (!stats.isEmpty()) {
                     return stats.stream()
                         .map(RecentBookViewRepository.ViewStats::bookId)
@@ -184,7 +197,7 @@ public class RecentlyViewedService {
                 throw new IllegalStateException("Failed to fetch recently viewed book IDs from repository", e);
             }
         }
-        
+
         // Fallback to in-memory cache
         return recentlyViewedBooks.stream()
             .filter(b -> b != null && StringUtils.hasText(b.getId()))
@@ -235,7 +248,7 @@ public class RecentlyViewedService {
 
     /**
      * Clears the recently viewed books list
-     * 
+     *
      * @implNote Thread-safe implementation using synchronized block
      * Logs the action for debugging and audit purposes
      * Does not affect default recommendations which are generated dynamically

--- a/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -703,13 +703,13 @@
     {
       "name": "app.similarity.embeddings.max-section-text-chars",
       "type": "java.lang.Integer",
-      "description": "Maximum rendered characters kept per similarity embedding section before source hashing; values below one disable source truncation",
+      "description": "Maximum rendered characters kept per similarity embedding section before source hashing; values below one disable source truncation and use a distinct vector contract",
       "defaultValue": 15000
     },
     {
       "name": "app.similarity.embeddings.input-token-comfort-limit",
       "type": "java.lang.Integer",
-      "description": "Conservative per-input estimated token budget used to split book similarity embedding request items before provider calls",
+      "description": "Conservative per-input estimated token budget used to split book similarity embedding request items before provider calls; runtime caps this at 8192 and encodes the effective limit in section cache keys",
       "defaultValue": 8192
     },
     {

--- a/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -699,6 +699,24 @@
       "type": "java.lang.Integer",
       "description": "Central AI queue pending-depth ceiling that pauses scheduled book similarity embedding enqueue",
       "defaultValue": 100
+    },
+    {
+      "name": "app.similarity.embeddings.max-section-text-chars",
+      "type": "java.lang.Integer",
+      "description": "Maximum rendered characters kept per similarity embedding section before source hashing; values below one disable source truncation",
+      "defaultValue": 15000
+    },
+    {
+      "name": "app.similarity.embeddings.input-token-comfort-limit",
+      "type": "java.lang.Integer",
+      "description": "Conservative per-input estimated token budget used to split book similarity embedding request items before provider calls",
+      "defaultValue": 8192
+    },
+    {
+      "name": "app.similarity.embeddings.request-input-batch-size",
+      "type": "java.lang.Integer",
+      "description": "Maximum number of embeddings input items sent in one provider request before runtime token-budget clamping",
+      "defaultValue": 32
     }
   ],
   "hints": []

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -94,6 +94,9 @@ app:
       refresh-batch-size: ${APP_SIMILARITY_EMBEDDINGS_REFRESH_BATCH_SIZE:25}
       scheduler-enqueue-limit: ${APP_SIMILARITY_EMBEDDINGS_SCHEDULER_ENQUEUE_LIMIT:25}
       scheduler-max-pending: ${APP_SIMILARITY_EMBEDDINGS_SCHEDULER_MAX_PENDING:100}
+      max-section-text-chars: ${APP_SIMILARITY_EMBEDDINGS_MAX_SECTION_TEXT_CHARS:15000}
+      input-token-comfort-limit: ${APP_SIMILARITY_EMBEDDINGS_INPUT_TOKEN_COMFORT_LIMIT:8192}
+      request-input-batch-size: ${APP_SIMILARITY_EMBEDDINGS_REQUEST_INPUT_BATCH_SIZE:32}
   weekly-refresh:
     enabled: ${APP_WEEKLY_REFRESH_ENABLED:true}
     cron: ${APP_WEEKLY_REFRESH_CRON:0 0 4 * * SUN}

--- a/src/test/java/net/findmybook/application/similarity/BookEmbeddingClientTest.java
+++ b/src/test/java/net/findmybook/application/similarity/BookEmbeddingClientTest.java
@@ -40,6 +40,13 @@ class BookEmbeddingClientTest {
     }
 
     @Test
+    void should_IncludeChunkingContract_When_ModelIsUsedForEmbeddingCache() {
+        BookEmbeddingClient client = clientWithRequester((batchTexts, ignoredOptions) -> List.of());
+
+        assertThat(client.cacheModel()).isEqualTo("qwen/qwen3-embedding-4b:chunked_8192_v1");
+    }
+
+    @Test
     void should_ClampChunkSizeToComfortLimit_When_ConfiguredLimitIsTooHigh() {
         List<BookEmbeddingClient.EmbeddingInputPlan> inputPlans = BookEmbeddingClient.planEmbeddingInputs(
             List.of("a".repeat(8_193)),
@@ -54,18 +61,15 @@ class BookEmbeddingClientTest {
     @Test
     void should_SendChunkArraysAndCollapseInOriginalSectionOrder_When_SectionsSplitAcrossBatches() {
         List<List<String>> requestBatches = new ArrayList<>();
-        BookEmbeddingClient client = new BookEmbeddingClient(
-            "qwen/qwen3-embedding-4b",
-            1,
-            1,
+        BookEmbeddingClient client = clientWithRequester(
             4,
             2,
-            Map.of(LlmGatewayTier.BACKGROUND_BATCH, (batchTexts, ignoredOptions) -> {
+            (batchTexts, ignoredOptions) -> {
                 requestBatches.add(List.copyOf(batchTexts));
                 return batchTexts.stream()
                     .map(text -> embeddingWith((float) text.codePointAt(0), 1.0f))
                     .toList();
-            })
+            }
         );
 
         List<List<Float>> sectionEmbeddings = client.embedSections(
@@ -100,6 +104,23 @@ class BookEmbeddingClientTest {
 
     private static org.assertj.core.data.Offset<Float> withinTolerance() {
         return org.assertj.core.data.Offset.offset(0.00001f);
+    }
+
+    private static BookEmbeddingClient clientWithRequester(BookEmbeddingClient.BatchEmbeddingRequester requester) {
+        return clientWithRequester(8_192, 32, requester);
+    }
+
+    private static BookEmbeddingClient clientWithRequester(int configuredInputTokenLimit,
+                                                           int configuredRequestInputBatchSize,
+                                                           BookEmbeddingClient.BatchEmbeddingRequester requester) {
+        return new BookEmbeddingClient(
+            "qwen/qwen3-embedding-4b",
+            1,
+            1,
+            configuredInputTokenLimit,
+            configuredRequestInputBatchSize,
+            Map.of(LlmGatewayTier.BACKGROUND_BATCH, requester)
+        );
     }
 
     private static List<Float> embeddingWith(float firstComponent, float secondComponent) {

--- a/src/test/java/net/findmybook/application/similarity/BookEmbeddingClientTest.java
+++ b/src/test/java/net/findmybook/application/similarity/BookEmbeddingClientTest.java
@@ -123,6 +123,18 @@ class BookEmbeddingClientTest {
     }
 
     @Test
+    void should_NormalizeChunkEmbedding_When_InputHasSingleChunk() {
+        List<Float> fusedEmbedding = BookEmbeddingClient.fuseInputChunks(
+            List.of(embeddingWith(3.0f, 4.0f)),
+            List.of(new BookEmbeddingClient.EmbeddingChunk("section text", 12))
+        );
+
+        assertThat(fusedEmbedding).hasSize(EMBEDDING_DIMENSION);
+        assertThat(fusedEmbedding.get(0)).isCloseTo(0.6f, withinTolerance());
+        assertThat(fusedEmbedding.get(1)).isCloseTo(0.8f, withinTolerance());
+    }
+
+    @Test
     void should_ReadPreviousVectorContract_When_CurrentContractCannotFillLimit() {
         UUID sourceBookId = UUID.fromString("019da3e5-3838-703e-9112-bad4a489239e");
         UUID currentMatchId = UUID.fromString("019c3b68-3ee9-7ef0-917c-c37b663d97c1");

--- a/src/test/java/net/findmybook/application/similarity/BookEmbeddingClientTest.java
+++ b/src/test/java/net/findmybook/application/similarity/BookEmbeddingClientTest.java
@@ -2,12 +2,24 @@ package net.findmybook.application.similarity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import net.findmybook.adapters.persistence.BookEmbeddingSectionRepository;
+import net.findmybook.adapters.persistence.BookSimilarityEmbeddingRepository;
+import net.findmybook.boot.BookSimilarityEmbeddingProperties;
+import net.findmybook.domain.similarity.BookSimilarityFusionPolicy;
+import net.findmybook.domain.similarity.BookSimilarityFusionProfile;
+import net.findmybook.domain.similarity.BookSimilaritySectionKey;
+import net.findmybook.support.ai.BookAiContentRequestQueue;
 import net.findmybook.support.llm.LlmGatewayTier;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 
 class BookEmbeddingClientTest {
 
@@ -102,6 +114,27 @@ class BookEmbeddingClientTest {
         assertThat(fusedEmbedding.get(1)).isCloseTo(0.9486833f, withinTolerance());
     }
 
+    @Test
+    void should_ReadLegacyVectorContract_When_CurrentContractCannotFillLimit() {
+        UUID sourceBookId = UUID.fromString("019da3e5-3838-703e-9112-bad4a489239e");
+        UUID currentMatchId = UUID.fromString("019c3b68-3ee9-7ef0-917c-c37b663d97c1");
+        UUID legacyMatchId = UUID.fromString("019c175b-8cf5-7455-90af-6787b965e5a2");
+        String currentModelVersion = "qwen/qwen3-embedding-4b:chunked_8192_v1:test:section_fusion";
+        String legacyModelVersion = "qwen/qwen3-embedding-4b:test:section_fusion";
+        BookSimilarityEmbeddingRepository repository = mock(BookSimilarityEmbeddingRepository.class);
+        when(repository.findNearestBooks(sourceBookId, currentModelVersion, "profile-hash", 2))
+            .thenReturn(List.of(new BookSimilarityEmbeddingRepository.NearestBookRow(currentMatchId, 0.91d)));
+        when(repository.findNearestBooks(sourceBookId, legacyModelVersion, "profile-hash", 2))
+            .thenReturn(List.of(new BookSimilarityEmbeddingRepository.NearestBookRow(legacyMatchId, 0.89d)));
+        BookSimilarityEmbeddingService service = similarityService(repository);
+
+        List<BookSimilarityEmbeddingService.SimilarBookMatch> matches = service.findNearestBooks(sourceBookId, 2);
+
+        assertThat(matches)
+            .extracting(BookSimilarityEmbeddingService.SimilarBookMatch::bookId)
+            .containsExactly(legacyMatchId);
+    }
+
     private static org.assertj.core.data.Offset<Float> withinTolerance() {
         return org.assertj.core.data.Offset.offset(0.00001f);
     }
@@ -120,6 +153,30 @@ class BookEmbeddingClientTest {
             configuredInputTokenLimit,
             configuredRequestInputBatchSize,
             Map.of(LlmGatewayTier.BACKGROUND_BATCH, requester)
+        );
+    }
+
+    private static BookSimilarityEmbeddingService similarityService(BookSimilarityEmbeddingRepository repository) {
+        return new BookSimilarityEmbeddingService(
+            repository,
+            mock(BookEmbeddingSectionRepository.class),
+            clientWithRequester((batchTexts, ignoredOptions) -> List.of()),
+            similarityPolicy(),
+            mock(BookSimilarityVectorFusion.class),
+            mock(BookAiContentRequestQueue.class),
+            mock(ObjectMapper.class),
+            new BookSimilarityEmbeddingProperties()
+        );
+    }
+
+    private static BookSimilarityFusionPolicy similarityPolicy() {
+        EnumMap<BookSimilaritySectionKey, Double> weights = new EnumMap<>(BookSimilaritySectionKey.class);
+        weights.put(BookSimilaritySectionKey.IDENTITY, 1.0d);
+        return new BookSimilarityFusionPolicy(
+            "test",
+            List.of(BookSimilaritySectionKey.IDENTITY),
+            List.of(new BookSimilarityFusionProfile("test", "Test profile", weights)),
+            "profile-hash"
         );
     }
 

--- a/src/test/java/net/findmybook/application/similarity/BookEmbeddingClientTest.java
+++ b/src/test/java/net/findmybook/application/similarity/BookEmbeddingClientTest.java
@@ -1,0 +1,114 @@
+package net.findmybook.application.similarity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import net.findmybook.support.llm.LlmGatewayTier;
+import org.junit.jupiter.api.Test;
+
+class BookEmbeddingClientTest {
+
+    private static final int EMBEDDING_DIMENSION = BookSimilarityVectorFusion.EMBEDDING_DIMENSION;
+
+    @Test
+    void should_SplitEmbeddingInputs_When_EstimatedTokensExceedComfortLimit() {
+        List<BookEmbeddingClient.EmbeddingInputPlan> inputPlans = BookEmbeddingClient.planEmbeddingInputs(
+            List.of("abcdefghij", "short"),
+            4
+        );
+
+        assertThat(inputPlans).hasSize(2);
+        assertThat(inputPlans.getFirst().chunks())
+            .extracting(BookEmbeddingClient.EmbeddingChunk::text)
+            .containsExactly("abcd", "efgh", "ij");
+        assertThat(inputPlans.getFirst().chunks())
+            .extracting(BookEmbeddingClient.EmbeddingChunk::estimatedTokens)
+            .containsExactly(4, 4, 2);
+        assertThat(inputPlans.get(1).chunks())
+            .extracting(BookEmbeddingClient.EmbeddingChunk::text)
+            .containsExactly("shor", "t");
+    }
+
+    @Test
+    void should_RejectBlankEmbeddingInput_When_PlanningRequest() {
+        assertThatThrownBy(() -> BookEmbeddingClient.planEmbeddingInputs(List.of("valid", " "), 8_192))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("embedding input[1] is required");
+    }
+
+    @Test
+    void should_ClampChunkSizeToComfortLimit_When_ConfiguredLimitIsTooHigh() {
+        List<BookEmbeddingClient.EmbeddingInputPlan> inputPlans = BookEmbeddingClient.planEmbeddingInputs(
+            List.of("a".repeat(8_193)),
+            100_000
+        );
+
+        assertThat(inputPlans.getFirst().chunks())
+            .extracting(BookEmbeddingClient.EmbeddingChunk::estimatedTokens)
+            .containsExactly(8_192, 1);
+    }
+
+    @Test
+    void should_SendChunkArraysAndCollapseInOriginalSectionOrder_When_SectionsSplitAcrossBatches() {
+        List<List<String>> requestBatches = new ArrayList<>();
+        BookEmbeddingClient client = new BookEmbeddingClient(
+            "qwen/qwen3-embedding-4b",
+            1,
+            1,
+            4,
+            2,
+            Map.of(LlmGatewayTier.BACKGROUND_BATCH, (batchTexts, ignoredOptions) -> {
+                requestBatches.add(List.copyOf(batchTexts));
+                return batchTexts.stream()
+                    .map(text -> embeddingWith((float) text.codePointAt(0), 1.0f))
+                    .toList();
+            })
+        );
+
+        List<List<Float>> sectionEmbeddings = client.embedSections(
+            List.of("abcdefghij", "klmnop"),
+            LlmGatewayTier.BACKGROUND_BATCH
+        );
+
+        assertThat(requestBatches)
+            .containsExactly(
+                List.of("abcd", "efgh"),
+                List.of("ij", "klmn"),
+                List.of("op")
+            );
+        assertThat(sectionEmbeddings).hasSize(2);
+        assertThat(sectionEmbeddings.getFirst().getFirst()).isLessThan(sectionEmbeddings.get(1).getFirst());
+    }
+
+    @Test
+    void should_FuseChunkEmbeddingsByEstimatedTokenWeight_When_InputWasSplit() {
+        List<Float> fusedEmbedding = BookEmbeddingClient.fuseInputChunks(
+            List.of(embeddingWith(1.0f, 0.0f), embeddingWith(0.0f, 1.0f)),
+            List.of(
+                new BookEmbeddingClient.EmbeddingChunk("a", 1),
+                new BookEmbeddingClient.EmbeddingChunk("bbb", 3)
+            )
+        );
+
+        assertThat(fusedEmbedding).hasSize(EMBEDDING_DIMENSION);
+        assertThat(fusedEmbedding.get(0)).isCloseTo(0.31622776f, withinTolerance());
+        assertThat(fusedEmbedding.get(1)).isCloseTo(0.9486833f, withinTolerance());
+    }
+
+    private static org.assertj.core.data.Offset<Float> withinTolerance() {
+        return org.assertj.core.data.Offset.offset(0.00001f);
+    }
+
+    private static List<Float> embeddingWith(float firstComponent, float secondComponent) {
+        List<Float> embedding = new ArrayList<>(EMBEDDING_DIMENSION);
+        embedding.add(firstComponent);
+        embedding.add(secondComponent);
+        while (embedding.size() < EMBEDDING_DIMENSION) {
+            embedding.add(0.0f);
+        }
+        return List.copyOf(embedding);
+    }
+}

--- a/src/test/java/net/findmybook/application/similarity/BookEmbeddingClientTest.java
+++ b/src/test/java/net/findmybook/application/similarity/BookEmbeddingClientTest.java
@@ -3,6 +3,7 @@ package net.findmybook.application.similarity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -56,6 +57,13 @@ class BookEmbeddingClientTest {
         BookEmbeddingClient client = clientWithRequester((batchTexts, ignoredOptions) -> List.of());
 
         assertThat(client.cacheModel()).isEqualTo("qwen/qwen3-embedding-4b:chunked_8192_v1");
+    }
+
+    @Test
+    void should_IncludeEffectiveChunkingContract_When_ConfiguredLimitIsNonDefault() {
+        BookEmbeddingClient client = clientWithRequester(4_096, 32, (batchTexts, ignoredOptions) -> List.of());
+
+        assertThat(client.cacheModel()).isEqualTo("qwen/qwen3-embedding-4b:chunked_4096_v1");
     }
 
     @Test
@@ -115,16 +123,17 @@ class BookEmbeddingClientTest {
     }
 
     @Test
-    void should_ReadLegacyVectorContract_When_CurrentContractCannotFillLimit() {
+    void should_ReadPreviousVectorContract_When_CurrentContractCannotFillLimit() {
         UUID sourceBookId = UUID.fromString("019da3e5-3838-703e-9112-bad4a489239e");
         UUID currentMatchId = UUID.fromString("019c3b68-3ee9-7ef0-917c-c37b663d97c1");
         UUID legacyMatchId = UUID.fromString("019c175b-8cf5-7455-90af-6787b965e5a2");
-        String currentModelVersion = "qwen/qwen3-embedding-4b:chunked_8192_v1:test:section_fusion";
-        String legacyModelVersion = "qwen/qwen3-embedding-4b:test:section_fusion";
+        String currentModelVersion =
+            "qwen/qwen3-embedding-4b:chunked_8192_v1:source_chars_15000_v1:test:section_fusion";
+        String previousModelVersion = "qwen/qwen3-embedding-4b:chunked_8192_v1:test:section_fusion";
         BookSimilarityEmbeddingRepository repository = mock(BookSimilarityEmbeddingRepository.class);
         when(repository.findNearestBooks(sourceBookId, currentModelVersion, "profile-hash", 2))
             .thenReturn(List.of(new BookSimilarityEmbeddingRepository.NearestBookRow(currentMatchId, 0.91d)));
-        when(repository.findNearestBooks(sourceBookId, legacyModelVersion, "profile-hash", 2))
+        when(repository.findNearestBooks(sourceBookId, previousModelVersion, "profile-hash", 2))
             .thenReturn(List.of(new BookSimilarityEmbeddingRepository.NearestBookRow(legacyMatchId, 0.89d)));
         BookSimilarityEmbeddingService service = similarityService(repository);
 
@@ -133,6 +142,46 @@ class BookEmbeddingClientTest {
         assertThat(matches)
             .extracting(BookSimilarityEmbeddingService.SimilarBookMatch::bookId)
             .containsExactly(legacyMatchId);
+    }
+
+    @Test
+    void should_QueryRefreshCandidatesWithSourceTextContract_When_SchedulerRuns() {
+        String modelVersion =
+            "qwen/qwen3-embedding-4b:chunked_8192_v1:source_chars_15000_v1:test:section_fusion";
+        BookSimilarityEmbeddingRepository repository = mock(BookSimilarityEmbeddingRepository.class);
+        BookAiContentRequestQueue requestQueue = mock(BookAiContentRequestQueue.class);
+        when(requestQueue.snapshot()).thenReturn(new BookAiContentRequestQueue.QueueSnapshot(0, 0, 1));
+        when(repository.findRefreshCandidates(modelVersion, "profile-hash", 25)).thenReturn(List.of());
+        BookSimilarityEmbeddingService service = similarityService(
+            repository,
+            requestQueue,
+            new BookSimilarityEmbeddingProperties()
+        );
+
+        int enqueued = service.enqueueRefreshCandidates(25, 10, 100);
+
+        assertThat(enqueued).isZero();
+        verify(repository).findRefreshCandidates(modelVersion, "profile-hash", 25);
+    }
+
+    @Test
+    void should_CheckDemandFreshnessWithSourceTextContract_When_DemandRefreshIsRequested() {
+        UUID bookId = UUID.fromString("019da3e5-3838-703e-9112-bad4a489239e");
+        String modelVersion = "qwen/qwen3-embedding-4b:chunked_8192_v1:source_full_v1:test:section_fusion";
+        BookSimilarityEmbeddingRepository repository = mock(BookSimilarityEmbeddingRepository.class);
+        BookSimilarityEmbeddingProperties properties = new BookSimilarityEmbeddingProperties();
+        properties.setMaxSectionTextChars(0);
+        when(repository.isVectorFresh(bookId, modelVersion, "profile-hash")).thenReturn(true);
+        BookSimilarityEmbeddingService service = similarityService(
+            repository,
+            mock(BookAiContentRequestQueue.class),
+            properties
+        );
+
+        boolean enqueued = service.enqueueDemandRefresh(bookId);
+
+        assertThat(enqueued).isFalse();
+        verify(repository).isVectorFresh(bookId, modelVersion, "profile-hash");
     }
 
     private static org.assertj.core.data.Offset<Float> withinTolerance() {
@@ -157,15 +206,21 @@ class BookEmbeddingClientTest {
     }
 
     private static BookSimilarityEmbeddingService similarityService(BookSimilarityEmbeddingRepository repository) {
+        return similarityService(repository, mock(BookAiContentRequestQueue.class), new BookSimilarityEmbeddingProperties());
+    }
+
+    private static BookSimilarityEmbeddingService similarityService(BookSimilarityEmbeddingRepository repository,
+                                                                    BookAiContentRequestQueue requestQueue,
+                                                                    BookSimilarityEmbeddingProperties properties) {
         return new BookSimilarityEmbeddingService(
             repository,
             mock(BookEmbeddingSectionRepository.class),
             clientWithRequester((batchTexts, ignoredOptions) -> List.of()),
             similarityPolicy(),
             mock(BookSimilarityVectorFusion.class),
-            mock(BookAiContentRequestQueue.class),
+            requestQueue,
             mock(ObjectMapper.class),
-            new BookSimilarityEmbeddingProperties()
+            properties
         );
     }
 


### PR DESCRIPTION
## Summary
Pulls two Dependabot upgrades (devalue 5.6.4 → 5.8.1, svelte 5.53.6 → 5.55.7) into `main`. The Svelte bump closes an XSS in SSR hydration of user-supplied content; the devalue bump fixes a sparse-array allocation bug that affected payloads serialized between server and client.

## Changes

### Security
- **Svelte SSR XSS via `hydratable`**: User-supplied content rendered through Svelte's hydration path could be escaped incorrectly; 5.55.7 hardens the escape and moves Svelte runtime properties to symbols so user data cannot collide with framework internals (`frontend/package.json`, `frontend/package-lock.json`).
- **SSR attribute hardening**: Empty attribute names are now rejected during SSR and an internal regex was tightened, removing two parser-level injection vectors (`frontend/package-lock.json`).

### Bug Fixes
- **Sparse arrays serialized as dense**: devalue 5.8.1 now forces sparse arrays to allocate sparsely instead of filling holes with `undefined`, so server→client payloads that contain `[,,,1]`-style arrays round-trip with the correct length and shape (`frontend/package.json`).
- **Async effects rejecting instead of awaiting**: Svelte 5.55.6 changed stale promises to wait for a later resolution rather than rejecting, eliminating spurious errors in components that use `$state.eager`/`$state.pending` while data is still in flight (`frontend/package-lock.json`).
- **Eager effects not flushing in production**: 5.55.6 ensures eager effects flush in production builds, so derived UI state updates on the same tick as in dev mode (`frontend/package-lock.json`).
- **`bind:this` stale after proxy update**: 5.55.6 accounts for the proxified instance when updating `bind:this`, so refs no longer point at a stale object after a proxy reassignment (`frontend/package-lock.json`).
- **Stale derived values**: 5.55.6 resolves stale `\$derived` values with the latest input and reapplies context after a transform error during SSR, preventing components from rendering with one-tick-old data after a thrown error in a child (`frontend/package-lock.json`).

### Refactoring
- **devalue migration toward native base64**: 5.7.0 uses native `atob`/`btoa` alternatives and adds `DataView` plus `Float16Array` support; consuming code that previously avoided passing typed-array views over the SvelteKit boundary can now do so directly (`frontend/package-lock.json`).

## Breaking Changes
None — both bumps are within their major version (5.x) and Dependabot verified ranges are compatible.

## Related Issues
Rolls up #93 and #94.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to developer tooling config (lefthook/oxlint) and documentation updates; no application runtime code is modified.
> 
> **Overview**
> Updates pre-commit tooling to run the frontend `oxlint --fix` hook only on staged files under `frontend/src/**` instead of any JS/TS/Svelte file in the repo.
> 
> Refreshes docs around book-similarity embedding reads to reflect the expanded active contract (*model/profile/source/input*) and a backfill-friendly fallback to the previous vector contract, and documents new embedding-related env vars (`APP_SIMILARITY_EMBEDDINGS_*`) for section truncation and request chunking/batching.
> 
> Tweaks `oxlintrc.json` rules by removing a few previously enabled checks and adding `unicorn/no-unnecessary-await`, plus adjusting Vitest override settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb579a66d494240a3f65e5dbd63785a6aba3559c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR combines two Dependabot dependency upgrades (Svelte 5.53.6 → 5.55.7, devalue 5.6.4 → 5.8.1) with a substantive backend refactor that adds chunked embedding support, source-text contract versioning, and three new runtime configuration knobs for the book similarity embedding pipeline.

- **Security/dependency bumps**: Svelte 5.55.7 closes an SSR XSS via `hydratable`, hardens SSR attribute validation, and moves runtime properties to symbols to prevent user-data collision with framework internals; devalue 5.8.1 fixes sparse-array allocation in server→client payloads. Companion major-version bumps (Vite 7→8, Vitest 3→4, ESLint 9→10) are included.
- **Embedding chunking**: `BookEmbeddingClient` now splits oversized section texts into token-bounded chunks before each provider call and fuses the resulting vectors back into a single section embedding; chunk size is encoded in the section-cache key so a limit change forces a real re-embed instead of reusing stale rows.
- **Source-text contract**: `BookSimilarityEmbeddingProperties` derives a `sourceTextContract()` string (e.g. `source_chars_15000_v1`) that is appended to the model version, ensuring that changing `APP_SIMILARITY_EMBEDDINGS_MAX_SECTION_TEXT_CHARS` triggers a proper backfill; `findNearestBooks` cascades through the current contract → previous contract (without source segment) → legacy model to serve results during the backfill window.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are well-scoped dependency upgrades plus carefully tested embedding-pipeline logic with no data-loss or regression vectors identified.

All three changed subsystems (frontend deps, embedding chunking, model-version contracts) are covered by matching tests. The chunking arithmetic, weight-fusion, and cache-key derivation are verified by the new BookEmbeddingClientTest. Frontend refactoring (re-export removal, URL.canParse replacement, mock updates) is consistent across pages and test files. No logic gaps were found.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/main/java/net/findmybook/application/similarity/BookEmbeddingClient.java | Major refactor: replaced a fixed per-section embedding call with a chunked pipeline (planEmbeddingInputs → splitIntoChunks → batch-bounded embedSections → fuseInputChunks), plus the chunk-size-aware cache-key via embeddingInputContract. Logic is self-consistent and thoroughly tested. |
| src/main/java/net/findmybook/application/similarity/BookSimilarityEmbeddingService.java | Removed the handleBookUpsert @EventListener (previously flagged); adds sourceTextContract to activeModelVersion so limit changes force a real re-embed; findNearestBooks now cascades through current → previous (without source contract) → legacy model contracts during backfill. |
| src/main/java/net/findmybook/boot/BookSimilarityEmbeddingProperties.java | Adds three new configuration knobs (maxSectionTextChars, inputTokenComfortLimit, requestInputBatchSize) with static normalization helpers that encode into cache-key contract strings; bounds checking is correct throughout. |
| src/main/java/net/findmybook/application/similarity/BookSimilarityVectorFusion.java | Extracted fuseWeighted as a package-visible static method so BookEmbeddingClient can reuse it for chunk-level fusion; original fuse logic preserved, new static helper validated by direct tests. |
| frontend/package.json | Bumps svelte 5.53.6 → 5.55.7 (XSS/SSR fix), devalue 5.6.4 → 5.8.1 (sparse-array fix), vite 7 → 8, vitest 3 → 4, eslint 9 → 10, and companion plugins; all within stated intent of the PR. |
| frontend/src/lib/router/routerHistoryState.ts | Replaces try/catch around new URL(...) with URL.canParse pre-flight check; semantically equivalent and removes the now-unnecessary warning log. |
| frontend/src/lib/services/coverRelayPersistence.ts | Same try/catch → URL.canParse refactor; passes undefined as base when location is unavailable (SSR), which the WHATWG spec treats identically to omitting the argument. |
| frontend/src/lib/services/books.ts | Removed re-exports of persistRenderedCover and search-hit utilities; callers (BookPage.svelte, SearchPage.svelte) now import directly from source modules, and all test mocks updated accordingly. |
| .config/lefthook.yml | Fixes the pre-commit lint glob from *.{js,ts,svelte} (only matched root-level frontend files, effectively a no-op for src/) to src/**/*.{js,ts,svelte}, which now correctly lints staged source files. |
| frontend/vite.config.ts | Adds define: { global: 'globalThis' } shim; standard fix for npm packages that reference the Node.js global object in a browser bundle. |
| src/test/java/net/findmybook/application/similarity/BookEmbeddingClientTest.java | New test file covering chunking, fusing, batch ordering, cache-key contract encoding, and the model-version fallback cascade in BookSimilarityEmbeddingService; assertions are correct and the helpers (embeddingWith, clientWithRequester) are reusable across tests. |
| frontend/config/oxlintrc.json | Removes redundant import/order: off and promise/no-return-await, adds unicorn/no-unnecessary-await: error, drops zod/require-schema-suffix, and adds vitest/require-mock-type-parameters: off to test overrides. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant EmbSvc as BookSimilarityEmbeddingService
    participant EmbClient as BookEmbeddingClient
    participant SectionRepo as BookEmbeddingSectionRepository
    participant Provider as Embedding Provider

    Caller->>EmbSvc: refreshBookIfStale(bookId)
    EmbSvc->>EmbSvc: "activeModelVersion = policy.modelVersion(cacheModel + sourceTextContract)"
    EmbSvc->>SectionRepo: fetchSectionEmbedding(bookId, key, cacheModel, inputHash)
    alt cache hit
        SectionRepo-->>EmbSvc: cached embedding
    else cache miss
        EmbSvc->>EmbClient: embedSections(sectionTexts, tier)
        EmbClient->>EmbClient: planEmbeddingInputs(texts, inputTokenComfortLimit)
        note over EmbClient: split each section into token-bounded chunks
        loop batches of requestInputBatchSize
            EmbClient->>Provider: embed(batchChunks)
            Provider-->>EmbClient: chunk embeddings
        end
        EmbClient->>EmbClient: fuseInputChunks weighted by estimatedTokens
        EmbClient-->>EmbSvc: section embeddings
        EmbSvc->>SectionRepo: upsertSectionEmbedding(cacheModel)
    end
    EmbSvc->>EmbSvc: vectorFusion.fuse(sourceDocument, sectionEmbeddings)
    EmbSvc->>EmbSvc: repository.upsertFusedEmbedding(modelVersion)

    Caller->>EmbSvc: findNearestBooks(bookId, limit)
    EmbSvc->>EmbSvc: query currentModelVersion with sourceTextContract
    alt current rows fill limit
        EmbSvc-->>Caller: currentMatches
    else not enough rows during backfill
        EmbSvc->>EmbSvc: query policy.modelVersion(cacheModel) without sourceTextContract
        alt previous rows non-empty
            EmbSvc-->>Caller: previousMatches
        else
            EmbSvc->>EmbSvc: query policy.modelVersion(legacyModel)
            EmbSvc-->>Caller: legacyMatches or currentMatches
        end
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/main/java/net/findmybook/application/similarity/BookEmbeddingClient.java`, line 121-126 ([link](https://github.com/williamagh/findmybook/blob/33c5951000253d07c43d33e998e1999eccf95a59/src/main/java/net/findmybook/application/similarity/BookEmbeddingClient.java#L121-L126)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Cache key does not encode the effective chunk size**

   `EMBEDDING_INPUT_CONTRACT` is the compile-time constant `"chunked_8192_v1"`, so `cacheModel()` always returns `model:chunked_8192_v1` regardless of the runtime `inputTokenComfortLimit`. If an operator configures `input-token-comfort-limit` to anything below 8192 (e.g. 4096), sections are split at the lower limit, producing different chunk boundaries and therefore different fused vectors, but those embeddings are stored and fetched under the same cache key as the 8192-token chunks. A stale cache entry produced with a different chunk size would be silently returned as a valid hit, yielding wrong similarity results without any error.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/main/java/net/findmybook/application/similarity/BookEmbeddingClient.java
   Line: 121-126

   Comment:
   **Cache key does not encode the effective chunk size**

   `EMBEDDING_INPUT_CONTRACT` is the compile-time constant `"chunked_8192_v1"`, so `cacheModel()` always returns `model:chunked_8192_v1` regardless of the runtime `inputTokenComfortLimit`. If an operator configures `input-token-comfort-limit` to anything below 8192 (e.g. 4096), sections are split at the lower limit, producing different chunk boundaries and therefore different fused vectors, but those embeddings are stored and fetched under the same cache key as the 8192-token chunks. A stale cache entry produced with a different chunk size would be silently returned as a valid hit, yielding wrong similarity results without any error.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fmain%2Fjava%2Fnet%2Ffindmybook%2Fapplication%2Fsimilarity%2FBookEmbeddingClient.java%0ALine%3A%20121-126%0A%0AComment%3A%0A**Cache%20key%20does%20not%20encode%20the%20effective%20chunk%20size**%0A%0A%60EMBEDDING_INPUT_CONTRACT%60%20is%20the%20compile-time%20constant%20%60%22chunked_8192_v1%22%60%2C%20so%20%60cacheModel%28%29%60%20always%20returns%20%60model%3Achunked_8192_v1%60%20regardless%20of%20the%20runtime%20%60inputTokenComfortLimit%60.%20If%20an%20operator%20configures%20%60input-token-comfort-limit%60%20to%20anything%20below%208192%20%28e.g.%204096%29%2C%20sections%20are%20split%20at%20the%20lower%20limit%2C%20producing%20different%20chunk%20boundaries%20and%20therefore%20different%20fused%20vectors%2C%20but%20those%20embeddings%20are%20stored%20and%20fetched%20under%20the%20same%20cache%20key%20as%20the%208192-token%20chunks.%20A%20stale%20cache%20entry%20produced%20with%20a%20different%20chunk%20size%20would%20be%20silently%20returned%20as%20a%20valid%20hit%2C%20yielding%20wrong%20similarity%20results%20without%20any%20error.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=williamagh%2Ffindmybook&pr=96&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fmain%2Fjava%2Fnet%2Ffindmybook%2Fapplication%2Fsimilarity%2FBookEmbeddingClient.java%0ALine%3A%20121-126%0A%0AComment%3A%0A**Cache%20key%20does%20not%20encode%20the%20effective%20chunk%20size**%0A%0A%60EMBEDDING_INPUT_CONTRACT%60%20is%20the%20compile-time%20constant%20%60%22chunked_8192_v1%22%60%2C%20so%20%60cacheModel%28%29%60%20always%20returns%20%60model%3Achunked_8192_v1%60%20regardless%20of%20the%20runtime%20%60inputTokenComfortLimit%60.%20If%20an%20operator%20configures%20%60input-token-comfort-limit%60%20to%20anything%20below%208192%20%28e.g.%204096%29%2C%20sections%20are%20split%20at%20the%20lower%20limit%2C%20producing%20different%20chunk%20boundaries%20and%20therefore%20different%20fused%20vectors%2C%20but%20those%20embeddings%20are%20stored%20and%20fetched%20under%20the%20same%20cache%20key%20as%20the%208192-token%20chunks.%20A%20stale%20cache%20entry%20produced%20with%20a%20different%20chunk%20size%20would%20be%20silently%20returned%20as%20a%20valid%20hit%2C%20yielding%20wrong%20similarity%20results%20without%20any%20error.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=96&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22williamagh%2Ffindmybook%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fmain%2Fjava%2Fnet%2Ffindmybook%2Fapplication%2Fsimilarity%2FBookEmbeddingClient.java%0ALine%3A%20121-126%0A%0AComment%3A%0A**Cache%20key%20does%20not%20encode%20the%20effective%20chunk%20size**%0A%0A%60EMBEDDING_INPUT_CONTRACT%60%20is%20the%20compile-time%20constant%20%60%22chunked_8192_v1%22%60%2C%20so%20%60cacheModel%28%29%60%20always%20returns%20%60model%3Achunked_8192_v1%60%20regardless%20of%20the%20runtime%20%60inputTokenComfortLimit%60.%20If%20an%20operator%20configures%20%60input-token-comfort-limit%60%20to%20anything%20below%208192%20%28e.g.%204096%29%2C%20sections%20are%20split%20at%20the%20lower%20limit%2C%20producing%20different%20chunk%20boundaries%20and%20therefore%20different%20fused%20vectors%2C%20but%20those%20embeddings%20are%20stored%20and%20fetched%20under%20the%20same%20cache%20key%20as%20the%208192-token%20chunks.%20A%20stale%20cache%20entry%20produced%20with%20a%20different%20chunk%20size%20would%20be%20silently%20returned%20as%20a%20valid%20hit%2C%20yielding%20wrong%20similarity%20results%20without%20any%20error.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

2. `src/main/java/net/findmybook/application/similarity/BookSimilarityEmbeddingService.java`, line 80-81 ([link](https://github.com/williamagh/findmybook/blob/3c3a6110829245ab7155301d432183b6c9ddcb1d/src/main/java/net/findmybook/application/similarity/BookSimilarityEmbeddingService.java#L80-L81)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Event-driven refresh silently removed with no replacement**

   The `handleBookUpsert` `@EventListener` was deleted, so book content changes no longer trigger an immediate similarity-embedding refresh. The only remaining refresh paths are the scheduler (`enqueueRefreshCandidates`) and explicit `backfillStale` / `enqueueDemandRefresh` calls. Until the scheduler runs its next pass, updated books will serve stale recommendation vectors. The PR description does not mention this behavior change, which suggests it may be unintentional.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/main/java/net/findmybook/application/similarity/BookSimilarityEmbeddingService.java
   Line: 80-81

   Comment:
   **Event-driven refresh silently removed with no replacement**

   The `handleBookUpsert` `@EventListener` was deleted, so book content changes no longer trigger an immediate similarity-embedding refresh. The only remaining refresh paths are the scheduler (`enqueueRefreshCandidates`) and explicit `backfillStale` / `enqueueDemandRefresh` calls. Until the scheduler runs its next pass, updated books will serve stale recommendation vectors. The PR description does not mention this behavior change, which suggests it may be unintentional.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fmain%2Fjava%2Fnet%2Ffindmybook%2Fapplication%2Fsimilarity%2FBookSimilarityEmbeddingService.java%0ALine%3A%2080-81%0A%0AComment%3A%0A**Event-driven%20refresh%20silently%20removed%20with%20no%20replacement**%0A%0AThe%20%60handleBookUpsert%60%20%60%40EventListener%60%20was%20deleted%2C%20so%20book%20content%20changes%20no%20longer%20trigger%20an%20immediate%20similarity-embedding%20refresh.%20The%20only%20remaining%20refresh%20paths%20are%20the%20scheduler%20%28%60enqueueRefreshCandidates%60%29%20and%20explicit%20%60backfillStale%60%20%2F%20%60enqueueDemandRefresh%60%20calls.%20Until%20the%20scheduler%20runs%20its%20next%20pass%2C%20updated%20books%20will%20serve%20stale%20recommendation%20vectors.%20The%20PR%20description%20does%20not%20mention%20this%20behavior%20change%2C%20which%20suggests%20it%20may%20be%20unintentional.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=williamagh%2Ffindmybook&pr=96&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fmain%2Fjava%2Fnet%2Ffindmybook%2Fapplication%2Fsimilarity%2FBookSimilarityEmbeddingService.java%0ALine%3A%2080-81%0A%0AComment%3A%0A**Event-driven%20refresh%20silently%20removed%20with%20no%20replacement**%0A%0AThe%20%60handleBookUpsert%60%20%60%40EventListener%60%20was%20deleted%2C%20so%20book%20content%20changes%20no%20longer%20trigger%20an%20immediate%20similarity-embedding%20refresh.%20The%20only%20remaining%20refresh%20paths%20are%20the%20scheduler%20%28%60enqueueRefreshCandidates%60%29%20and%20explicit%20%60backfillStale%60%20%2F%20%60enqueueDemandRefresh%60%20calls.%20Until%20the%20scheduler%20runs%20its%20next%20pass%2C%20updated%20books%20will%20serve%20stale%20recommendation%20vectors.%20The%20PR%20description%20does%20not%20mention%20this%20behavior%20change%2C%20which%20suggests%20it%20may%20be%20unintentional.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=96&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22williamagh%2Ffindmybook%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fmain%2Fjava%2Fnet%2Ffindmybook%2Fapplication%2Fsimilarity%2FBookSimilarityEmbeddingService.java%0ALine%3A%2080-81%0A%0AComment%3A%0A**Event-driven%20refresh%20silently%20removed%20with%20no%20replacement**%0A%0AThe%20%60handleBookUpsert%60%20%60%40EventListener%60%20was%20deleted%2C%20so%20book%20content%20changes%20no%20longer%20trigger%20an%20immediate%20similarity-embedding%20refresh.%20The%20only%20remaining%20refresh%20paths%20are%20the%20scheduler%20%28%60enqueueRefreshCandidates%60%29%20and%20explicit%20%60backfillStale%60%20%2F%20%60enqueueDemandRefresh%60%20calls.%20Until%20the%20scheduler%20runs%20its%20next%20pass%2C%20updated%20books%20will%20serve%20stale%20recommendation%20vectors.%20The%20PR%20description%20does%20not%20mention%20this%20behavior%20change%2C%20which%20suggests%20it%20may%20be%20unintentional.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (7): Last reviewed commit: ["fix(frontend): restore browser global fo..."](https://github.com/williamagh/findmybook/commit/fb579a66d494240a3f65e5dbd63785a6aba3559c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32282967)</sub>

<!-- /greptile_comment -->