### PR TITLE
docs(config): AI requests route through the LLM gateway using the own-hardware qwen3.6:onprem model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,11 +9,12 @@ SPRING_DATASOURCE_URL=jdbc:postgresql://aws-1-us-west-1.pooler.supabase.com:5432
 SPRING_DATASOURCE_USERNAME=postgres.something
 SPRING_DATASOURCE_PASSWORD=[YOUR-PASSWORD]
 
-# OpenAI-compatible AI configuration
-OPENAI_API_KEY=your-openai-compatible-api-key
-OPENAI_BASE_URL=https://your-openai-compatible-endpoint.example/v1
-OPENAI_MODEL=your-inference-model
-OPENAI_EMBEDDINGS_MODEL=your-embeddings-model
+# OpenAI-compatible AI configuration (Researchly LLM gateway, data-plane channel)
+OPENAI_API_KEY=lgw-your-gateway-client-key
+OPENAI_BASE_URL=https://api.llm-gateway.iocloudhost.net
+# qwen3.6:onprem routes only to our own inference hosts (never a paid cloud provider)
+OPENAI_MODEL=qwen3.6:onprem
+OPENAI_EMBEDDINGS_MODEL=qwen/qwen3-embedding-4b
 
 # Google Books API configuration
 GOOGLE_BOOKS_API_BASE_URL=https://www.googleapis.com/books/v1


### PR DESCRIPTION
## Summary
Documents the cutover of all AI generation and embedding traffic from the direct `popos-sf7.com` host to the LLM gateway's data-plane channel (`https://api.llm-gateway.iocloudhost.net`), using the `qwen3.6:onprem` alias — which the gateway round-robins across our own inference hosts (sf4/sf6/sf8/sf9) and can never route to a paid cloud provider.

## Changes

### Documentation
- **New deployers get working gateway config by copy-paste**: `.env.example` now shows the real gateway endpoint shape (`lgw-*` key, `qwen3.6:onprem` chat model, `qwen/qwen3-embedding-4b` embeddings) instead of generic placeholders (`.env.example`)

## Required environment variable updates (not in this PR — `.env` is gitignored)
| Variable | New value |
|---|---|
| `OPENAI_BASE_URL` | `https://api.llm-gateway.iocloudhost.net` |
| `OPENAI_API_KEY` | gateway `lgw-*` client key |
| `OPENAI_MODEL` | `qwen3.6:onprem` (was `qwen3.6`, which routes to OpenRouter first and spends money) |
| `OPENAI_EMBEDDINGS_MODEL` | `qwen/qwen3-embedding-4b` |

Dead `AI_DEFAULT_LLM_MODEL` / `AI_DEFAULT_OPENAI_API_KEY` / `AI_DEFAULT_OPENAI_BASE_URL` vars (unreferenced in code, pointing at the old sf7 endpoint) were removed from the local `.env`. Apply the same four updates to any deployment environment (Coolify/Docker).

## Code changes required
None — `OpenAiProperties` already normalizes the base URL and appends `/v1`; the OpenAI Java SDK client works unchanged against the gateway. Verified live: chat via `qwen3.6:onprem` and 2560-dim embeddings both pass through the gateway.

## Breaking Changes
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example env documentation only; runtime behavior is unchanged unless operators update their real `.env` separately.
> 
> **Overview**
> Updates **`.env.example`** so new deployers copy-paste **Researchly LLM gateway** settings instead of generic OpenAI-style placeholders.
> 
> **`OPENAI_BASE_URL`** now points at `https://api.llm-gateway.iocloudhost.net`, **`OPENAI_API_KEY`** uses an `lgw-*` gateway client key shape, **`OPENAI_MODEL`** is **`qwen3.6:onprem`** (with a comment that it stays on own inference hosts), and **`OPENAI_EMBEDDINGS_MODEL`** is **`qwen/qwen3-embedding-4b`**. No application code changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f3470752ad686e04350beddbdd9acf0c31a78fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->