### PR TITLE
Fix book identity, realtime search, cover, and persistence bugs

### DIFF
--- a/frontend/src/lib/router/router.book-page.cover-relay.test.ts
+++ b/frontend/src/lib/router/router.book-page.cover-relay.test.ts
@@ -121,9 +121,9 @@ describe("BookPage cover relay persistence", () => {
         id: "book-1",
         title: "Browser Cover Book",
         cover: buildCover({
-          preferredUrl: "https://books.google.com/books/content?id=abc&printsec=frontcover&img=1&zoom=1",
-          fallbackUrl: "https://books.google.com/books/content?id=abc&printsec=frontcover&img=1&zoom=1",
-          source: "GOOGLE_BOOKS",
+          preferredUrl: "https://relay.example.com/covers/browser-cover-book.jpg",
+          fallbackUrl: "https://relay.example.com/covers/browser-cover-book.jpg",
+          source: "BROWSER_RELAY",
         }),
       }),
     );
@@ -145,8 +145,8 @@ describe("BookPage cover relay persistence", () => {
     });
     expect(persistRenderedCoverMock).toHaveBeenCalledWith({
       identifier: "book-1",
-      renderedCoverUrl: "https://books.google.com/books/content?id=abc&printsec=frontcover&img=1&zoom=1",
-      source: "GOOGLE_BOOKS",
+      renderedCoverUrl: "https://relay.example.com/covers/browser-cover-book.jpg",
+      source: "BROWSER_RELAY",
     });
   });
 
@@ -205,6 +205,35 @@ describe("BookPage cover relay persistence", () => {
     });
 
     const cover = await screen.findByAltText("Open Library Cover Book cover");
+    await fireEvent.load(cover);
+
+    await waitFor(() => {
+      expect(persistRenderedCoverMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("shouldSkipRenderedCoverPersistenceForGoogleBooksProviderCover", async () => {
+    getBookMock.mockResolvedValueOnce(
+      createBookPayload({
+        id: "book-1",
+        title: "Google Books Cover Book",
+        cover: buildCover({
+          preferredUrl: "https://books.google.com/books/content?id=abc&printsec=frontcover&img=1&zoom=6",
+          fallbackUrl: "https://books.google.com/books/content?id=abc&printsec=frontcover&img=1&zoom=6",
+          source: "GOOGLE_BOOKS",
+        }),
+      }),
+    );
+
+    const currentUrl = new URL("https://findmybook.net/book/book-1");
+    render(BookPage, {
+      props: {
+        currentUrl,
+        identifier: "book-1",
+      },
+    });
+
+    const cover = await screen.findByAltText("Google Books Cover Book cover");
     await fireEvent.load(cover);
 
     await waitFor(() => {

--- a/frontend/src/lib/router/router.book-page.cover-relay.test.ts
+++ b/frontend/src/lib/router/router.book-page.cover-relay.test.ts
@@ -182,4 +182,33 @@ describe("BookPage cover relay persistence", () => {
       expect(persistRenderedCoverMock).not.toHaveBeenCalled();
     });
   });
+
+  it("shouldSkipRenderedCoverPersistenceForOpenLibraryProviderCover", async () => {
+    getBookMock.mockResolvedValueOnce(
+      createBookPayload({
+        id: "book-1",
+        title: "Open Library Cover Book",
+        cover: buildCover({
+          preferredUrl: "https://covers.openlibrary.org/b/id/15162569-L.jpg",
+          fallbackUrl: "https://covers.openlibrary.org/b/id/15162569-L.jpg",
+          source: "OPEN_LIBRARY",
+        }),
+      }),
+    );
+
+    const currentUrl = new URL("https://findmybook.net/book/book-1");
+    render(BookPage, {
+      props: {
+        currentUrl,
+        identifier: "book-1",
+      },
+    });
+
+    const cover = await screen.findByAltText("Open Library Cover Book cover");
+    await fireEvent.load(cover);
+
+    await waitFor(() => {
+      expect(persistRenderedCoverMock).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/frontend/src/lib/services/coverRelayPersistence.ts
+++ b/frontend/src/lib/services/coverRelayPersistence.ts
@@ -11,7 +11,11 @@ import { type Book, buildCover } from "$lib/validation/schemas";
 
 const PLACEHOLDER_COVER_FILENAME = "placeholder-book-cover.svg";
 const PERSISTED_COVER_PATH_SEGMENT = "images/book-covers/";
-const OPEN_LIBRARY_COVER_HOST = "covers.openlibrary.org";
+const SERVER_MANAGED_COVER_HOSTS = new Set([
+  "books.google.com",
+  "books.googleusercontent.com",
+  "covers.openlibrary.org",
+]);
 
 export function normalizeCoverUrl(candidateUrl: string): string | null {
   if (!candidateUrl || candidateUrl.trim().length === 0) {
@@ -46,7 +50,7 @@ function isPlaceholderCoverUrl(candidateUrl: string, placeholderCoverUrl: string
 }
 
 function isServerManagedProviderCoverUrl(candidateUrl: string): boolean {
-  return new URL(candidateUrl).hostname.toLowerCase() === OPEN_LIBRARY_COVER_HOST;
+  return SERVER_MANAGED_COVER_HOSTS.has(new URL(candidateUrl).hostname.toLowerCase());
 }
 
 function coverPersistKey(bookId: string, coverUrl: string): string {

--- a/frontend/src/lib/services/coverRelayPersistence.ts
+++ b/frontend/src/lib/services/coverRelayPersistence.ts
@@ -11,6 +11,7 @@ import { type Book, buildCover } from "$lib/validation/schemas";
 
 const PLACEHOLDER_COVER_FILENAME = "placeholder-book-cover.svg";
 const PERSISTED_COVER_PATH_SEGMENT = "images/book-covers/";
+const OPEN_LIBRARY_COVER_HOST = "covers.openlibrary.org";
 
 export function normalizeCoverUrl(candidateUrl: string): string | null {
   if (!candidateUrl || candidateUrl.trim().length === 0) {
@@ -44,6 +45,10 @@ function isPlaceholderCoverUrl(candidateUrl: string, placeholderCoverUrl: string
     || normalized.includes(PLACEHOLDER_COVER_FILENAME);
 }
 
+function isServerManagedProviderCoverUrl(candidateUrl: string): boolean {
+  return new URL(candidateUrl).hostname.toLowerCase() === OPEN_LIBRARY_COVER_HOST;
+}
+
 function coverPersistKey(bookId: string, coverUrl: string): string {
   return `${bookId}::${coverUrl}`;
 }
@@ -75,6 +80,7 @@ export function reserveCoverRelayCandidate(
     hasPersistedS3Cover(book)
     || isPersistedCoverUrl(normalizedRenderedUrl)
     || isPlaceholderCoverUrl(normalizedRenderedUrl, placeholderCoverUrl)
+    || isServerManagedProviderCoverUrl(normalizedRenderedUrl)
   ) {
     return null;
   }

--- a/src/main/java/net/findmybook/application/cover/BackfillCandidateQuery.java
+++ b/src/main/java/net/findmybook/application/cover/BackfillCandidateQuery.java
@@ -37,8 +37,9 @@ class BackfillCandidateQuery {
                       SELECT 1 FROM book_image_links bil
                       WHERE bil.book_id = b.id
                         AND bil.download_error IS NULL
-                        AND ((bil.url IS NOT NULL AND bil.url <> '')
-                             OR (bil.s3_image_path IS NOT NULL AND bil.s3_image_path <> ''))
+                        AND COALESCE(bil.is_grayscale, false) = false
+                        AND bil.s3_image_path IS NOT NULL
+                        AND bil.s3_image_path <> ''
                   )
                 ORDER BY b.created_at DESC
                 LIMIT ?
@@ -56,8 +57,8 @@ class BackfillCandidateQuery {
                       WHERE bil.book_id = b.id
                         AND bil.download_error IS NULL
                         AND COALESCE(bil.is_grayscale, false) = false
-                        AND ((bil.url IS NOT NULL AND bil.url <> '')
-                             OR (bil.s3_image_path IS NOT NULL AND bil.s3_image_path <> ''))
+                        AND bil.s3_image_path IS NOT NULL
+                        AND bil.s3_image_path <> ''
                   )
                 ORDER BY b.created_at DESC
                 LIMIT ?
@@ -75,6 +76,7 @@ class BackfillCandidateQuery {
                       SELECT 1 FROM book_image_links bil
                       WHERE bil.book_id = b.id
                         AND bil.download_error IS NULL
+                        AND COALESCE(bil.is_grayscale, false) = false
                         AND bil.s3_image_path IS NOT NULL
                         AND bil.s3_image_path <> ''
                   )

--- a/src/main/java/net/findmybook/controller/dto/search/SearchContractMapper.java
+++ b/src/main/java/net/findmybook/controller/dto/search/SearchContractMapper.java
@@ -44,7 +44,18 @@ public final class SearchContractMapper {
             .map(SearchContractMapper::toSearchHit)
             .filter(Objects::nonNull)
             .toList();
-        String queryHash = SearchQueryUtils.topicKey(page.query());
+        String coverSource = page.coverSource() != null ? page.coverSource().name() : CoverImageSource.ANY.name();
+        String resolutionPreference = page.resolutionPreference() != null
+            ? page.resolutionPreference().name()
+            : ImageResolutionPreference.ANY.name();
+        String queryHash = SearchQueryUtils.topicKey(
+            page.query(),
+            page.orderBy(),
+            coverSource,
+            resolutionPreference,
+            page.publishedYear(),
+            page.maxResults()
+        );
 
         return new SearchResponse(
             page.query(),
@@ -56,8 +67,8 @@ public final class SearchContractMapper {
             page.nextStartIndex(),
             page.prefetchedCount(),
             page.orderBy(),
-            page.coverSource() != null ? page.coverSource().name() : CoverImageSource.ANY.name(),
-            page.resolutionPreference() != null ? page.resolutionPreference().name() : ImageResolutionPreference.ANY.name(),
+            coverSource,
+            resolutionPreference,
             hits
         );
     }
@@ -72,7 +83,14 @@ public final class SearchContractMapper {
     public static SearchResponse emptySearchResponse(String query, SearchPaginationService.SearchRequest request) {
         return new SearchResponse(
             query,
-            SearchQueryUtils.topicKey(query),
+            SearchQueryUtils.topicKey(
+                query,
+                request.orderBy(),
+                request.coverSource().name(),
+                request.resolutionPreference().name(),
+                request.publishedYear(),
+                request.maxResults()
+            ),
             request.startIndex(),
             request.maxResults(),
             0,

--- a/src/main/java/net/findmybook/scheduler/NewYorkTimesBestsellerScheduler.java
+++ b/src/main/java/net/findmybook/scheduler/NewYorkTimesBestsellerScheduler.java
@@ -257,12 +257,8 @@ public class NewYorkTimesBestsellerScheduler {
                 updatedFrequency,
                 listNode
             ))
-            .orElse(null);
-
-        if (collectionId == null) {
-            log.warn("Failed to upsert NYT collection for list code {}", listCode);
-            return;
-        }
+            .orElseThrow(() -> new IllegalStateException(
+                "NYT collection upsert returned no id for list code " + listCode));
 
         ArrayNode booksNode = listNode.has("books") && listNode.get("books").isArray() ? (ArrayNode) listNode.get("books") : null;
         if (booksNode == null || booksNode.isEmpty()) {
@@ -362,7 +358,6 @@ public class NewYorkTimesBestsellerScheduler {
         } else {
             persistenceCollaborator.enrichExistingCanonicalBookMetadata(canonicalId, bookNode);
         }
-        persistenceCollaborator.upsertNytExternalIdentifiers(canonicalId, bookNode, isbn13, isbn10);
 
         String title = payloadMapper.firstNonEmptyText(bookNode, "title");
         if (canonicalId == null) {
@@ -372,6 +367,8 @@ public class NewYorkTimesBestsellerScheduler {
                 title != null ? title : "unknown");
             return null;
         }
+
+        persistenceCollaborator.upsertNytExternalIdentifiers(canonicalId, bookNode, isbn13, isbn10);
 
         log.info("Processing NYT book: canonicalId='{}', isNew={}, listCode='{}', isbn13='{}', title='{}'",
             canonicalId,

--- a/src/main/java/net/findmybook/service/BookCollectionPersistenceService.java
+++ b/src/main/java/net/findmybook/service/BookCollectionPersistenceService.java
@@ -28,10 +28,10 @@ public class BookCollectionPersistenceService {
 
     /**
      * Upserts a category into the book_collections table.
-     * 
+     *
      * <p>Uses {@link CategoryNormalizer#normalizeForDatabase(String)} to generate
      * a consistent normalized_name for database uniqueness constraints.
-     * 
+     *
      * @param displayName Human-readable category name
      * @return Optional containing the category ID, or empty if operation failed
      * @see CategoryNormalizer#normalizeForDatabase(String)
@@ -115,23 +115,23 @@ public class BookCollectionPersistenceService {
             return Optional.ofNullable(id);
         } catch (DataAccessException ex) {
             LoggingUtils.error(log, ex, "Failed upserting bestseller collection listCode={} publishedDate={}", dto.listCode(), dto.publishedDate());
-            return JdbcUtils.optionalString(
-                jdbcTemplate,
-                "SELECT id FROM book_collections WHERE source = 'NYT' AND provider_list_code = ? AND published_date = ?",
-                dto.listCode(),
-                dto.publishedDate()
+            throw new IllegalStateException(
+                "Failed upserting NYT bestseller collection listCode=%s publishedDate=%s"
+                    .formatted(dto.listCode(), dto.publishedDate()),
+                ex
             );
         }
     }
 
     public void upsertBestsellerMembership(BestsellerMembershipDto dto) {
         if (jdbcTemplate == null) {
-            log.warn("upsertBestsellerMembership: jdbcTemplate is null");
-            return;
+            throw new IllegalStateException("JdbcTemplate unavailable for NYT bestseller membership persistence");
         }
         if (dto.collectionId() == null || dto.bookId() == null) {
-            log.warn("upsertBestsellerMembership: collectionId or bookId is null - collectionId: {}, bookId: {}", dto.collectionId(), dto.bookId());
-            return;
+            throw new IllegalArgumentException(
+                "NYT bestseller membership requires collectionId and bookId; collectionId=%s bookId=%s"
+                    .formatted(dto.collectionId(), dto.bookId())
+            );
         }
 
         try {
@@ -151,10 +151,10 @@ public class BookCollectionPersistenceService {
                     bookUuid
                 );
             }
-            
+
             log.debug("Inserting book into collection: collectionId='{}', bookId='{}', position={}, isbn13='{}'",
                 dto.collectionId(), dto.bookId(), dto.position(), dto.providerIsbn13());
-            
+
             JdbcUtils.executeUpdate(
                 jdbcTemplate,
                 "INSERT INTO book_collections_join (id, collection_id, book_id, position, weeks_on_list, rank_last_week, peak_position, provider_isbn13, provider_isbn10, provider_book_ref, raw_item_json, created_at, updated_at) " +
@@ -172,19 +172,25 @@ public class BookCollectionPersistenceService {
                 dto.providerBookRef(),
                 dto.rawItemJson()
             );
-            
+
             log.info("Successfully added book to collection: collectionId='{}', bookId='{}', position={}",
                 dto.collectionId(), dto.bookId(), dto.position());
         } catch (IllegalArgumentException ex) {
             LoggingUtils.error(log, ex, "Invalid UUID format for bookId: {}", dto.bookId());
+            throw ex;
         } catch (DataAccessException ex) {
             LoggingUtils.error(log, ex, "Database error adding book to collection: collectionId='{}', bookId='{}', position={}, isbn13='{}'",
                 dto.collectionId(), dto.bookId(), dto.position(), dto.providerIsbn13());
+            throw new IllegalStateException(
+                "Failed persisting NYT bestseller membership collectionId=%s bookId=%s position=%s"
+                    .formatted(dto.collectionId(), dto.bookId(), dto.position()),
+                ex
+            );
         }
     }
 
     public record BestsellerCollectionDto(String providerListId, String listCode, String displayName, String normalizedName, String description, LocalDate bestsellersDate, LocalDate publishedDate, String updatedFrequency, JsonNode rawListJson) {}
-    
+
     public record BestsellerMembershipDto(String collectionId, String bookId, Integer position, Integer weeksOnList, Integer rankLastWeek, Integer peakPosition, String providerIsbn13, String providerIsbn10, String providerBookRef, String rawItemJson) {}
 
     public Optional<String> upsertList(String source,

--- a/src/main/java/net/findmybook/service/BookLookupService.java
+++ b/src/main/java/net/findmybook/service/BookLookupService.java
@@ -58,10 +58,24 @@ public class BookLookupService {
      * @return Optional containing the book ID if found
      */
     public Optional<String> findBookIdByIsbn13(String isbn13) {
-        if (!StringUtils.hasText(isbn13)) {
+        String sanitized = IsbnUtils.sanitize(isbn13);
+        if (!StringUtils.hasText(sanitized)) {
             return Optional.empty();
         }
 
+        Optional<String> exact = findBookIdByIsbn13Exact(sanitized);
+        if (exact.isPresent()) {
+            return exact;
+        }
+
+        String equivalentIsbn10 = IsbnUtils.toIsbn10(sanitized);
+        return findBookIdByIsbn10Exact(equivalentIsbn10);
+    }
+
+    private Optional<String> findBookIdByIsbn13Exact(String isbn13) {
+        if (!StringUtils.hasText(isbn13)) {
+            return Optional.empty();
+        }
         // First check books table
         Optional<String> bookId = JdbcUtils.optionalString(
             jdbcTemplate,
@@ -90,10 +104,24 @@ public class BookLookupService {
      * @return Optional containing the book ID if found
      */
     public Optional<String> findBookIdByIsbn10(String isbn10) {
-        if (!StringUtils.hasText(isbn10)) {
+        String sanitized = IsbnUtils.sanitize(isbn10);
+        if (!StringUtils.hasText(sanitized)) {
             return Optional.empty();
         }
 
+        Optional<String> exact = findBookIdByIsbn10Exact(sanitized);
+        if (exact.isPresent()) {
+            return exact;
+        }
+
+        String equivalentIsbn13 = IsbnUtils.toIsbn13(sanitized);
+        return findBookIdByIsbn13Exact(equivalentIsbn13);
+    }
+
+    private Optional<String> findBookIdByIsbn10Exact(String isbn10) {
+        if (!StringUtils.hasText(isbn10)) {
+            return Optional.empty();
+        }
         // First check books table
         Optional<String> bookId = JdbcUtils.optionalString(
             jdbcTemplate,

--- a/src/main/java/net/findmybook/service/BookUpsertService.java
+++ b/src/main/java/net/findmybook/service/BookUpsertService.java
@@ -214,7 +214,7 @@ public class BookUpsertService {
             }
         }
 
-        Optional<UUID> clusteredMatch = findBookByWorkCluster(sanitizedIsbn13);
+        Optional<UUID> clusteredMatch = findBookByWorkCluster(isbn13IdentityForLookup(aggregate));
         if (clusteredMatch.isPresent()) {
             log.debug("Found existing book {} via work cluster lookup", clusteredMatch.get());
             return clusteredMatch;
@@ -244,10 +244,22 @@ public class BookUpsertService {
             return Optional.empty();
         }
 
+        Optional<UUID> exact = queryBookByIsbn13(sanitized);
+        if (exact.isPresent()) {
+            return exact;
+        }
+
+        return queryBookByIsbn10(IsbnUtils.toIsbn10(sanitized));
+    }
+
+    private Optional<UUID> queryBookByIsbn13(String isbn13) {
+        if (isbn13 == null || isbn13.isBlank()) {
+            return Optional.empty();
+        }
         UUID id = jdbcTemplate.query(
             "SELECT id FROM books WHERE isbn13 = ? LIMIT 1",
             rs -> rs.next() ? (UUID) rs.getObject("id") : null,
-            sanitized
+            isbn13
         );
         return Optional.ofNullable(id);
     }
@@ -258,10 +270,22 @@ public class BookUpsertService {
             return Optional.empty();
         }
 
+        Optional<UUID> exact = queryBookByIsbn10(sanitized);
+        if (exact.isPresent()) {
+            return exact;
+        }
+
+        return queryBookByIsbn13(IsbnUtils.toIsbn13(sanitized));
+    }
+
+    private Optional<UUID> queryBookByIsbn10(String isbn10) {
+        if (isbn10 == null || isbn10.isBlank()) {
+            return Optional.empty();
+        }
         UUID id = jdbcTemplate.query(
             "SELECT id FROM books WHERE isbn10 = ? LIMIT 1",
             rs -> rs.next() ? (UUID) rs.getObject("id") : null,
-            sanitized
+            isbn10
         );
         return Optional.ofNullable(id);
     }
@@ -272,8 +296,18 @@ public class BookUpsertService {
         }
 
         UUID id = jdbcTemplate.query(
-            "SELECT id FROM books WHERE slug = ? LIMIT 1",
+            """
+            SELECT id
+            FROM books
+            WHERE slug = ?
+               OR (slug LIKE ? AND substring(slug from ?) ~ '^[0-9]+$')
+            ORDER BY CASE WHEN slug = ? THEN 0 ELSE 1 END, length(slug), slug
+            LIMIT 1
+            """,
             rs -> rs.next() ? (UUID) rs.getObject("id") : null,
+            slug,
+            slug + "-%",
+            slug.length() + 2,
             slug
         );
         return Optional.ofNullable(id);
@@ -306,15 +340,9 @@ public class BookUpsertService {
 
     private Long computeBookLockKey(BookAggregate aggregate) {
         String lockString = null;
-        String sanitizedIsbn13 = IsbnUtils.sanitize(aggregate.getIsbn13());
-        if (sanitizedIsbn13 != null) {
-            lockString = "ISBN13:" + sanitizedIsbn13;
-        }
-        else {
-            String sanitizedIsbn10 = IsbnUtils.sanitize(aggregate.getIsbn10());
-            if (sanitizedIsbn10 != null) {
-                lockString = "ISBN10:" + sanitizedIsbn10;
-            }
+        String isbn13Identity = isbn13IdentityForLookup(aggregate);
+        if (isbn13Identity != null) {
+            lockString = "ISBN:" + isbn13Identity;
         }
         if (lockString == null && aggregate.getIdentifiers() != null) {
             String source = aggregate.getIdentifiers().getSource();
@@ -328,6 +356,14 @@ public class BookUpsertService {
             return null; // No identifiers available
         }
         return fnv1a64(lockString);
+    }
+
+    private String isbn13IdentityForLookup(BookAggregate aggregate) {
+        String isbn13Identity = IsbnUtils.isbn13Identity(aggregate.getIsbn13());
+        if (isbn13Identity != null) {
+            return isbn13Identity;
+        }
+        return IsbnUtils.isbn13Identity(aggregate.getIsbn10());
     }
 
     private static long fnv1a64(String input) {

--- a/src/main/java/net/findmybook/service/OpenLibraryBookDataService.java
+++ b/src/main/java/net/findmybook/service/OpenLibraryBookDataService.java
@@ -9,12 +9,15 @@
 package net.findmybook.service;
 
 import net.findmybook.model.Book;
+import net.findmybook.model.image.CoverImageSource;
+import net.findmybook.model.image.CoverImages;
 import net.findmybook.util.ExternalApiLogger;
 import net.findmybook.util.IsbnUtils;
 import net.findmybook.util.LoggingUtils;
 import net.findmybook.util.SearchExternalProviderUtils;
 import net.findmybook.util.TextUtils;
 import net.findmybook.util.ApplicationConstants;
+import net.findmybook.util.DateParsingUtils;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import lombok.extern.slf4j.Slf4j;
@@ -46,6 +49,7 @@ public class OpenLibraryBookDataService {
     private static final int WORK_DETAILS_CONCURRENCY = 6;
     private static final int WORK_DETAILS_MAX_ENRICHMENTS = 12;
     private static final Duration WORK_DETAILS_TIMEOUT = Duration.ofSeconds(3);
+    private static final Duration ISBN_EDITION_DETAILS_TIMEOUT = Duration.ofSeconds(3);
     private static final String SEARCH_FIELDS =
         "key,title,author_name,isbn,cover_i,first_publish_year,number_of_pages_median,subject,publisher,language,first_sentence";
 
@@ -196,9 +200,11 @@ public class OpenLibraryBookDataService {
                 })
                 .take(safeMaxResults);
 
-        Flux<Book> response = includeEverythingMode
-            ? enrichWithWorkDetails(parsedBooks, queryValue)
-            : parsedBooks;
+        Flux<Book> response = parsedBooks;
+        if (includeEverythingMode) {
+            response = enrichWithIsbnEditionDetails(response, queryValue);
+            response = enrichWithWorkDetails(response, queryValue);
+        }
 
         return response
                 .doOnError(e -> LoggingUtils.error(log, e, "Error searching books by {} '{}' from OpenLibrary", queryParamName, queryValue))
@@ -252,7 +258,7 @@ public class OpenLibraryBookDataService {
                 int count = responseNode.get("docs").size();
                 ExternalApiLogger.logApiCallSuccess(log, "OpenLibrary", apiOperation, requestContext, count);
                 return Flux.fromIterable(responseNode.get("docs"))
-                    .map(this::parseOpenLibrarySearchDoc)
+                    .map(docNode -> parseOpenLibrarySearchDoc(docNode, queryValue))
                     .filter(Objects::nonNull);
             });
     }
@@ -295,28 +301,96 @@ public class OpenLibraryBookDataService {
     }
 
     private Book parseOpenLibrarySearchDoc(JsonNode docNode) {
+        return parseOpenLibrarySearchDoc(docNode, null);
+    }
+
+    private Book parseOpenLibrarySearchDoc(JsonNode docNode, String queryValue) {
         if (docNode == null || docNode.isMissingNode() || !docNode.isObject()) {
             return null;
         }
 
+        String queryIsbn13Identity = IsbnUtils.isbn13Identity(queryValue);
+        boolean exactIsbnMatch = docContainsIsbnIdentity(docNode, queryIsbn13Identity);
         Book book = new Book();
         book.setId(extractOpenLibraryId(docNode));
         book.setTitle(TextUtils.normalizeBookTitle(emptyToNull(docNode.path("title").asString())));
         book.setAuthors(extractSearchAuthors(docNode));
         book.setDescription(extractSearchDescription(docNode));
-        book.setPublisher(extractSearchPublisher(docNode));
-        book.setLanguage(extractSearchLanguage(docNode));
         book.setCategories(extractSearchCategories(docNode));
-        extractSearchPageCount(docNode, book);
-        extractSearchIsbns(docNode, book);
-        extractSearchPublishedDate(docNode, book);
-        extractSearchCover(docNode, book);
+        extractSearchIsbns(docNode, book, queryIsbn13Identity);
+        if (!exactIsbnMatch) {
+            book.setPublisher(extractSearchPublisher(docNode));
+            book.setLanguage(extractSearchLanguage(docNode));
+            extractSearchPageCount(docNode, book);
+            extractSearchPublishedDate(docNode, book);
+            extractSearchCover(docNode, book);
+        }
         book.setRawJsonResponse(docNode.toString());
 
         if (book.getId() != null && book.getTitle() != null) {
             return book;
         }
         return null;
+    }
+
+    private Flux<Book> enrichWithIsbnEditionDetails(Flux<Book> books, String queryValue) {
+        String queryIsbn13Identity = IsbnUtils.isbn13Identity(queryValue);
+        if (!StringUtils.hasText(queryIsbn13Identity)) {
+            return books;
+        }
+        String isbnLookupKey = isbnLookupKey(queryValue, queryIsbn13Identity);
+        return books.flatMapSequential(book -> {
+            if (!bookMatchesIsbnIdentity(book, queryIsbn13Identity)) {
+                return Mono.just(book);
+            }
+            return fetchIsbnEditionDetails(book, isbnLookupKey, queryIsbn13Identity);
+        }, WORK_DETAILS_CONCURRENCY);
+    }
+
+    private Mono<Book> fetchIsbnEditionDetails(Book book, String isbnLookupKey, String queryIsbn13Identity) {
+        String bibKey = "ISBN:" + isbnLookupKey;
+        return webClient.get()
+            .uri(uriBuilder -> uriBuilder.path("/api/books")
+                .queryParam("bibkeys", bibKey)
+                .queryParam("format", "json")
+                .queryParam("jscmd", "details")
+                .build())
+            .retrieve()
+            .bodyToMono(JsonNode.class)
+            .timeout(ISBN_EDITION_DETAILS_TIMEOUT)
+            .map(responseNode -> mergeIsbnEditionDetails(book, responseNode, bibKey, queryIsbn13Identity))
+            .onErrorResume(ex -> {
+                LoggingUtils.warn(
+                    log,
+                    ex,
+                    "OpenLibrary ISBN edition lookup failed for ISBN '{}' and work '{}'; using unambiguous search fields only",
+                    isbnLookupKey,
+                    book.getId()
+                );
+                return Mono.just(book);
+            });
+    }
+
+    private Book mergeIsbnEditionDetails(Book book, JsonNode responseNode, String bibKey, String queryIsbn13Identity) {
+        if (book == null || responseNode == null || responseNode.isMissingNode() || !responseNode.isObject()) {
+            return book;
+        }
+        JsonNode editionNode = responseNode.path(bibKey);
+        if (editionNode.isMissingNode() || !editionNode.isObject()) {
+            return book;
+        }
+        JsonNode detailsNode = editionNode.path("details");
+        if (detailsNode.isMissingNode() || !detailsNode.isObject()) {
+            return book;
+        }
+
+        assignIsbnEditionIdentifiers(detailsNode, book, queryIsbn13Identity);
+        assignIsbnEditionPublisher(detailsNode, book);
+        assignIsbnEditionLanguage(detailsNode, book);
+        assignIsbnEditionPageCount(detailsNode, book);
+        assignIsbnEditionPublishedDate(detailsNode, book);
+        assignIsbnEditionCover(detailsNode, book);
+        return book;
     }
 
     private Flux<Book> enrichWithWorkDetails(Flux<Book> books, String queryValue) {
@@ -390,7 +464,7 @@ public class OpenLibraryBookDataService {
         return authors.isEmpty() ? List.of() : authors;
     }
 
-    private static void extractSearchIsbns(JsonNode docNode, Book book) {
+    private static void extractSearchIsbns(JsonNode docNode, Book book, String preferredIsbn13Identity) {
         if (!docNode.has("isbn") || !docNode.get("isbn").isArray()) {
             return;
         }
@@ -399,8 +473,17 @@ public class OpenLibraryBookDataService {
             String sanitized = IsbnUtils.sanitize(emptyToNull(isbnNode.asString()));
             if (sanitized != null) {
                 sanitizedIsbns.add(sanitized);
-                classifyIsbn(sanitized, book);
             }
+        }
+        if (StringUtils.hasText(preferredIsbn13Identity) && sanitizedIsbns.stream()
+            .map(IsbnUtils::isbn13Identity)
+            .anyMatch(preferredIsbn13Identity::equals)) {
+            book.setIsbn13(preferredIsbn13Identity);
+            book.setIsbn10(IsbnUtils.toIsbn10(preferredIsbn13Identity));
+            return;
+        }
+        for (String sanitized : sanitizedIsbns) {
+            classifyIsbn(sanitized, book);
         }
         if (book.getIsbn13() == null && book.getIsbn10() == null) {
             assignFirstMatchingIsbns(sanitizedIsbns, book);
@@ -422,6 +505,141 @@ public class OpenLibraryBookDataService {
         for (String isbn : isbns) {
             if (isbn.length() == IsbnUtils.ISBN_10_LENGTH) { book.setIsbn10(isbn); break; }
         }
+    }
+
+    private static void assignIsbnEditionIdentifiers(JsonNode detailsNode, Book book, String queryIsbn13Identity) {
+        if (StringUtils.hasText(queryIsbn13Identity)) {
+            book.setIsbn13(queryIsbn13Identity);
+            book.setIsbn10(IsbnUtils.toIsbn10(queryIsbn13Identity));
+            return;
+        }
+
+        String isbn13 = firstSanitizedArrayValue(detailsNode, "isbn_13", IsbnUtils.ISBN_13_LENGTH);
+        if (StringUtils.hasText(isbn13)) {
+            book.setIsbn13(isbn13);
+        }
+        String isbn10 = firstSanitizedArrayValue(detailsNode, "isbn_10", IsbnUtils.ISBN_10_LENGTH);
+        if (StringUtils.hasText(isbn10)) {
+            book.setIsbn10(isbn10);
+        }
+    }
+
+    private static void assignIsbnEditionPublisher(JsonNode detailsNode, Book book) {
+        String publisher = firstArrayText(detailsNode, "publishers");
+        if (StringUtils.hasText(publisher)) {
+            book.setPublisher(publisher);
+        }
+    }
+
+    private static void assignIsbnEditionLanguage(JsonNode detailsNode, Book book) {
+        JsonNode languagesNode = detailsNode.path("languages");
+        if (languagesNode.isMissingNode() || !languagesNode.isArray()) {
+            return;
+        }
+        for (JsonNode languageNode : languagesNode) {
+            String languageKey = emptyToNull(languageNode.path("key").asString());
+            if (!StringUtils.hasText(languageKey)) {
+                continue;
+            }
+            int slashIndex = languageKey.lastIndexOf('/');
+            String language = slashIndex >= 0 ? languageKey.substring(slashIndex + 1) : languageKey;
+            if (StringUtils.hasText(language)) {
+                book.setLanguage(language);
+                return;
+            }
+        }
+    }
+
+    private static void assignIsbnEditionPageCount(JsonNode detailsNode, Book book) {
+        if (!detailsNode.has("number_of_pages") || detailsNode.path("number_of_pages").isNull()) {
+            return;
+        }
+        int pageCount = detailsNode.path("number_of_pages").asInt(0);
+        if (pageCount > 0) {
+            book.setPageCount(pageCount);
+        }
+    }
+
+    private static void assignIsbnEditionPublishedDate(JsonNode detailsNode, Book book) {
+        String publishedDate = emptyToNull(detailsNode.path("publish_date").asString());
+        Date parsedDate = DateParsingUtils.parseFlexibleDate(publishedDate);
+        if (parsedDate != null) {
+            book.setPublishedDate(parsedDate);
+        }
+    }
+
+    private static void assignIsbnEditionCover(JsonNode detailsNode, Book book) {
+        JsonNode coversNode = detailsNode.path("covers");
+        if (coversNode.isMissingNode() || !coversNode.isArray()) {
+            return;
+        }
+        for (JsonNode coverNode : coversNode) {
+            String coverId = emptyToNull(coverNode.asString());
+            if (StringUtils.hasText(coverId)) {
+                String coverUrl = "https://covers.openlibrary.org/b/id/" + coverId + "-L.jpg";
+                book.setExternalImageUrl(coverUrl);
+                book.setCoverImages(new CoverImages(coverUrl, coverUrl, CoverImageSource.OPEN_LIBRARY));
+                return;
+            }
+        }
+    }
+
+    private static String firstSanitizedArrayValue(JsonNode detailsNode, String fieldName, int expectedLength) {
+        JsonNode valuesNode = detailsNode.path(fieldName);
+        if (valuesNode.isMissingNode() || !valuesNode.isArray()) {
+            return null;
+        }
+        for (JsonNode valueNode : valuesNode) {
+            String sanitized = IsbnUtils.sanitize(emptyToNull(valueNode.asString()));
+            if (sanitized != null && sanitized.length() == expectedLength) {
+                return sanitized;
+            }
+        }
+        return null;
+    }
+
+    private static String firstArrayText(JsonNode detailsNode, String fieldName) {
+        JsonNode valuesNode = detailsNode.path(fieldName);
+        if (valuesNode.isMissingNode() || !valuesNode.isArray()) {
+            return null;
+        }
+        for (JsonNode valueNode : valuesNode) {
+            String value = emptyToNull(valueNode.asString());
+            if (StringUtils.hasText(value)) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private static boolean docContainsIsbnIdentity(JsonNode docNode, String isbn13Identity) {
+        if (!StringUtils.hasText(isbn13Identity) || !docNode.has("isbn") || !docNode.get("isbn").isArray()) {
+            return false;
+        }
+        for (JsonNode isbnNode : docNode.get("isbn")) {
+            if (isbn13Identity.equals(IsbnUtils.isbn13Identity(isbnNode.asString()))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean bookMatchesIsbnIdentity(Book book, String isbn13Identity) {
+        if (book == null || !StringUtils.hasText(isbn13Identity)) {
+            return false;
+        }
+        return isbn13Identity.equals(IsbnUtils.isbn13Identity(book.getIsbn13()))
+            || isbn13Identity.equals(IsbnUtils.isbn13Identity(book.getIsbn10()));
+    }
+
+    private static String isbnLookupKey(String queryValue, String queryIsbn13Identity) {
+        String sanitizedQuery = IsbnUtils.sanitize(queryValue);
+        if (StringUtils.hasText(sanitizedQuery)
+            && (sanitizedQuery.length() == IsbnUtils.ISBN_10_LENGTH
+                || sanitizedQuery.length() == IsbnUtils.ISBN_13_LENGTH)) {
+            return sanitizedQuery;
+        }
+        return queryIsbn13Identity;
     }
 
     private static void extractSearchCover(JsonNode docNode, Book book) {

--- a/src/main/java/net/findmybook/service/SearchPaginationService.java
+++ b/src/main/java/net/findmybook/service/SearchPaginationService.java
@@ -127,6 +127,7 @@ public class SearchPaginationService {
                 request.orderBy(),
                 request.coverSource(),
                 request.resolutionPreference(),
+                request.publishedYear(),
                 list,
                 window
             ))
@@ -217,17 +218,22 @@ public class SearchPaginationService {
 
     private int projectedUniqueCount(List<Book> existingResults, List<Book> fallbackCandidates) {
         Set<String> projectedKeys = ConcurrentHashMap.newKeySet();
+        int uniqueCount = 0;
         if (existingResults != null) {
             for (Book existing : existingResults) {
-                CandidateKeyResolver.resolve(existing).ifPresent(projectedKeys::add);
+                if (registerCandidateAliases(projectedKeys, existing)) {
+                    uniqueCount++;
+                }
             }
         }
         if (fallbackCandidates != null) {
             for (Book candidate : fallbackCandidates) {
-                CandidateKeyResolver.resolve(candidate).ifPresent(projectedKeys::add);
+                if (registerCandidateAliases(projectedKeys, candidate)) {
+                    uniqueCount++;
+                }
             }
         }
-        return projectedKeys.size();
+        return uniqueCount;
     }
 
     private Flux<Book> streamOpenLibraryCandidates(SearchRequest request, int startIndex, int maxResults) {
@@ -249,9 +255,7 @@ public class SearchPaginationService {
             .filter(Objects::nonNull)
             .map(SearchExternalProviderUtils::tagOpenLibraryFallback)
             .filter(book -> SearchExternalProviderUtils.matchesPublishedYear(book, request.publishedYear()))
-            .filter(book -> CandidateKeyResolver.resolve(book)
-                .filter(seenKeys::add)
-                .isPresent())
+            .filter(book -> registerCandidateAliases(seenKeys, book))
             .take(maxResults);
     }
 
@@ -286,6 +290,7 @@ public class SearchPaginationService {
             request.orderBy(),
             request.coverSource(),
             request.resolutionPreference(),
+            request.publishedYear(),
             deduplicateCandidates(mergedCandidates),
             window
         );
@@ -296,12 +301,17 @@ public class SearchPaginationService {
             return List.of();
         }
         Map<String, Book> uniqueCandidates = new LinkedHashMap<>();
+        Set<String> seenAliases = ConcurrentHashMap.newKeySet();
         for (Book candidate : fallbackBooks) {
             if (candidate == null) {
                 continue;
             }
-            CandidateKeyResolver.resolve(candidate)
-                .ifPresent(key -> uniqueCandidates.putIfAbsent(key, candidate));
+            List<String> aliases = CandidateKeyResolver.resolveAliases(candidate);
+            if (aliases.isEmpty() || aliases.stream().anyMatch(seenAliases::contains)) {
+                continue;
+            }
+            seenAliases.addAll(aliases);
+            uniqueCandidates.put(aliases.getFirst(), candidate);
         }
         return List.copyOf(uniqueCandidates.values());
     }
@@ -313,20 +323,26 @@ public class SearchPaginationService {
         Set<String> existingKeys = ConcurrentHashMap.newKeySet();
         if (existingResults != null) {
             for (Book existing : existingResults) {
-                CandidateKeyResolver.resolve(existing).ifPresent(existingKeys::add);
+                existingKeys.addAll(CandidateKeyResolver.resolveAliases(existing));
             }
         }
 
         List<Book> netNew = new ArrayList<>();
         for (Book candidate : candidates) {
-            CandidateKeyResolver.resolve(candidate)
-                .filter(key -> !existingKeys.contains(key))
-                .ifPresent(key -> {
-                    existingKeys.add(key);
-                    netNew.add(candidate);
-                });
+            if (registerCandidateAliases(existingKeys, candidate)) {
+                netNew.add(candidate);
+            }
         }
         return List.copyOf(netNew);
+    }
+
+    private boolean registerCandidateAliases(Set<String> seenAliases, Book candidate) {
+        List<String> aliases = CandidateKeyResolver.resolveAliases(candidate);
+        if (aliases.isEmpty() || aliases.stream().anyMatch(seenAliases::contains)) {
+            return false;
+        }
+        seenAliases.addAll(aliases);
+        return true;
     }
 
     private boolean hasCoverGap(SearchPage page, int pageSize) {
@@ -524,6 +540,7 @@ public class SearchPaginationService {
      * @param orderBy normalized ordering key applied by the assembler
      * @param coverSource effective cover source filter applied by the assembler
      * @param resolutionPreference effective resolution preference applied by the assembler
+     * @param publishedYear optional publication-year filter applied to the page
      */
     public record SearchPage(String query,
                              int startIndex,
@@ -537,6 +554,37 @@ public class SearchPaginationService {
                              int prefetchedCount,
                              String orderBy,
                              CoverImageSource coverSource,
-                             ImageResolutionPreference resolutionPreference) {
+                             ImageResolutionPreference resolutionPreference,
+                             Integer publishedYear) {
+        public SearchPage(String query,
+                          int startIndex,
+                          int maxResults,
+                          int totalRequested,
+                          int totalUnique,
+                          List<Book> pageItems,
+                          List<Book> uniqueResults,
+                          boolean hasMore,
+                          int nextStartIndex,
+                          int prefetchedCount,
+                          String orderBy,
+                          CoverImageSource coverSource,
+                          ImageResolutionPreference resolutionPreference) {
+            this(
+                query,
+                startIndex,
+                maxResults,
+                totalRequested,
+                totalUnique,
+                pageItems,
+                uniqueResults,
+                hasMore,
+                nextStartIndex,
+                prefetchedCount,
+                orderBy,
+                coverSource,
+                resolutionPreference,
+                null
+            );
+        }
     }
 }

--- a/src/main/java/net/findmybook/service/SearchRealtimeCoordinator.java
+++ b/src/main/java/net/findmybook/service/SearchRealtimeCoordinator.java
@@ -76,11 +76,17 @@ final class SearchRealtimeCoordinator {
             return;
         }
 
-        String queryHash = SearchQueryUtils.topicKey(request.query());
-        String signature = realtimeSignature(request);
+        String queryHash = SearchQueryUtils.topicKey(
+            request.query(),
+            request.orderBy(),
+            request.coverSource().name(),
+            request.resolutionPreference().name(),
+            request.publishedYear(),
+            request.maxResults()
+        );
         SearchRealtimeState state = realtimeStates.get(queryHash, unused -> new SearchRealtimeState());
 
-        if (!state.tryAcquireAndPrepare(signature, page.totalUnique(), page.uniqueResults())) {
+        if (!state.tryAcquireAndPrepare(page.totalUnique(), page.uniqueResults())) {
             return;
         }
 
@@ -199,20 +205,6 @@ final class SearchRealtimeCoordinator {
         eventPublisher.get().publishEvent(new SearchResultsUpdatedEvent(searchQuery, newResults, source, totalResultsNow, queryHash, isComplete));
     }
 
-    private String realtimeSignature(SearchPaginationService.SearchRequest request) {
-        String source = request.coverSource() != null ? request.coverSource().name() : "ANY";
-        String resolution = request.resolutionPreference() != null ? request.resolutionPreference().name() : "ANY";
-        return request.query()
-            + "|"
-            + Optional.ofNullable(request.orderBy()).orElse("relevance")
-            + "|"
-            + source
-            + "|"
-            + resolution
-            + "|"
-            + Optional.ofNullable(request.publishedYear()).map(String::valueOf).orElse("-");
-    }
-
     private static SearchProgressEvent.SearchStatus classifyProviderError(Throwable ex) {
         if (ex instanceof WebClientResponseException webEx
             && webEx.getStatusCode().value() == HttpStatus.TOO_MANY_REQUESTS.value()) {
@@ -243,28 +235,30 @@ final class SearchRealtimeCoordinator {
         private final Set<String> emittedKeys = ConcurrentHashMap.newKeySet();
         private final AtomicBoolean streaming = new AtomicBoolean(false);
         private final AtomicInteger totalResults = new AtomicInteger(0);
-        private volatile String signature = "";
 
-        synchronized boolean tryAcquireAndPrepare(String newSignature, int baselineTotal, List<Book> existingResults) {
-            if (!Objects.equals(signature, newSignature)) {
-                emittedKeys.clear();
-                signature = newSignature;
+        synchronized boolean tryAcquireAndPrepare(int baselineTotal, List<Book> existingResults) {
+            if (!streaming.compareAndSet(false, true)) {
+                return false;
             }
+            emittedKeys.clear();
             totalResults.set(Math.max(0, baselineTotal));
 
             if (existingResults != null) {
                 for (Book existing : existingResults) {
-                    CandidateKeyResolver.resolve(existing).ifPresent(emittedKeys::add);
+                    emittedKeys.addAll(CandidateKeyResolver.resolveAliases(existing));
                 }
             }
 
-            return streaming.compareAndSet(false, true);
+            return true;
         }
 
         boolean registerCandidate(Book candidate) {
-            return CandidateKeyResolver.resolve(candidate)
-                .filter(emittedKeys::add)
-                .isPresent();
+            List<String> aliases = CandidateKeyResolver.resolveAliases(candidate);
+            if (aliases.isEmpty() || aliases.stream().anyMatch(emittedKeys::contains)) {
+                return false;
+            }
+            emittedKeys.addAll(aliases);
+            return true;
         }
 
         void markIdle() {

--- a/src/main/java/net/findmybook/support/s3/S3CoverUrlSupport.java
+++ b/src/main/java/net/findmybook/support/s3/S3CoverUrlSupport.java
@@ -12,11 +12,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 /**
  * Builds CDN URLs and materializes S3-backed image details from storage keys.
  */
 @Component
+@EnableConfigurationProperties(S3CoverStorageProperties.class)
 public class S3CoverUrlSupport {
 
     private static final Logger logger = LoggerFactory.getLogger(S3CoverUrlSupport.class);
@@ -25,15 +27,18 @@ public class S3CoverUrlSupport {
     private final String s3PublicCdnUrl;
     private final String s3ServerUrl;
     private final String s3BucketName;
+    private final S3CoverStorageProperties s3CoverStorageProperties;
 
     public S3CoverUrlSupport(@Value("${s3.cdn-url}") String s3CdnUrl,
                              @Value("${s3.public-cdn-url:${S3_PUBLIC_CDN_URL:}}") String s3PublicCdnUrl,
                              @Value("${s3.server-url:https://sfo3.digitaloceanspaces.com}") String s3ServerUrl,
-                             @Value("${s3.bucket-name}") String s3BucketName) {
+                             @Value("${s3.bucket-name}") String s3BucketName,
+                             S3CoverStorageProperties s3CoverStorageProperties) {
         this.s3CdnUrl = s3CdnUrl;
         this.s3PublicCdnUrl = s3PublicCdnUrl;
         this.s3ServerUrl = s3ServerUrl;
         this.s3BucketName = s3BucketName;
+        this.s3CoverStorageProperties = s3CoverStorageProperties;
     }
 
     /**
@@ -41,7 +46,7 @@ public class S3CoverUrlSupport {
      */
     @PostConstruct
     void configureResolver() {
-        resolveCdnBase().ifPresent(CoverUrlResolver::setCdnBase);
+        CoverUrlResolver.setCdnBase(resolveCdnBase().orElse(null));
     }
 
     /**
@@ -77,6 +82,10 @@ public class S3CoverUrlSupport {
      * Builds the externally accessible CDN URL for a storage key.
      */
     public Optional<String> buildCdnUrl(String s3Key) {
+        if (!s3CoverStorageProperties.enabled()) {
+            logger.warn("S3 cover storage is disabled; unable to build S3 cover URL for key {}", s3Key);
+            return Optional.empty();
+        }
         return resolveCdnBase()
             .map(base -> appendPath(base, s3Key))
             .or(() -> {
@@ -86,6 +95,9 @@ public class S3CoverUrlSupport {
     }
 
     private Optional<String> resolveCdnBase() {
+        if (!s3CoverStorageProperties.enabled()) {
+            return Optional.empty();
+        }
         if (StringUtils.hasText(s3PublicCdnUrl)) {
             return Optional.of(normalizeBase(s3PublicCdnUrl));
         }

--- a/src/main/java/net/findmybook/support/search/CandidateKeyResolver.java
+++ b/src/main/java/net/findmybook/support/search/CandidateKeyResolver.java
@@ -4,6 +4,8 @@ import net.findmybook.model.Book;
 import net.findmybook.util.IsbnUtils;
 import org.springframework.util.StringUtils;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -11,10 +13,14 @@ import java.util.regex.Pattern;
 /**
  * Resolves a stable deduplication key for a book search candidate.
  *
- * <p>Keys follow a priority chain: ISBN-13 → ISBN-10 → normalized title+author composite
+ * <p>Keys follow a priority chain: canonical ISBN identity → normalized title+author composite
  * → provider/internal ID. Content keys intentionally outrank IDs so a persisted book and
  * an external fallback row can collapse when providers assign different identifiers to
  * the same work.</p>
+ *
+ * <p>{@link #resolveAliases(Book)} returns every safe content identity for overlap checks. That lets
+ * candidates collapse when one provider supplies ISBN metadata and another only supplies a stable
+ * title/author identity for the same work.</p>
  *
  * <p>Rows that lack both ISBNs and an internal ID and carry only a partial title or author
  * do not qualify for a dedupe key: partial keys would collapse distinct works, so such
@@ -22,8 +28,7 @@ import java.util.regex.Pattern;
  */
 public final class CandidateKeyResolver {
 
-    private static final String ISBN13_KEY_PREFIX = "ISBN13:";
-    private static final String ISBN10_KEY_PREFIX = "ISBN10:";
+    private static final String ISBN_KEY_PREFIX = "ISBN:";
     private static final String TITLE_AUTHOR_KEY_PREFIX = "TITLE_AUTHOR:";
     private static final String ID_KEY_PREFIX = "ID:";
     private static final String CONTRIBUTOR_BY_PREFIX = "by ";
@@ -40,32 +45,40 @@ public final class CandidateKeyResolver {
      * @return a stable key string, or empty when the book is null or lacks any usable identifier
      */
     public static Optional<String> resolve(Book book) {
+        List<String> aliases = resolveAliases(book);
+        return aliases.isEmpty() ? Optional.empty() : Optional.of(aliases.getFirst());
+    }
+
+    /**
+     * Computes all safe deduplication identities for the given book.
+     *
+     * @param book the candidate book to key
+     * @return ordered alias keys, or an empty list when no usable identity exists
+     */
+    public static List<String> resolveAliases(Book book) {
         if (book == null) {
-            return Optional.empty();
+            return List.of();
         }
 
-        String isbn13 = IsbnUtils.sanitize(book.getIsbn13());
-        if (StringUtils.hasText(isbn13)) {
-            return Optional.of(ISBN13_KEY_PREFIX + isbn13);
-        }
-
-        String isbn10 = IsbnUtils.sanitize(book.getIsbn10());
-        if (StringUtils.hasText(isbn10)) {
-            return Optional.of(ISBN10_KEY_PREFIX + isbn10);
+        List<String> aliases = new ArrayList<>(2);
+        String isbnIdentity = Optional.ofNullable(IsbnUtils.isbn13Identity(book.getIsbn13()))
+            .orElseGet(() -> IsbnUtils.isbn13Identity(book.getIsbn10()));
+        if (StringUtils.hasText(isbnIdentity)) {
+            aliases.add(ISBN_KEY_PREFIX + isbnIdentity);
         }
 
         String title = normalizeText(book.getTitle());
         String firstAuthor = normalizeAuthor(firstAuthor(book));
         if (StringUtils.hasText(title) && StringUtils.hasText(firstAuthor)) {
-            return Optional.of(TITLE_AUTHOR_KEY_PREFIX + title + "::" + firstAuthor);
+            aliases.add(TITLE_AUTHOR_KEY_PREFIX + title + "::" + firstAuthor);
         }
 
         String id = book.getId();
-        if (StringUtils.hasText(id)) {
-            return Optional.of(ID_KEY_PREFIX + id);
+        if (aliases.isEmpty() && StringUtils.hasText(id)) {
+            aliases.add(ID_KEY_PREFIX + id);
         }
 
-        return Optional.empty();
+        return List.copyOf(aliases);
     }
 
     private static String firstAuthor(Book book) {

--- a/src/main/java/net/findmybook/support/search/SearchPageAssembler.java
+++ b/src/main/java/net/findmybook/support/search/SearchPageAssembler.java
@@ -41,6 +41,7 @@ public final class SearchPageAssembler {
      * @param orderBy ordering key
      * @param coverSource cover source preference
      * @param resolutionPreference image resolution preference
+     * @param publishedYear optional publication-year filter
      * @param rawResults hydrated candidate books
      * @param window paging window descriptor
      * @return immutable page payload for API responses
@@ -49,6 +50,7 @@ public final class SearchPageAssembler {
                                                         String orderBy,
                                                         CoverImageSource coverSource,
                                                         ImageResolutionPreference resolutionPreference,
+                                                        Integer publishedYear,
                                                         List<Book> rawResults,
                                                         PagingUtils.Window window) {
         List<Book> safeRawResults = rawResults == null ? List.of() : rawResults;
@@ -65,14 +67,16 @@ public final class SearchPageAssembler {
 
         LinkedHashMap<String, Book> orderedCandidatesByKey = new LinkedHashMap<>();
         Map<String, Integer> insertionOrder = new LinkedHashMap<>();
+        Set<String> seenCandidateAliases = new HashSet<>();
         int position = 0;
 
         for (Book book : eligibleCandidates) {
-            String resolvedKey = CandidateKeyResolver.resolve(book).orElse(null);
-            if (resolvedKey == null || orderedCandidatesByKey.containsKey(resolvedKey)) {
+            List<String> aliases = CandidateKeyResolver.resolveAliases(book);
+            if (aliases.isEmpty() || aliases.stream().anyMatch(seenCandidateAliases::contains)) {
                 continue;
             }
-            orderedCandidatesByKey.put(resolvedKey, book);
+            orderedCandidatesByKey.put(aliases.getFirst(), book);
+            seenCandidateAliases.addAll(aliases);
             insertionOrder.put(book.getId(), position++);
         }
 
@@ -104,7 +108,8 @@ public final class SearchPageAssembler {
             prefetched,
             Optional.ofNullable(orderBy).orElse("newest"),
             effectiveSource,
-            effectiveResolution
+            effectiveResolution,
+            publishedYear
         );
     }
 

--- a/src/main/java/net/findmybook/util/IsbnUtils.java
+++ b/src/main/java/net/findmybook/util/IsbnUtils.java
@@ -12,6 +12,7 @@ public final class IsbnUtils {
     public static final int ISBN_13_LENGTH = 13;
 
     private static final Pattern NON_ISBN_CHARACTERS = Pattern.compile("[^0-9Xx]");
+    private static final String ISBN_13_BOOK_PREFIX = "978";
 
     private IsbnUtils() {
     }
@@ -54,5 +55,83 @@ public final class IsbnUtils {
         }
         String cleaned = sanitize(isbn);
         return cleaned != null && cleaned.length() == ISBN_10_LENGTH && cleaned.matches("\\d{9}[\\dX]");
+    }
+
+    /**
+     * Converts a syntactically valid ISBN-10 into the equivalent ISBN-13 used for modern book identity.
+     *
+     * @param rawIsbn10 user-provided ISBN-10 input
+     * @return equivalent ISBN-13 value, or {@code null} when the input is not ISBN-10 shaped
+     */
+    public static String toIsbn13(String rawIsbn10) {
+        String cleaned = sanitize(rawIsbn10);
+        if (cleaned == null || cleaned.length() != ISBN_10_LENGTH || !cleaned.matches("\\d{9}[\\dX]")) {
+            return null;
+        }
+        String firstTwelveDigits = ISBN_13_BOOK_PREFIX + cleaned.substring(0, ISBN_10_LENGTH - 1);
+        return firstTwelveDigits + isbn13CheckDigit(firstTwelveDigits);
+    }
+
+    /**
+     * Converts a 978-prefixed ISBN-13 into the equivalent ISBN-10 representation.
+     *
+     * @param rawIsbn13 user-provided ISBN-13 input
+     * @return equivalent ISBN-10 value, or {@code null} when the input cannot be represented as ISBN-10
+     */
+    public static String toIsbn10(String rawIsbn13) {
+        String cleaned = sanitize(rawIsbn13);
+        if (cleaned == null
+            || cleaned.length() != ISBN_13_LENGTH
+            || !cleaned.matches("\\d{13}")
+            || !cleaned.startsWith(ISBN_13_BOOK_PREFIX)) {
+            return null;
+        }
+        String firstNineDigits = cleaned.substring(ISBN_13_BOOK_PREFIX.length(), ISBN_13_LENGTH - 1);
+        return firstNineDigits + isbn10CheckDigit(firstNineDigits);
+    }
+
+    /**
+     * Resolves either ISBN-10 or ISBN-13 input to the ISBN-13 identity key used for matching.
+     *
+     * @param raw user-provided ISBN input
+     * @return ISBN-13 identity value, or {@code null} when no ISBN-13 equivalent can be produced
+     */
+    public static String isbn13Identity(String raw) {
+        String cleaned = sanitize(raw);
+        if (cleaned == null) {
+            return null;
+        }
+        if (cleaned.length() == ISBN_13_LENGTH && cleaned.matches("\\d{13}")) {
+            return cleaned;
+        }
+        if (cleaned.length() == ISBN_10_LENGTH) {
+            return toIsbn13(cleaned);
+        }
+        return null;
+    }
+
+    private static int isbn13CheckDigit(String firstTwelveDigits) {
+        int sum = 0;
+        for (int index = 0; index < firstTwelveDigits.length(); index++) {
+            int digit = Character.digit(firstTwelveDigits.charAt(index), 10);
+            sum += digit * (index % 2 == 0 ? 1 : 3);
+        }
+        return (10 - (sum % 10)) % 10;
+    }
+
+    private static char isbn10CheckDigit(String firstNineDigits) {
+        int sum = 0;
+        for (int index = 0; index < firstNineDigits.length(); index++) {
+            int digit = Character.digit(firstNineDigits.charAt(index), 10);
+            sum += digit * (10 - index);
+        }
+        int remainder = 11 - (sum % 11);
+        if (remainder == 10) {
+            return 'X';
+        }
+        if (remainder == 11) {
+            return '0';
+        }
+        return (char) ('0' + remainder);
     }
 }

--- a/src/main/java/net/findmybook/util/JdbcUtils.java
+++ b/src/main/java/net/findmybook/util/JdbcUtils.java
@@ -39,12 +39,13 @@ public final class JdbcUtils {
     }
 
     /**
-     * Executes the supplied query and returns the first column as an optional string,
-     * invoking the provided failure callback when a {@link DataAccessException} occurs.
+     * Executes the supplied query and returns the first column as an optional string.
+     * Only a no-row result is converted to empty; database failures propagate so callers
+     * cannot confuse outages with missing rows.
      *
      * @param jdbcTemplate the {@link JdbcTemplate} to use; treated as absent when {@code null}
      * @param sql          SQL statement to execute
-     * @param onFailure    callback invoked when a {@link DataAccessException} is thrown (optional)
+     * @param onFailure    callback invoked before propagating non-empty-result data access failures (optional)
      * @param args         positional arguments for the SQL statement
      * @return optional string result
      */
@@ -57,11 +58,13 @@ public final class JdbcUtils {
         }
         try {
             return Optional.ofNullable(jdbcTemplate.queryForObject(sql, String.class, args));
+        } catch (EmptyResultDataAccessException ex) {
+            return Optional.empty();
         } catch (DataAccessException ex) {
             if (onFailure != null) {
                 onFailure.accept(ex);
             }
-            return Optional.empty();
+            throw ex;
         }
     }
 

--- a/src/main/java/net/findmybook/util/SearchQueryUtils.java
+++ b/src/main/java/net/findmybook/util/SearchQueryUtils.java
@@ -96,4 +96,37 @@ public final class SearchQueryUtils {
         }
         return sanitized;
     }
+
+    /**
+     * Generates a stable realtime topic key for a fully-qualified search request.
+     *
+     * <p>Realtime streams are scoped by query and filters so emissions from an older
+     * in-flight request cannot be delivered to a newer filtered search.</p>
+     */
+    public static String topicKey(String query,
+                                  String orderBy,
+                                  String coverSource,
+                                  String resolutionPreference,
+                                  Integer publishedYear,
+                                  int maxResults) {
+        String canonicalQuery = Objects.requireNonNullElse(canonicalize(query), "");
+        String canonical = canonicalQuery
+            + "|order=" + normalizedTopicComponent(orderBy, "relevance")
+            + "|cover=" + normalizedTopicComponent(coverSource, "any")
+            + "|resolution=" + normalizedTopicComponent(resolutionPreference, "any")
+            + "|year=" + (publishedYear != null && publishedYear > 0 ? publishedYear : "any")
+            + "|max=" + Math.max(0, maxResults);
+        String sanitized = TOPIC_KEY_SANITIZER.matcher(canonical).replaceAll("_");
+        if (sanitized.isBlank()) {
+            return "search";
+        }
+        return sanitized;
+    }
+
+    private static String normalizedTopicComponent(String value, String fallback) {
+        if (value == null || value.trim().isEmpty()) {
+            return fallback;
+        }
+        return value.trim().toLowerCase(Locale.ROOT);
+    }
 }

--- a/src/main/java/net/findmybook/util/SlugGenerator.java
+++ b/src/main/java/net/findmybook/util/SlugGenerator.java
@@ -14,6 +14,7 @@ public final class SlugGenerator {
     private static final Pattern WHITESPACE = Pattern.compile("[\\s_]+");
     private static final Pattern EDGE_DASHES = Pattern.compile("^-+|-+$");
     private static final Pattern MULTIPLE_DASHES = Pattern.compile("-{2,}");
+    private static final String FALLBACK_BOOK_SLUG = "book";
 
     private static final int MAX_SLUG_LENGTH = 100;
     private static final int MAX_TITLE_LENGTH = 60;
@@ -40,6 +41,9 @@ public final class SlugGenerator {
 
         // Process title
         String titleSlug = slugify(title);
+        if (titleSlug.isBlank()) {
+            titleSlug = FALLBACK_BOOK_SLUG;
+        }
         if (titleSlug.length() > MAX_TITLE_LENGTH) {
             // Truncate at word boundary
             titleSlug = truncateAtWordBoundary(titleSlug, MAX_TITLE_LENGTH);
@@ -51,10 +55,12 @@ public final class SlugGenerator {
             String firstAuthor = authors.get(0);
             if (firstAuthor != null && !firstAuthor.trim().isEmpty()) {
                 String authorSlug = slugify(firstAuthor);
-                if (authorSlug.length() > MAX_AUTHOR_LENGTH) {
+                if (!authorSlug.isBlank() && authorSlug.length() > MAX_AUTHOR_LENGTH) {
                     authorSlug = truncateAtWordBoundary(authorSlug, MAX_AUTHOR_LENGTH);
                 }
-                slugBuilder.append("-").append(authorSlug);
+                if (!authorSlug.isBlank()) {
+                    slugBuilder.append("-").append(authorSlug);
+                }
             }
         }
 
@@ -63,6 +69,10 @@ public final class SlugGenerator {
         // Ensure final slug doesn't exceed max length
         if (finalSlug.length() > MAX_SLUG_LENGTH) {
             finalSlug = truncateAtWordBoundary(finalSlug, MAX_SLUG_LENGTH);
+        }
+
+        if (finalSlug.isBlank()) {
+            return FALLBACK_BOOK_SLUG;
         }
 
         return finalSlug;
@@ -100,7 +110,6 @@ public final class SlugGenerator {
 
         // Replace common contractions and special cases
         slug = slug.replace("&", "and");
-        slug = slug.replace("'", "");
         slug = slug.replace("'", "");
         // Remove left and right typographic double quotes
         slug = slug.replace("\u201C", "");

--- a/src/main/java/net/findmybook/util/cover/CoverQuality.java
+++ b/src/main/java/net/findmybook/util/cover/CoverQuality.java
@@ -31,17 +31,21 @@ public final class CoverQuality {
      * @return quality tier between 0 and 5 inclusive
      */
     public static int rank(RankingContext context) {
-        boolean hasS3 = isRenderable(context.s3Path());
-        boolean hasExternal = isRenderable(context.externalUrl());
-        if (!hasS3 && !hasExternal) {
-            return 0;
-        }
-        String preferred = hasS3 ? context.s3Path() : context.externalUrl();
-        return rankFromUrl(new UrlRankingContext(
-            preferred,
+        CoverUrlResolver.ResolvedCover resolved = CoverUrlResolver.resolve(
+            context.s3Path(),
+            context.externalUrl(),
             context.width(),
             context.height(),
-            context.highResolution(),
+            context.highResolution()
+        );
+        if (!isRenderable(resolved.url())) {
+            return 0;
+        }
+        return rankFromUrl(new UrlRankingContext(
+            resolved.url(),
+            resolved.width(),
+            resolved.height(),
+            resolved.highResolution(),
             context.grayscale()
         ));
     }
@@ -91,6 +95,23 @@ public final class CoverQuality {
             return 0;
         }
 
+        if (isStorageKey(url)) {
+            CoverUrlResolver.ResolvedCover resolved = CoverUrlResolver.resolve(url);
+            if (!resolved.fromS3()) {
+                return 0;
+            }
+            Integer width = context.width() != null ? context.width() : resolved.width();
+            Integer height = context.height() != null ? context.height() : resolved.height();
+            Boolean highResolution = context.highResolution() != null ? context.highResolution() : resolved.highResolution();
+            return rankFromUrl(new UrlRankingContext(
+                resolved.url(),
+                width,
+                height,
+                highResolution,
+                context.grayscale()
+            ));
+        }
+
         if (!CoverUrlValidator.isLikelyCoverImage(url)) {
             return 0;
         }
@@ -103,8 +124,7 @@ public final class CoverQuality {
             return 1;
         }
 
-        boolean fromS3 = url != null && !(url.startsWith("http://") || url.startsWith("https://"));
-        boolean hasCdn = fromS3 || CoverUrlResolver.isCdnUrl(url);
+        boolean hasCdn = CoverUrlResolver.isCdnUrl(url);
         boolean resolvedHighRes = Boolean.TRUE.equals(context.highResolution())
             || ImageDimensionUtils.isHighResolution(context.width(), context.height());
         boolean meetsDisplay = ImageDimensionUtils.meetsSearchDisplayThreshold(context.width(), context.height());
@@ -179,5 +199,12 @@ public final class CoverQuality {
         return StringUtils.hasText(url)
             && !CoverUrlResolver.isNullEquivalent(url)
             && !normalized.contains("placeholder-book-cover.svg");
+    }
+
+    private static boolean isStorageKey(String url) {
+        return StringUtils.hasText(url)
+            && !url.regionMatches(true, 0, "http://", 0, 7)
+            && !url.regionMatches(true, 0, "https://", 0, 8)
+            && !url.startsWith("data:image");
     }
 }

--- a/src/main/java/net/findmybook/util/cover/CoverUrlResolver.java
+++ b/src/main/java/net/findmybook/util/cover/CoverUrlResolver.java
@@ -277,6 +277,9 @@ public final class CoverUrlResolver {
     }
 
     private static String resolveCdnBaseFromEnvironment() {
+        if (s3DisabledByEnvironment()) {
+            return "";
+        }
         String configured = System.getProperty("s3.cdn-url");
         if (!StringUtils.hasText(configured)) {
             configured = System.getProperty("S3_CDN_URL");
@@ -292,6 +295,17 @@ public final class CoverUrlResolver {
             return "";
         }
         return trimmed.endsWith("/") ? trimmed : trimmed + "/";
+    }
+
+    private static boolean s3DisabledByEnvironment() {
+        String configured = System.getProperty("s3.enabled");
+        if (!StringUtils.hasText(configured)) {
+            configured = System.getProperty("S3_ENABLED");
+        }
+        if (!StringUtils.hasText(configured)) {
+            configured = System.getenv("S3_ENABLED");
+        }
+        return StringUtils.hasText(configured) && "false".equalsIgnoreCase(configured.trim());
     }
 
     private static String normalizeBase(String value) {

--- a/src/test/java/net/findmybook/application/cover/CoverS3UploadCoordinatorTest.java
+++ b/src/test/java/net/findmybook/application/cover/CoverS3UploadCoordinatorTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -32,6 +33,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.http.HttpHeaders;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 
@@ -364,6 +367,27 @@ class CoverS3UploadCoordinatorTest {
         RuntimeException exception = new RuntimeException(" ", new IllegalStateException("inner-cause-message"));
 
         assertThat(CoverSourceFetcher.summarizeThrowable(exception)).isEqualTo("inner-cause-message");
+    }
+
+    @Test
+    void should_SelectMissingBackfillCandidates_When_PriorImageRowsOnlyContainFailuresOrExternalUrls() {
+        JdbcTemplate candidateJdbcTemplate = Mockito.mock(JdbcTemplate.class);
+        BackfillCandidateQuery candidateQuery = new BackfillCandidateQuery(candidateJdbcTemplate);
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+
+        when(candidateJdbcTemplate.query(
+            sqlCaptor.capture(),
+            org.mockito.ArgumentMatchers.<RowMapper<BackfillCandidate>>any(),
+            eq(25)
+        )).thenReturn(List.of());
+
+        candidateQuery.queryCandidates(BackfillMode.MISSING, 25);
+
+        assertThat(sqlCaptor.getValue())
+            .contains("bil.download_error IS NULL")
+            .contains("bil.s3_image_path IS NOT NULL")
+            .doesNotContain("bil.url IS NOT NULL")
+            .doesNotContain("bil.url <> ''");
     }
 
     private void assertCounterEventuallyEquals(String metricName, double expectedValue) {

--- a/src/test/java/net/findmybook/controller/dto/BookDtoMapperTest.java
+++ b/src/test/java/net/findmybook/controller/dto/BookDtoMapperTest.java
@@ -135,6 +135,30 @@ class BookDtoMapperTest {
     }
 
     @Test
+    void should_UseExternalCover_When_S3KeyExistsButCdnIsDisabled() {
+        CoverUrlResolver.setCdnBase(null);
+        try {
+            Book book = new Book();
+            book.setId("s3-disabled");
+            book.setTitle("S3 Disabled");
+            book.setAuthors(List.of("Author"));
+            book.setS3ImagePath("images/book-covers/s3-disabled.jpg");
+            book.setExternalImageUrl("https://covers.openlibrary.org/b/id/123-L.jpg");
+            book.setCoverImageWidth(600);
+            book.setCoverImageHeight(900);
+            book.setIsCoverHighResolution(true);
+
+            BookDto dto = BookDtoMapper.toDto(book);
+
+            assertThat(dto.cover().preferredUrl()).isEqualTo("https://covers.openlibrary.org/b/id/123-L.jpg");
+            assertThat(dto.cover().s3ImagePath()).isNull();
+            assertThat(dto.cover().source()).isEqualTo(CoverImageSource.OPEN_LIBRARY.name());
+        } finally {
+            CoverUrlResolver.setCdnBase(null);
+        }
+    }
+
+    @Test
     void should_SanitizeUnsafeHtml_When_DescriptionContainsScriptTag() {
         Book book = new Book();
         book.setId("unsafe-html");

--- a/src/test/java/net/findmybook/mapper/GoogleBooksMapperTest.java
+++ b/src/test/java/net/findmybook/mapper/GoogleBooksMapperTest.java
@@ -97,6 +97,21 @@ class GoogleBooksMapperTest {
         assertThat(aggregate).isNull();
     }
 
+    @Test
+    void map_usesFallbackSlugBase_When_TitleCannotBeLatinSlugified() {
+        var volume = objectMapper.createObjectNode();
+        volume.put("id", "non-latin-fixture");
+        var volumeInfo = volume.putObject("volumeInfo");
+        volumeInfo.put("title", "你好");
+        var authors = volumeInfo.putArray("authors");
+        authors.add("Jane Writer");
+
+        BookAggregate aggregate = mapper.map(volume);
+
+        assertThat(aggregate).isNotNull();
+        assertThat(aggregate.getSlugBase()).isEqualTo("book-jane-writer");
+    }
+
     private JsonNode loadFixture(String path) {
         try (InputStream stream = getClass().getResourceAsStream(path)) {
             if (stream == null) {

--- a/src/test/java/net/findmybook/scheduler/SitemapRefreshSchedulerTest.java
+++ b/src/test/java/net/findmybook/scheduler/SitemapRefreshSchedulerTest.java
@@ -203,6 +203,36 @@ class NewYorkTimesBestsellerSchedulerTest {
     }
 
     @Test
+    void processNewYorkTimesBestsellers_shouldFailList_When_CollectionUpsertReturnsEmpty() throws Exception {
+        JsonNode overview = objectMapper.readTree(
+            """
+            {
+              "results": {
+                "published_date": "2026-02-08",
+                "lists": [
+                  {
+                    "list_name_encoded": "hardcover-fiction",
+                    "updated": "WEEKLY",
+                    "books": []
+                  }
+                ]
+              }
+            }
+            """
+        );
+        when(newYorkTimesService.fetchBestsellerListOverview(nullable(LocalDate.class))).thenReturn(Mono.just(overview));
+        when(collectionPersistenceService.upsertBestsellerCollection(
+            any(BookCollectionPersistenceService.BestsellerCollectionDto.class)
+        )).thenReturn(Optional.empty());
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class,
+            () -> scheduler.processNewYorkTimesBestsellers());
+
+        assertThat(thrown.getMessage()).contains("1 of 1 list(s) failed");
+        verifyNoInteractions(bookLookupService, supplementalPersistenceService, bookUpsertService);
+    }
+
+    @Test
     void processNewYorkTimesBestsellers_shouldProcessAllListsThenThrow_WhenOneListFails() throws Exception {
         JsonNode overview = objectMapper.readTree(
             """

--- a/src/test/java/net/findmybook/service/BookCollectionPersistenceServiceTest.java
+++ b/src/test/java/net/findmybook/service/BookCollectionPersistenceServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 
@@ -17,6 +18,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.startsWith;
@@ -117,6 +119,32 @@ class BookCollectionPersistenceServiceTest {
     }
 
     @Test
+    void should_PropagateBestsellerCollectionFailure_When_DatabaseWriteFails() {
+        when(jdbcTemplate.queryForObject(
+            anyString(),
+            org.mockito.ArgumentMatchers.<RowMapper<String>>any(),
+            any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+        )).thenThrow(new DataAccessResourceFailureException("database unavailable"));
+
+        BookCollectionPersistenceService.BestsellerCollectionDto dto = new BookCollectionPersistenceService.BestsellerCollectionDto(
+            "nyt-nonfiction-2024-40",
+            "hardcover-nonfiction",
+            "NYT Hardcover Nonfiction",
+            "hardcover-nonfiction",
+            "Latest weekly update",
+            LocalDate.of(2024, 9, 15),
+            LocalDate.of(2024, 9, 22),
+            "WEEKLY",
+            objectMapper.createObjectNode()
+        );
+
+        assertThatThrownBy(() -> service.upsertBestsellerCollection(dto))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Failed upserting NYT bestseller collection")
+            .hasRootCauseMessage("database unavailable");
+    }
+
+    @Test
     void upsertBestsellerMembership_usesIdempotentConflictKey_WhenPersistingDuplicateRows() {
         BookCollectionPersistenceService.BestsellerMembershipDto dto = new BookCollectionPersistenceService.BestsellerMembershipDto(
             "collection-1",
@@ -143,5 +171,30 @@ class BookCollectionPersistenceServiceTest {
             any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
         );
         assertThat(sqlCaptor.getValue()).contains("ON CONFLICT (collection_id, book_id) DO UPDATE");
+    }
+
+    @Test
+    void should_PropagateBestsellerMembershipFailure_When_DatabaseWriteFails() {
+        BookCollectionPersistenceService.BestsellerMembershipDto dto = new BookCollectionPersistenceService.BestsellerMembershipDto(
+            "collection-1",
+            UUID.randomUUID().toString(),
+            1,
+            10,
+            2,
+            1,
+            "9780316769488",
+            null,
+            "https://amazon.example/item",
+            "{\"title\":\"Example\"}"
+        );
+        when(jdbcTemplate.update(
+            startsWith("UPDATE book_collections_join SET position = NULL"),
+            any(), any(), any()
+        )).thenThrow(new DataAccessResourceFailureException("database unavailable"));
+
+        assertThatThrownBy(() -> service.upsertBestsellerMembership(dto))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Failed persisting NYT bestseller membership")
+            .hasRootCauseMessage("database unavailable");
     }
 }

--- a/src/test/java/net/findmybook/service/OpenLibraryBookDataServiceParsingTest.java
+++ b/src/test/java/net/findmybook/service/OpenLibraryBookDataServiceParsingTest.java
@@ -1,6 +1,7 @@
 package net.findmybook.service;
 
 import net.findmybook.model.Book;
+import net.findmybook.util.DateParsingUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -43,6 +44,88 @@ class OpenLibraryBookDataServiceParsingTest {
         assertThat(parsed.getPageCount()).isEqualTo(416);
         assertThat(parsed.getPublisher()).isEqualTo("Doubleday");
         assertThat(parsed.getLanguage()).isEqualTo("eng");
+    }
+
+    @Test
+    @DisplayName("parseOpenLibrarySearchDoc prefers queried ISBN and suppresses aggregate edition fields")
+    void parseOpenLibrarySearchDoc_prefersQueriedIsbnAndSuppressesAggregateEditionFields() {
+        OpenLibraryBookDataService service = new OpenLibraryBookDataService(
+            WebClient.builder(),
+            "https://openlibrary.org",
+            true
+        );
+
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode doc = mapper.createObjectNode();
+        doc.put("key", "/works/OL3140822W");
+        doc.put("title", "To Kill a Mockingbird");
+        doc.putArray("author_name").add("Harper Lee");
+        doc.put("first_publish_year", 1960);
+        doc.put("cover_i", 14351077);
+        doc.put("number_of_pages_median", 320);
+        doc.putArray("isbn")
+            .add("0446310786")
+            .add("9780061120084")
+            .add("0061120081");
+        doc.putArray("publisher").add("Sel Yayıncılık");
+        doc.putArray("language").add("tur");
+
+        Book parsed = ReflectionTestUtils.invokeMethod(service, "parseOpenLibrarySearchDoc", doc, "0061120081");
+
+        assertThat(parsed).isNotNull();
+        assertThat(parsed.getIsbn13()).isEqualTo("9780061120084");
+        assertThat(parsed.getIsbn10()).isEqualTo("0061120081");
+        assertThat(parsed.getPublisher()).isNull();
+        assertThat(parsed.getLanguage()).isNull();
+        assertThat(parsed.getPageCount()).isNull();
+        assertThat(parsed.getPublishedDate()).isNull();
+        assertThat(parsed.getExternalImageUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("mergeIsbnEditionDetails uses Open Library edition metadata for exact ISBN results")
+    void mergeIsbnEditionDetails_usesEditionMetadataForExactIsbnResults() {
+        OpenLibraryBookDataService service = new OpenLibraryBookDataService(
+            WebClient.builder(),
+            "https://openlibrary.org",
+            true
+        );
+
+        Book book = new Book();
+        book.setId("OL3140822W");
+        book.setTitle("To Kill a Mockingbird");
+
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode root = mapper.createObjectNode();
+        ObjectNode edition = root.putObject("ISBN:0061120081");
+        ObjectNode details = edition.putObject("details");
+        details.put("publish_date", "2006");
+        details.put("number_of_pages", 323);
+        details.putArray("publishers").add("Harper Perennial Modern Classics");
+        details.putArray("languages").addObject().put("key", "/languages/eng");
+        details.putArray("covers").add(15162569);
+        details.putArray("isbn_10").add("0061120081");
+        details.putArray("isbn_13").add("9780061120084");
+
+        Book merged = ReflectionTestUtils.invokeMethod(
+            service,
+            "mergeIsbnEditionDetails",
+            book,
+            root,
+            "ISBN:0061120081",
+            "9780061120084"
+        );
+
+        assertThat(merged).isNotNull();
+        assertThat(merged.getPublisher()).isEqualTo("Harper Perennial Modern Classics");
+        assertThat(merged.getLanguage()).isEqualTo("eng");
+        assertThat(merged.getPageCount()).isEqualTo(323);
+        assertThat(DateParsingUtils.formatIsoDate(merged.getPublishedDate())).isEqualTo("2006-01-01");
+        assertThat(merged.getExternalImageUrl()).isEqualTo("https://covers.openlibrary.org/b/id/15162569-L.jpg");
+        assertThat(merged.getCoverImages()).isNotNull();
+        assertThat(merged.getCoverImages().getPreferredUrl()).isEqualTo("https://covers.openlibrary.org/b/id/15162569-L.jpg");
+        assertThat(merged.getIsbn13()).isEqualTo("9780061120084");
+        assertThat(merged.getIsbn10()).isEqualTo("0061120081");
     }
 
     @Test

--- a/src/test/java/net/findmybook/service/PersistenceSupportServicesTest.java
+++ b/src/test/java/net/findmybook/service/PersistenceSupportServicesTest.java
@@ -2,12 +2,14 @@ package net.findmybook.service;
 
 import net.findmybook.dto.BookAggregate;
 import net.findmybook.service.image.CoverPersistenceService;
+import net.findmybook.util.JdbcUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.dao.DuplicateKeyException;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.RowMapper;
@@ -194,10 +196,119 @@ class PersistenceSupportServicesTest {
 
         assertThat(existing).contains(existingBookId);
         verify(lockJdbcTemplate).query(
-            eq("SELECT id FROM books WHERE slug = ? LIMIT 1"),
+            org.mockito.ArgumentMatchers.contains("substring(slug from ?)"),
             org.mockito.ArgumentMatchers.<org.springframework.jdbc.core.ResultSetExtractor<UUID>>any(),
+            eq("the-partner-john-grisham"),
+            eq("the-partner-john-grisham-%"),
+            eq("the-partner-john-grisham".length() + 2),
             eq("the-partner-john-grisham")
         );
+    }
+
+    @Test
+    void bookUpsertService_findExistingBookId_matchesEquivalentIsbn13_When_AggregateOnlyHasIsbn10() {
+        JdbcTemplate lockJdbcTemplate = mock(JdbcTemplate.class);
+        BookUpsertTransactionService transactionService = mock(BookUpsertTransactionService.class);
+        BookImageLinkPersistenceService imageLinkPersistenceService = mock(BookImageLinkPersistenceService.class);
+        BookOutboxEventService outboxEventService = mock(BookOutboxEventService.class);
+        UUID existingBookId = UUID.randomUUID();
+        stubAdvisoryLock(lockJdbcTemplate);
+        when(lockJdbcTemplate.query(
+            eq("SELECT id FROM books WHERE isbn10 = ? LIMIT 1"),
+            org.mockito.ArgumentMatchers.<org.springframework.jdbc.core.ResultSetExtractor<UUID>>any(),
+            eq("0306406152")
+        )).thenReturn(null);
+        when(lockJdbcTemplate.query(
+            eq("SELECT id FROM books WHERE isbn13 = ? LIMIT 1"),
+            org.mockito.ArgumentMatchers.<org.springframework.jdbc.core.ResultSetExtractor<UUID>>any(),
+            eq("9780306406157")
+        )).thenReturn(existingBookId);
+
+        BookUpsertService upsertService = new BookUpsertService(
+            lockJdbcTemplate,
+            transactionService,
+            imageLinkPersistenceService,
+            outboxEventService
+        );
+
+        BookAggregate aggregate = BookAggregate.builder()
+            .title("Equivalent ISBN")
+            .isbn10("0-306-40615-2")
+            .slugBase("equivalent-isbn")
+            .build();
+
+        Optional<UUID> existing = ReflectionTestUtils.invokeMethod(upsertService, "findExistingBookId", aggregate);
+
+        assertThat(existing).contains(existingBookId);
+    }
+
+    @Test
+    void bookUpsertService_computeBookLockKey_usesSameIdentityForEquivalentIsbnFormats() {
+        JdbcTemplate lockJdbcTemplate = mock(JdbcTemplate.class);
+        BookUpsertService upsertService = new BookUpsertService(
+            lockJdbcTemplate,
+            mock(BookUpsertTransactionService.class),
+            mock(BookImageLinkPersistenceService.class),
+            mock(BookOutboxEventService.class)
+        );
+        BookAggregate isbn10Aggregate = BookAggregate.builder()
+            .title("ISBN10")
+            .isbn10("0-306-40615-2")
+            .slugBase("isbn10")
+            .build();
+        BookAggregate isbn13Aggregate = BookAggregate.builder()
+            .title("ISBN13")
+            .isbn13("978-0-306-40615-7")
+            .slugBase("isbn13")
+            .build();
+
+        Long isbn10Lock = ReflectionTestUtils.invokeMethod(upsertService, "computeBookLockKey", isbn10Aggregate);
+        Long isbn13Lock = ReflectionTestUtils.invokeMethod(upsertService, "computeBookLockKey", isbn13Aggregate);
+
+        assertThat(isbn10Lock).isEqualTo(isbn13Lock);
+    }
+
+    @Test
+    void jdbcUtils_optionalString_shouldPropagateDataAccessFailures_When_DatabaseIsUnavailable() {
+        JdbcTemplate lookupJdbcTemplate = mock(JdbcTemplate.class);
+        when(lookupJdbcTemplate.queryForObject(
+            eq("SELECT id FROM books WHERE id = ?"),
+            eq(String.class),
+            eq("book-1")
+        )).thenThrow(new DataAccessResourceFailureException("database unavailable"));
+
+        assertThatThrownBy(() -> JdbcUtils.optionalString(
+            lookupJdbcTemplate,
+            "SELECT id FROM books WHERE id = ?",
+            "book-1"
+        ))
+            .isInstanceOf(DataAccessResourceFailureException.class)
+            .hasMessageContaining("database unavailable");
+    }
+
+    @Test
+    void bookLookupService_shouldResolveEquivalentIsbn10_When_LookingUpIsbn13() {
+        JdbcTemplate lookupJdbcTemplate = mock(JdbcTemplate.class);
+        when(lookupJdbcTemplate.queryForObject(
+            eq("SELECT id::text FROM books WHERE isbn13 = ? LIMIT 1"),
+            eq(String.class),
+            eq("9780306406157")
+        )).thenThrow(new EmptyResultDataAccessException(1));
+        when(lookupJdbcTemplate.queryForObject(
+            eq("SELECT book_id FROM book_external_ids WHERE provider_isbn13 = ? LIMIT 1"),
+            eq(String.class),
+            eq("9780306406157")
+        )).thenThrow(new EmptyResultDataAccessException(1));
+        when(lookupJdbcTemplate.queryForObject(
+            eq("SELECT id::text FROM books WHERE isbn10 = ? LIMIT 1"),
+            eq(String.class),
+            eq("0306406152")
+        )).thenReturn("book-1");
+        BookLookupService lookupService = new BookLookupService(lookupJdbcTemplate);
+
+        Optional<String> bookId = lookupService.findBookIdByIsbn("978-0-306-40615-7");
+
+        assertThat(bookId).contains("book-1");
     }
 
     @Test
@@ -245,8 +356,11 @@ class PersistenceSupportServicesTest {
 
     private void stubSlugLookup(JdbcTemplate lockJdbcTemplate, String slug, UUID resultBookId) {
         when(lockJdbcTemplate.query(
-            eq("SELECT id FROM books WHERE slug = ? LIMIT 1"),
+            org.mockito.ArgumentMatchers.contains("substring(slug from ?)"),
             org.mockito.ArgumentMatchers.<org.springframework.jdbc.core.ResultSetExtractor<UUID>>any(),
+            eq(slug),
+            eq(slug + "-%"),
+            eq(slug.length() + 2),
             eq(slug)
         )).thenReturn(resultBookId);
     }

--- a/src/test/java/net/findmybook/service/SearchPaginationServiceFallbackTest.java
+++ b/src/test/java/net/findmybook/service/SearchPaginationServiceFallbackTest.java
@@ -111,6 +111,81 @@ class SearchPaginationServiceFallbackTest extends AbstractSearchPaginationServic
     }
 
     @Test
+    @DisplayName("search() deduplicates Open Library ISBN-10 and Google ISBN-13 fallback rows")
+    void should_DeduplicateExternalFallbackRows_When_IsbnFormatsAreEquivalent() {
+        Book openLibraryCandidate = buildOpenLibraryCandidate("OL-ISBN-10", "Provider Primary Title");
+        openLibraryCandidate.setAuthors(List.of("Open Library Author"));
+        openLibraryCandidate.setIsbn10("0061120081");
+
+        BookAggregate googleCandidate = BookAggregate.builder()
+            .title("Provider Secondary Title")
+            .authors(List.of("Google Author"))
+            .isbn13("9780061120084")
+            .slugBase("provider-secondary-title")
+            .identifiers(BookAggregate.ExternalIdentifiers.builder()
+                .source("GOOGLE_BOOKS")
+                .externalId("google-vol-isbn")
+                .imageLinks(Map.of())
+                .build())
+            .build();
+
+        when(bookSearchService.searchBooks("0061120081", 4)).thenReturn(List.of());
+        when(openLibraryBookDataService.queryBooksByEverything(eq("0061120081"), anyString(), eq(0), eq(4)))
+            .thenReturn(Flux.just(openLibraryCandidate));
+        when(googleApiFetcher.isApiKeyAvailable()).thenReturn(true);
+        when(googleApiFetcher.streamSearchItems("0061120081", 4, "newest", null, true))
+            .thenReturn(Flux.just(googleVolumeNode("google-vol-isbn", "Provider Secondary Title")));
+        when(googleApiFetcher.isFallbackAllowed()).thenReturn(false);
+        when(googleBooksMapper.map(argThat(node -> "google-vol-isbn".equals(node.path("id").asString("")))))
+            .thenReturn(googleCandidate);
+
+        SearchPaginationService fallbackService = fallbackEnabledService();
+        SearchPaginationService.SearchPage page = fallbackService.search(searchRequest("0061120081", 0, 2, "newest")).block();
+
+        assertThat(page).isNotNull();
+        assertThat(page.totalUnique()).isEqualTo(1);
+        assertThat(page.pageItems()).extracting(Book::getId).containsExactly("OL-ISBN-10");
+        verify(googleApiFetcher, times(1)).streamSearchItems("0061120081", 4, "newest", null, true);
+    }
+
+    @Test
+    @DisplayName("search() deduplicates fallback rows when one provider lacks ISBN metadata")
+    void should_DeduplicateExternalFallbackRows_When_OneProviderOnlyHasTitleAuthorIdentity() {
+        Book openLibraryCandidate = buildOpenLibraryCandidate("OL-TITLE-AUTHOR", "To Kill a Mockingbird");
+        openLibraryCandidate.setAuthors(List.of("Harper Lee"));
+        openLibraryCandidate.setIsbn10("0061120081");
+
+        BookAggregate googleCandidate = BookAggregate.builder()
+            .title("To Kill a Mockingbird")
+            .authors(List.of("Harper Lee"))
+            .slugBase("to-kill-a-mockingbird-harper-lee")
+            .identifiers(BookAggregate.ExternalIdentifiers.builder()
+                .source("GOOGLE_BOOKS")
+                .externalId("google-vol-title-author")
+                .imageLinks(Map.of())
+                .build())
+            .build();
+
+        when(bookSearchService.searchBooks("0061120081", 4)).thenReturn(List.of());
+        when(openLibraryBookDataService.queryBooksByEverything(eq("0061120081"), anyString(), eq(0), eq(4)))
+            .thenReturn(Flux.just(openLibraryCandidate));
+        when(googleApiFetcher.isApiKeyAvailable()).thenReturn(true);
+        when(googleApiFetcher.streamSearchItems("0061120081", 4, "newest", null, true))
+            .thenReturn(Flux.just(googleVolumeNode("google-vol-title-author", "To Kill a Mockingbird")));
+        when(googleApiFetcher.isFallbackAllowed()).thenReturn(false);
+        when(googleBooksMapper.map(argThat(node -> "google-vol-title-author".equals(node.path("id").asString("")))))
+            .thenReturn(googleCandidate);
+
+        SearchPaginationService fallbackService = fallbackEnabledService();
+        SearchPaginationService.SearchPage page = fallbackService.search(searchRequest("0061120081", 0, 2, "newest")).block();
+
+        assertThat(page).isNotNull();
+        assertThat(page.totalUnique()).isEqualTo(1);
+        assertThat(page.pageItems()).extracting(Book::getId).containsExactly("OL-TITLE-AUTHOR");
+        verify(googleApiFetcher, times(1)).streamSearchItems("0061120081", 4, "newest", null, true);
+    }
+
+    @Test
     @DisplayName("search() does not add Open Library fallback duplicates for persisted title-author matches")
     void should_DeduplicateOpenLibraryFallback_When_PersistedBookMatchesTitleAndAuthor() {
         UUID postgresId = UUID.randomUUID();

--- a/src/test/java/net/findmybook/service/SearchPaginationServiceRealtimeTest.java
+++ b/src/test/java/net/findmybook/service/SearchPaginationServiceRealtimeTest.java
@@ -1,9 +1,13 @@
 package net.findmybook.service;
 
+import net.findmybook.dto.BookAggregate;
+import net.findmybook.service.event.SearchResultsUpdatedEvent;
+import net.findmybook.util.SearchQueryUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -70,5 +74,68 @@ class SearchPaginationServiceRealtimeTest extends AbstractSearchPaginationServic
 
         assertThat(page).isNotNull();
         verify(eventPublisher, timeout(300).times(0)).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("search() publishes realtime events on filter-scoped query hash")
+    void should_PublishRealtimeEventsOnFilterScopedTopic_When_FiltersArePresent() {
+        UUID postgresId = UUID.randomUUID();
+        when(bookSearchService.searchBooks("distributed systems", 24)).thenReturn(List.of(
+            new BookSearchService.SearchResult(postgresId, 0.96, "FULLTEXT")
+        ));
+        when(bookQueryRepository.fetchPublishedYears(anyList())).thenReturn(java.util.Map.of(postgresId, 2024));
+        when(bookQueryRepository.fetchBookListItems(anyList())).thenReturn(List.of(
+            buildListItem(
+                postgresId,
+                "Designing Data-Intensive Applications",
+                600,
+                900,
+                true,
+                "https://example.test/baseline.jpg",
+                LocalDate.of(2024, 1, 1)
+            )
+        ));
+
+        when(googleApiFetcher.isApiKeyAvailable()).thenReturn(true);
+        when(googleApiFetcher.streamSearchItems("distributed systems", 12, "relevance", null, true))
+            .thenReturn(Flux.just(googleVolumeNode("google-vol-filtered", "Filtered Systems")));
+        when(googleBooksMapper.map(argThat(node -> "google-vol-filtered".equals(node.path("id").asString("")))))
+            .thenReturn(BookAggregate.builder()
+                .title("Filtered Systems")
+                .authors(List.of("Google Author"))
+                .publishedDate(LocalDate.of(2024, 1, 1))
+                .slugBase("filtered-systems")
+                .identifiers(BookAggregate.ExternalIdentifiers.builder()
+                    .source("GOOGLE_BOOKS")
+                    .externalId("google-vol-filtered")
+                    .imageLinks(java.util.Map.of("thumbnail", "https://example.test/filtered.jpg"))
+                    .build())
+                .build());
+        SearchPaginationService realtimeService = new SearchPaginationService(
+            bookSearchService,
+            bookQueryRepository,
+            java.util.Optional.of(googleApiFetcher),
+            java.util.Optional.of(googleBooksMapper),
+            java.util.Optional.empty(),
+            java.util.Optional.of(bookDataOrchestrator),
+            java.util.Optional.of(eventPublisher),
+            true
+        );
+        SearchPaginationService.SearchRequest request = searchRequest("distributed systems", 0, 12, "title", 2024);
+        SearchPaginationService.SearchPage page = realtimeService.search(request).block();
+
+        assertThat(page).isNotNull();
+        String expectedQueryHash = SearchQueryUtils.topicKey(
+            "distributed systems",
+            "title",
+            "ANY",
+            "ANY",
+            2024,
+            12
+        );
+        verify(eventPublisher, timeout(2000).atLeastOnce()).publishEvent((Object) argThat(event ->
+            event instanceof SearchResultsUpdatedEvent updatedEvent
+                && expectedQueryHash.equals(updatedEvent.getQueryHash())
+        ));
     }
 }

--- a/src/test/java/net/findmybook/service/image/S3BookCoverServiceValidationTest.java
+++ b/src/test/java/net/findmybook/service/image/S3BookCoverServiceValidationTest.java
@@ -8,10 +8,12 @@ import net.findmybook.support.s3.S3CoverStorageGateway;
 import net.findmybook.support.s3.S3CoverStorageProperties;
 import net.findmybook.support.s3.S3CoverUploadExecutor;
 import net.findmybook.support.s3.S3CoverUrlSupport;
+import net.findmybook.util.cover.CoverUrlResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.core.env.Environment;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.test.StepVerifier;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -75,11 +77,20 @@ class S3BookCoverServiceValidationTest {
                                               String s3PublicCdnUrl,
                                               String s3ServerUrl,
                                               String s3BucketName) {
+        return buildUrlSupport(s3CdnUrl, s3PublicCdnUrl, s3ServerUrl, s3BucketName, true);
+    }
+
+    private S3CoverUrlSupport buildUrlSupport(String s3CdnUrl,
+                                              String s3PublicCdnUrl,
+                                              String s3ServerUrl,
+                                              String s3BucketName,
+                                              boolean s3Enabled) {
         S3CoverUrlSupport support = new S3CoverUrlSupport(
             s3CdnUrl,
             s3PublicCdnUrl,
             s3ServerUrl,
-            s3BucketName
+            s3BucketName,
+            new S3CoverStorageProperties(s3Enabled, true, ".jpg", java.util.List.of("google-books", "open-library", "longitood"))
         );
         return support;
     }
@@ -128,5 +139,30 @@ class S3BookCoverServiceValidationTest {
     void should_AllowNytStaticCoverHost_When_ValidatingUploadUrlSafety() {
         assertThat(coverUrlSafetyValidator.isAllowedImageUrl("https://static01.nyt.com/bestsellers/images/9780525509622.jpg"))
             .isTrue();
+    }
+
+    @Test
+    void should_ClearResolverCdnBase_When_S3StorageIsDisabled() {
+        CoverUrlResolver.setCdnBase("https://stale-cdn.example/");
+        try {
+            S3CoverUrlSupport disabledSupport = buildUrlSupport(
+                "https://cdn.example.com",
+                "",
+                "https://sfo3.digitaloceanspaces.com",
+                "test-bucket",
+                false
+            );
+
+            ReflectionTestUtils.invokeMethod(disabledSupport, "configureResolver");
+
+            CoverUrlResolver.ResolvedCover resolved = CoverUrlResolver.resolve(
+                "covers/stale.jpg",
+                "https://covers.openlibrary.org/b/id/1-L.jpg"
+            );
+            assertThat(resolved.url()).isEqualTo("https://covers.openlibrary.org/b/id/1-L.jpg");
+            assertThat(resolved.fromS3()).isFalse();
+        } finally {
+            CoverUrlResolver.setCdnBase(null);
+        }
     }
 }

--- a/src/test/java/net/findmybook/util/IsbnUtilsTest.java
+++ b/src/test/java/net/findmybook/util/IsbnUtilsTest.java
@@ -25,4 +25,24 @@ class IsbnUtilsTest {
     void sanitizeReturnsNullForNullInput() {
         assertThat(IsbnUtils.sanitize(null)).isNull();
     }
+
+    @Test
+    void should_ConvertIsbn10ToEquivalentIsbn13_When_InputIsSyntacticallyValid() {
+        assertThat(IsbnUtils.toIsbn13("0-306-40615-2")).isEqualTo("9780306406157");
+    }
+
+    @Test
+    void should_ConvertIsbn13ToEquivalentIsbn10_When_InputUsesBookPrefix() {
+        assertThat(IsbnUtils.toIsbn10("978-0-306-40615-7")).isEqualTo("0306406152");
+    }
+
+    @Test
+    void should_ReturnNullIsbn10_When_Isbn13CannotBeRepresentedAsIsbn10() {
+        assertThat(IsbnUtils.toIsbn10("9791234567896")).isNull();
+    }
+
+    @Test
+    void should_ResolveIsbn13Identity_When_InputIsEquivalentIsbn10() {
+        assertThat(IsbnUtils.isbn13Identity("0-306-40615-2")).isEqualTo("9780306406157");
+    }
 }

--- a/src/test/java/net/findmybook/util/SearchQueryUtilsTest.java
+++ b/src/test/java/net/findmybook/util/SearchQueryUtilsTest.java
@@ -56,4 +56,15 @@ class SearchQueryUtilsTest {
         assertThat(SearchQueryUtils.topicKey(null)).isEqualTo("search");
         assertThat(SearchQueryUtils.topicKey(" \t ")).isEqualTo("search");
     }
+
+    @Test
+    @DisplayName("topicKey includes filters for realtime routing isolation")
+    void should_ProduceDifferentTopicKeys_When_FilterStateChanges() {
+        String newest = SearchQueryUtils.topicKey("Distributed Systems", "newest", "ANY", "ANY", null, 12);
+        String author = SearchQueryUtils.topicKey("Distributed Systems", "author", "ANY", "ANY", null, 12);
+        String year = SearchQueryUtils.topicKey("Distributed Systems", "newest", "ANY", "ANY", 2024, 12);
+
+        assertThat(newest).isNotEqualTo(author);
+        assertThat(newest).isNotEqualTo(year);
+    }
 }

--- a/src/test/java/net/findmybook/util/cover/CoverPrioritizerTest.java
+++ b/src/test/java/net/findmybook/util/cover/CoverPrioritizerTest.java
@@ -161,6 +161,26 @@ class CoverPrioritizerTest {
     }
 
     @Test
+    @DisplayName("score(BookCard) ignores bare S3 key when CDN is disabled")
+    void scoreIgnoresBareS3KeyWhenCdnDisabled() {
+        CoverUrlResolver.setCdnBase(null);
+        BookCard s3Only = new BookCard(
+            "s3-only-disabled",
+            "s3-only-disabled",
+            "S3 Only Disabled",
+            List.of("Author"),
+            null,
+            "covers/s3-only-disabled.jpg",
+            null,
+            4.0,
+            25,
+            Map.of()
+        );
+
+        assertThat(CoverPrioritizer.score(s3Only)).isZero();
+    }
+
+    @Test
     @DisplayName("resolve() treats uppercase HTTP schemes as external URLs")
     void resolveHandlesUppercaseHttpScheme() {
         CoverUrlResolver.setCdnBase(null);

--- a/src/test/java/net/findmybook/util/cover/CoverQualityTest.java
+++ b/src/test/java/net/findmybook/util/cover/CoverQualityTest.java
@@ -1,10 +1,22 @@
 package net.findmybook.util.cover;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class CoverQualityTest {
+
+    @BeforeEach
+    void setUp() {
+        CoverUrlResolver.setCdnBase("https://cdn.test/");
+    }
+
+    @AfterEach
+    void tearDown() {
+        CoverUrlResolver.setCdnBase(null);
+    }
 
     @Test
     void should_ReturnTier0_When_NoCoverExists() {
@@ -36,6 +48,13 @@ class CoverQualityTest {
     @Test
     void should_ReturnTier5_When_S3HighResColor() {
         assertThat(CoverQuality.rank("covers/abc.jpg", null, 800, 1200, true, false)).isEqualTo(5);
+    }
+
+    @Test
+    void should_ReturnTier0_When_S3KeyCannotResolveToCdnUrl() {
+        CoverUrlResolver.setCdnBase(null);
+
+        assertThat(CoverQuality.rank("covers/abc.jpg", null, 800, 1200, true, false)).isZero();
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Fix book identity handling across equivalent ISBN-10/ISBN-13 inputs, slug fallback, and slug collision lookup.
- Scope realtime search topics by the full request and dedupe external fallback candidates by all safe aliases.
- Respect disabled S3/CDN configuration when resolving and ranking covers, and unblock cover backfill after failed or external-only rows.
- Fail explicitly on NYT persistence and optional database lookup outages instead of treating failures as missing data.

## Validation

- `./gradlew clean test`
- `npm --prefix frontend run build:css`
- `npm --prefix frontend run check`
- `npm --prefix frontend run test`
- `npm --prefix frontend run build`
- Pre-push hook: frontend check, frontend lint, frontend test, Gradle check

## Runtime Dogfood

- Local dogfood verified ISBN-10 search for `0061120081` returns and renders one result after alias dedupe.
- Report: `/tmp/findmybook-dogfood-20260610/report.md`

## Deployment Dogfood

- Blocked: `https://findmybook.net` still serves pre-fix behavior after `dev` was pushed to `3ead49f`.
- Evidence: live API returns `queryHash: "0061120081"` and `totalResults: 2` for `0061120081`.
- Report: `/tmp/findmybook-deploy-dogfood-20260610/report.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches canonical book matching, search deduplication, realtime routing, cover ingestion/backfill, and NYT ingest failure modes—bugs could duplicate books, leak stale realtime results, or break bestseller/cover pipelines.
> 
> **Overview**
> This PR tightens **book identity**, **search/realtime routing**, **cover handling**, and **ingest error semantics** across backend and frontend.
> 
> **Identity & deduplication:** `IsbnUtils` gains ISBN-10/13 conversion and a canonical ISBN-13 identity key. `BookLookupService` and `BookUpsertService` use cross-format ISBN matching, broader slug collision lookup (base slug plus numeric suffixes), and a unified advisory-lock key. `CandidateKeyResolver` exposes multiple aliases (ISBN + title/author) so Open Library and Google fallback rows collapse when formats or metadata differ.
> 
> **Search & realtime:** `SearchQueryUtils.topicKey` and API `queryHash` now include order, cover filters, year, and page size so realtime streams do not bleed across filter changes. Pagination, realtime coordinator, and page assembly dedupe via all aliases. `SearchPage` carries `publishedYear`. Open Library “everything” search enriches exact ISBN hits from edition API details and avoids misleading aggregate work-level fields on ISBN matches.
> 
> **Covers:** Backfill candidates require a real non-grayscale **S3** image link, not external-only URLs. Cover quality/ranking and CDN URL building honor disabled S3/CDN config and fall back to external URLs. The book page skips client cover relay for Google/Open Library provider URLs (server-managed); relay remains for other rendered URLs.
> 
> **Persistence & ingest:** `JdbcUtils.optionalString` propagates DB errors instead of returning empty. NYT collection/membership persistence and scheduler fail explicitly on upsert/DB failures; external IDs are upserted only after a canonical book id exists. Slug generation gets a safe fallback for non-Latin titles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28c761cd027897e1a1358224dec21fa5c8badfe4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->