### PR TITLE
fix(books): distinct ISBN editions, exact slug matches, and disabled S3 cover fallbacks

### DIFF
--- a/src/main/java/net/findmybook/service/BookUpsertService.java
+++ b/src/main/java/net/findmybook/service/BookUpsertService.java
@@ -296,18 +296,8 @@ public class BookUpsertService {
         }
 
         UUID id = jdbcTemplate.query(
-            """
-            SELECT id
-            FROM books
-            WHERE slug = ?
-               OR (slug LIKE ? AND substring(slug from ?) ~ '^[0-9]+$')
-            ORDER BY CASE WHEN slug = ? THEN 0 ELSE 1 END, length(slug), slug
-            LIMIT 1
-            """,
+            "SELECT id FROM books WHERE slug = ? LIMIT 1",
             rs -> rs.next() ? (UUID) rs.getObject("id") : null,
-            slug,
-            slug + "-%",
-            slug.length() + 2,
             slug
         );
         return Optional.ofNullable(id);

--- a/src/main/java/net/findmybook/service/SearchPaginationService.java
+++ b/src/main/java/net/findmybook/service/SearchPaginationService.java
@@ -33,8 +33,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Coordinates paginated search using repository-backed DTO projections.
@@ -217,18 +215,18 @@ public class SearchPaginationService {
     }
 
     private int projectedUniqueCount(List<Book> existingResults, List<Book> fallbackCandidates) {
-        Set<String> projectedKeys = ConcurrentHashMap.newKeySet();
+        List<Book> projectedBooks = new ArrayList<>();
         int uniqueCount = 0;
         if (existingResults != null) {
             for (Book existing : existingResults) {
-                if (registerCandidateAliases(projectedKeys, existing)) {
+                if (registerCandidateIdentity(projectedBooks, existing)) {
                     uniqueCount++;
                 }
             }
         }
         if (fallbackCandidates != null) {
             for (Book candidate : fallbackCandidates) {
-                if (registerCandidateAliases(projectedKeys, candidate)) {
+                if (registerCandidateIdentity(projectedBooks, candidate)) {
                     uniqueCount++;
                 }
             }
@@ -246,7 +244,7 @@ public class SearchPaginationService {
         }
 
         OpenLibraryBookDataService service = openLibraryBookDataService.get();
-        Set<String> seenKeys = ConcurrentHashMap.newKeySet();
+        List<Book> seenCandidates = new ArrayList<>();
         return service.queryBooksByEverything(query, request.orderBy(), startIndex, maxResults)
             .onErrorResume(ex -> {
                 log.warn("Open Library fallback failed for '{}': {}", request.query(), ex.getMessage());
@@ -255,7 +253,7 @@ public class SearchPaginationService {
             .filter(Objects::nonNull)
             .map(SearchExternalProviderUtils::tagOpenLibraryFallback)
             .filter(book -> SearchExternalProviderUtils.matchesPublishedYear(book, request.publishedYear()))
-            .filter(book -> registerCandidateAliases(seenKeys, book))
+            .filter(book -> registerCandidateIdentity(seenCandidates, book))
             .take(maxResults);
     }
 
@@ -301,17 +299,15 @@ public class SearchPaginationService {
             return List.of();
         }
         Map<String, Book> uniqueCandidates = new LinkedHashMap<>();
-        Set<String> seenAliases = ConcurrentHashMap.newKeySet();
         for (Book candidate : fallbackBooks) {
             if (candidate == null) {
                 continue;
             }
-            List<String> aliases = CandidateKeyResolver.resolveAliases(candidate);
-            if (aliases.isEmpty() || aliases.stream().anyMatch(seenAliases::contains)) {
+            Optional<String> candidateKey = CandidateKeyResolver.resolve(candidate);
+            if (candidateKey.isEmpty() || CandidateKeyResolver.overlapsAny(uniqueCandidates.values(), candidate)) {
                 continue;
             }
-            seenAliases.addAll(aliases);
-            uniqueCandidates.put(aliases.getFirst(), candidate);
+            uniqueCandidates.put(candidateKey.get(), candidate);
         }
         return List.copyOf(uniqueCandidates.values());
     }
@@ -320,28 +316,28 @@ public class SearchPaginationService {
         if (candidates == null || candidates.isEmpty()) {
             return List.of();
         }
-        Set<String> existingKeys = ConcurrentHashMap.newKeySet();
+        List<Book> seenCandidates = new ArrayList<>();
         if (existingResults != null) {
             for (Book existing : existingResults) {
-                existingKeys.addAll(CandidateKeyResolver.resolveAliases(existing));
+                registerCandidateIdentity(seenCandidates, existing);
             }
         }
 
         List<Book> netNew = new ArrayList<>();
         for (Book candidate : candidates) {
-            if (registerCandidateAliases(existingKeys, candidate)) {
+            if (registerCandidateIdentity(seenCandidates, candidate)) {
                 netNew.add(candidate);
             }
         }
         return List.copyOf(netNew);
     }
 
-    private boolean registerCandidateAliases(Set<String> seenAliases, Book candidate) {
-        List<String> aliases = CandidateKeyResolver.resolveAliases(candidate);
-        if (aliases.isEmpty() || aliases.stream().anyMatch(seenAliases::contains)) {
+    private boolean registerCandidateIdentity(List<Book> seenCandidates, Book candidate) {
+        Optional<String> candidateKey = CandidateKeyResolver.resolve(candidate);
+        if (candidateKey.isEmpty() || CandidateKeyResolver.overlapsAny(seenCandidates, candidate)) {
             return false;
         }
-        seenAliases.addAll(aliases);
+        seenCandidates.add(candidate);
         return true;
     }
 

--- a/src/main/java/net/findmybook/service/SearchRealtimeCoordinator.java
+++ b/src/main/java/net/findmybook/service/SearchRealtimeCoordinator.java
@@ -13,11 +13,10 @@ import net.findmybook.util.SearchExternalProviderUtils;
 import net.findmybook.util.SearchQueryUtils;
 import org.springframework.util.StringUtils;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.extern.slf4j.Slf4j;
@@ -82,7 +81,7 @@ final class SearchRealtimeCoordinator {
             request.coverSource().name(),
             request.resolutionPreference().name(),
             request.publishedYear(),
-            request.maxResults()
+            page.maxResults()
         );
         SearchRealtimeState state = realtimeStates.get(queryHash, unused -> new SearchRealtimeState());
 
@@ -232,7 +231,7 @@ final class SearchRealtimeCoordinator {
     private record RealtimeCandidate(String source, Book book) {}
 
     private final class SearchRealtimeState {
-        private final Set<String> emittedKeys = ConcurrentHashMap.newKeySet();
+        private final List<Book> emittedBooks = new ArrayList<>();
         private final AtomicBoolean streaming = new AtomicBoolean(false);
         private final AtomicInteger totalResults = new AtomicInteger(0);
 
@@ -240,24 +239,24 @@ final class SearchRealtimeCoordinator {
             if (!streaming.compareAndSet(false, true)) {
                 return false;
             }
-            emittedKeys.clear();
+            emittedBooks.clear();
             totalResults.set(Math.max(0, baselineTotal));
 
             if (existingResults != null) {
                 for (Book existing : existingResults) {
-                    emittedKeys.addAll(CandidateKeyResolver.resolveAliases(existing));
+                    registerCandidate(existing);
                 }
             }
 
             return true;
         }
 
-        boolean registerCandidate(Book candidate) {
-            List<String> aliases = CandidateKeyResolver.resolveAliases(candidate);
-            if (aliases.isEmpty() || aliases.stream().anyMatch(emittedKeys::contains)) {
+        synchronized boolean registerCandidate(Book candidate) {
+            Optional<String> candidateKey = CandidateKeyResolver.resolve(candidate);
+            if (candidateKey.isEmpty() || CandidateKeyResolver.overlapsAny(emittedBooks, candidate)) {
                 return false;
             }
-            emittedKeys.addAll(aliases);
+            emittedBooks.add(candidate);
             return true;
         }
 

--- a/src/main/java/net/findmybook/support/search/CandidateKeyResolver.java
+++ b/src/main/java/net/findmybook/support/search/CandidateKeyResolver.java
@@ -18,9 +18,9 @@ import java.util.regex.Pattern;
  * an external fallback row can collapse when providers assign different identifiers to
  * the same work.</p>
  *
- * <p>{@link #resolveAliases(Book)} returns every safe content identity for overlap checks. That lets
- * candidates collapse when one provider supplies ISBN metadata and another only supplies a stable
- * title/author identity for the same work.</p>
+ * <p>{@link #resolveAliases(Book)} returns every safe content identity for overlap checks.
+ * {@link #hasIdentityOverlap(Book, Book)} applies those aliases while preserving conflicting
+ * ISBN identities as separate editions.</p>
  *
  * <p>Rows that lack both ISBNs and an internal ID and carry only a partial title or author
  * do not qualify for a dedupe key: partial keys would collapse distinct works, so such
@@ -79,6 +79,70 @@ public final class CandidateKeyResolver {
         }
 
         return List.copyOf(aliases);
+    }
+
+    /**
+     * Determines whether two candidates represent the same search identity.
+     *
+     * @param first first candidate to compare
+     * @param second second candidate to compare
+     * @return true when the candidates share an identity and do not have conflicting ISBN identities
+     */
+    public static boolean hasIdentityOverlap(Book first, Book second) {
+        List<String> firstAliases = resolveAliases(first);
+        List<String> secondAliases = resolveAliases(second);
+        if (firstAliases.isEmpty() || secondAliases.isEmpty()) {
+            return false;
+        }
+        if (hasConflictingIsbnIdentity(firstAliases, secondAliases)) {
+            return false;
+        }
+        return aliasesOverlap(firstAliases, secondAliases);
+    }
+
+    /**
+     * Determines whether a candidate overlaps any already accepted candidate.
+     *
+     * @param acceptedCandidates candidates already accepted into the result set
+     * @param candidate candidate being considered
+     * @return true when any accepted candidate shares a non-conflicting identity with {@code candidate}
+     */
+    public static boolean overlapsAny(Iterable<Book> acceptedCandidates, Book candidate) {
+        if (acceptedCandidates == null) {
+            return false;
+        }
+        for (Book acceptedCandidate : acceptedCandidates) {
+            if (hasIdentityOverlap(acceptedCandidate, candidate)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasConflictingIsbnIdentity(List<String> firstAliases, List<String> secondAliases) {
+        String firstIsbn = firstIsbnAlias(firstAliases);
+        String secondIsbn = firstIsbnAlias(secondAliases);
+        return StringUtils.hasText(firstIsbn)
+            && StringUtils.hasText(secondIsbn)
+            && !firstIsbn.equals(secondIsbn);
+    }
+
+    private static boolean aliasesOverlap(List<String> firstAliases, List<String> secondAliases) {
+        for (String firstAlias : firstAliases) {
+            if (secondAliases.contains(firstAlias)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String firstIsbnAlias(List<String> aliases) {
+        for (String alias : aliases) {
+            if (alias != null && alias.startsWith(ISBN_KEY_PREFIX)) {
+                return alias;
+            }
+        }
+        return "";
     }
 
     private static String firstAuthor(Book book) {

--- a/src/main/java/net/findmybook/support/search/SearchPageAssembler.java
+++ b/src/main/java/net/findmybook/support/search/SearchPageAssembler.java
@@ -67,16 +67,16 @@ public final class SearchPageAssembler {
 
         LinkedHashMap<String, Book> orderedCandidatesByKey = new LinkedHashMap<>();
         Map<String, Integer> insertionOrder = new LinkedHashMap<>();
-        Set<String> seenCandidateAliases = new HashSet<>();
+        List<Book> acceptedCandidates = new ArrayList<>();
         int position = 0;
 
         for (Book book : eligibleCandidates) {
-            List<String> aliases = CandidateKeyResolver.resolveAliases(book);
-            if (aliases.isEmpty() || aliases.stream().anyMatch(seenCandidateAliases::contains)) {
+            Optional<String> candidateKey = CandidateKeyResolver.resolve(book);
+            if (candidateKey.isEmpty() || CandidateKeyResolver.overlapsAny(acceptedCandidates, book)) {
                 continue;
             }
-            orderedCandidatesByKey.put(aliases.getFirst(), book);
-            seenCandidateAliases.addAll(aliases);
+            orderedCandidatesByKey.put(candidateKey.get(), book);
+            acceptedCandidates.add(book);
             insertionOrder.put(book.getId(), position++);
         }
 

--- a/src/main/java/net/findmybook/util/SlugGenerator.java
+++ b/src/main/java/net/findmybook/util/SlugGenerator.java
@@ -42,7 +42,7 @@ public final class SlugGenerator {
         // Process title
         String titleSlug = slugify(title);
         if (titleSlug.isBlank()) {
-            titleSlug = FALLBACK_BOOK_SLUG;
+            titleSlug = fallbackBookSlug(title, authors);
         }
         if (titleSlug.length() > MAX_TITLE_LENGTH) {
             // Truncate at word boundary
@@ -72,7 +72,7 @@ public final class SlugGenerator {
         }
 
         if (finalSlug.isBlank()) {
-            return FALLBACK_BOOK_SLUG;
+            return fallbackBookSlug(title, authors);
         }
 
         return finalSlug;
@@ -128,6 +128,19 @@ public final class SlugGenerator {
         slug = EDGE_DASHES.matcher(slug).replaceAll("");
 
         return slug;
+    }
+
+    private static String fallbackBookSlug(String title, List<String> authors) {
+        StringBuilder source = new StringBuilder(title == null ? "" : title.trim());
+        if (authors != null) {
+            for (String author : authors) {
+                if (author != null && !author.trim().isEmpty()) {
+                    source.append('|').append(author.trim());
+                }
+            }
+        }
+        String hash = Integer.toUnsignedString(source.toString().hashCode(), Character.MAX_RADIX);
+        return FALLBACK_BOOK_SLUG + "-" + hash;
     }
 
     /**

--- a/src/main/java/net/findmybook/util/cover/CoverUrlResolver.java
+++ b/src/main/java/net/findmybook/util/cover/CoverUrlResolver.java
@@ -11,6 +11,7 @@ import java.util.Locale;
 public final class CoverUrlResolver {
 
     private static final java.util.concurrent.atomic.AtomicReference<String> CDN_BASE_OVERRIDE = new java.util.concurrent.atomic.AtomicReference<>();
+    private static final String CDN_BASE_DISABLED = "__FMB_CDN_DISABLED__";
     private static final String PLACEHOLDER_FILENAME = "placeholder-book-cover.svg";
 
     private CoverUrlResolver() {
@@ -20,12 +21,15 @@ public final class CoverUrlResolver {
         if (StringUtils.hasText(base)) {
             CDN_BASE_OVERRIDE.set(normalizeBase(base));
         } else {
-            CDN_BASE_OVERRIDE.set(null);
+            CDN_BASE_OVERRIDE.set(CDN_BASE_DISABLED);
         }
     }
 
     private static String currentCdnBase() {
         String override = CDN_BASE_OVERRIDE.get();
+        if (CDN_BASE_DISABLED.equals(override)) {
+            return "";
+        }
         if (StringUtils.hasText(override)) {
             return override;
         }

--- a/src/test/java/net/findmybook/mapper/GoogleBooksMapperTest.java
+++ b/src/test/java/net/findmybook/mapper/GoogleBooksMapperTest.java
@@ -109,7 +109,22 @@ class GoogleBooksMapperTest {
         BookAggregate aggregate = mapper.map(volume);
 
         assertThat(aggregate).isNotNull();
-        assertThat(aggregate.getSlugBase()).isEqualTo("book-jane-writer");
+        assertThat(aggregate.getSlugBase())
+            .startsWith("book-")
+            .endsWith("-jane-writer")
+            .isNotEqualTo("book-jane-writer");
+
+        var secondVolume = objectMapper.createObjectNode();
+        secondVolume.put("id", "second-non-latin-fixture");
+        var secondVolumeInfo = secondVolume.putObject("volumeInfo");
+        secondVolumeInfo.put("title", "再见");
+        var secondAuthors = secondVolumeInfo.putArray("authors");
+        secondAuthors.add("Jane Writer");
+
+        BookAggregate secondAggregate = mapper.map(secondVolume);
+
+        assertThat(secondAggregate).isNotNull();
+        assertThat(secondAggregate.getSlugBase()).isNotEqualTo(aggregate.getSlugBase());
     }
 
     private JsonNode loadFixture(String path) {

--- a/src/test/java/net/findmybook/service/PersistenceSupportServicesTest.java
+++ b/src/test/java/net/findmybook/service/PersistenceSupportServicesTest.java
@@ -166,7 +166,7 @@ class PersistenceSupportServicesTest {
     }
 
     @Test
-    void bookUpsertService_findExistingBookId_matchesBySlug_When_IdentifiersDoNotResolve() {
+    void bookUpsertService_findExistingBookId_matchesByExactSlug_When_IdentifiersDoNotResolve() {
         JdbcTemplate lockJdbcTemplate = mock(JdbcTemplate.class);
         BookUpsertTransactionService transactionService = mock(BookUpsertTransactionService.class);
         BookImageLinkPersistenceService imageLinkPersistenceService = mock(BookImageLinkPersistenceService.class);
@@ -196,11 +196,8 @@ class PersistenceSupportServicesTest {
 
         assertThat(existing).contains(existingBookId);
         verify(lockJdbcTemplate).query(
-            org.mockito.ArgumentMatchers.contains("substring(slug from ?)"),
+            eq("SELECT id FROM books WHERE slug = ? LIMIT 1"),
             org.mockito.ArgumentMatchers.<org.springframework.jdbc.core.ResultSetExtractor<UUID>>any(),
-            eq("the-partner-john-grisham"),
-            eq("the-partner-john-grisham-%"),
-            eq("the-partner-john-grisham".length() + 2),
             eq("the-partner-john-grisham")
         );
     }
@@ -356,11 +353,8 @@ class PersistenceSupportServicesTest {
 
     private void stubSlugLookup(JdbcTemplate lockJdbcTemplate, String slug, UUID resultBookId) {
         when(lockJdbcTemplate.query(
-            org.mockito.ArgumentMatchers.contains("substring(slug from ?)"),
+            eq("SELECT id FROM books WHERE slug = ? LIMIT 1"),
             org.mockito.ArgumentMatchers.<org.springframework.jdbc.core.ResultSetExtractor<UUID>>any(),
-            eq(slug),
-            eq(slug + "-%"),
-            eq(slug.length() + 2),
             eq(slug)
         )).thenReturn(resultBookId);
     }

--- a/src/test/java/net/findmybook/service/SearchPaginationServiceFallbackTest.java
+++ b/src/test/java/net/findmybook/service/SearchPaginationServiceFallbackTest.java
@@ -186,6 +186,45 @@ class SearchPaginationServiceFallbackTest extends AbstractSearchPaginationServic
     }
 
     @Test
+    @DisplayName("search() preserves fallback editions when title-author matches but ISBN differs")
+    void should_PreserveFallbackRows_When_TitleAuthorMatchesButIsbnDiffers() {
+        Book openLibraryCandidate = buildOpenLibraryCandidate("OL-DIFFERENT-ISBN", "Same Title");
+        openLibraryCandidate.setAuthors(List.of("Shared Author"));
+        openLibraryCandidate.setIsbn13("9780306406157");
+
+        BookAggregate googleCandidate = BookAggregate.builder()
+            .title("Same Title")
+            .authors(List.of("Shared Author"))
+            .isbn13("9780132350884")
+            .slugBase("same-title-shared-author")
+            .identifiers(BookAggregate.ExternalIdentifiers.builder()
+                .source("GOOGLE_BOOKS")
+                .externalId("google-vol-different-isbn")
+                .imageLinks(Map.of())
+                .build())
+            .build();
+
+        when(bookSearchService.searchBooks("same title", 4)).thenReturn(List.of());
+        when(openLibraryBookDataService.queryBooksByEverything(eq("same title"), anyString(), eq(0), eq(4)))
+            .thenReturn(Flux.just(openLibraryCandidate));
+        when(googleApiFetcher.isApiKeyAvailable()).thenReturn(true);
+        when(googleApiFetcher.streamSearchItems("same title", 4, "newest", null, true))
+            .thenReturn(Flux.just(googleVolumeNode("google-vol-different-isbn", "Same Title")));
+        when(googleApiFetcher.isFallbackAllowed()).thenReturn(false);
+        when(googleBooksMapper.map(argThat(node -> "google-vol-different-isbn".equals(node.path("id").asString("")))))
+            .thenReturn(googleCandidate);
+
+        SearchPaginationService fallbackService = fallbackEnabledService();
+        SearchPaginationService.SearchPage page = fallbackService.search(searchRequest("same title", 0, 2, "newest")).block();
+
+        assertThat(page).isNotNull();
+        assertThat(page.totalUnique()).isEqualTo(2);
+        assertThat(page.pageItems())
+            .extracting(Book::getId)
+            .containsExactly("OL-DIFFERENT-ISBN", "google-vol-different-isbn");
+    }
+
+    @Test
     @DisplayName("search() does not add Open Library fallback duplicates for persisted title-author matches")
     void should_DeduplicateOpenLibraryFallback_When_PersistedBookMatchesTitleAndAuthor() {
         UUID postgresId = UUID.randomUUID();

--- a/src/test/java/net/findmybook/service/SearchPaginationServiceRealtimeTest.java
+++ b/src/test/java/net/findmybook/service/SearchPaginationServiceRealtimeTest.java
@@ -138,4 +138,49 @@ class SearchPaginationServiceRealtimeTest extends AbstractSearchPaginationServic
                 && expectedQueryHash.equals(updatedEvent.getQueryHash())
         ));
     }
+
+    @Test
+    @DisplayName("search() publishes realtime events on clamped page-size query hash")
+    void should_PublishRealtimeEventsOnClampedTopic_When_MaxResultsExceedsLimit() {
+        UUID postgresId = UUID.randomUUID();
+        when(bookSearchService.searchBooks("distributed systems", 200)).thenReturn(List.of(
+            new BookSearchService.SearchResult(postgresId, 0.96, "FULLTEXT")
+        ));
+        when(bookQueryRepository.fetchBookListItems(anyList())).thenReturn(List.of(
+            buildListItem(postgresId, "Designing Data-Intensive Applications")
+        ));
+
+        when(googleApiFetcher.isApiKeyAvailable()).thenReturn(true);
+        when(googleApiFetcher.streamSearchItems("distributed systems", 20, "relevance", null, true))
+            .thenReturn(Flux.just(googleVolumeNode("google-vol-clamped", "Realtime Systems")));
+        when(googleBooksMapper.map(argThat(node -> "google-vol-clamped".equals(node.path("id").asString("")))))
+            .thenReturn(googleAggregate("google-vol-clamped", "Realtime Systems", "https://example.test/realtime.jpg"));
+
+        SearchPaginationService realtimeService = new SearchPaginationService(
+            bookSearchService,
+            bookQueryRepository,
+            java.util.Optional.of(googleApiFetcher),
+            java.util.Optional.of(googleBooksMapper),
+            java.util.Optional.empty(),
+            java.util.Optional.of(bookDataOrchestrator),
+            java.util.Optional.of(eventPublisher),
+            true
+        );
+        SearchPaginationService.SearchRequest request = searchRequest("distributed systems", 0, 500, "relevance");
+        SearchPaginationService.SearchPage page = realtimeService.search(request).block();
+
+        assertThat(page).isNotNull();
+        String expectedQueryHash = SearchQueryUtils.topicKey(
+            "distributed systems",
+            "relevance",
+            "ANY",
+            "ANY",
+            null,
+            100
+        );
+        verify(eventPublisher, timeout(2000).atLeastOnce()).publishEvent((Object) argThat(event ->
+            event instanceof SearchResultsUpdatedEvent updatedEvent
+                && expectedQueryHash.equals(updatedEvent.getQueryHash())
+        ));
+    }
 }

--- a/src/test/java/net/findmybook/service/image/S3BookCoverServiceValidationTest.java
+++ b/src/test/java/net/findmybook/service/image/S3BookCoverServiceValidationTest.java
@@ -144,6 +144,8 @@ class S3BookCoverServiceValidationTest {
     @Test
     void should_ClearResolverCdnBase_When_S3StorageIsDisabled() {
         CoverUrlResolver.setCdnBase("https://stale-cdn.example/");
+        String previousSystemCdnUrl = System.getProperty("S3_CDN_URL");
+        System.setProperty("S3_CDN_URL", "https://env-cdn.example/");
         try {
             S3CoverUrlSupport disabledSupport = buildUrlSupport(
                 "https://cdn.example.com",
@@ -162,7 +164,16 @@ class S3BookCoverServiceValidationTest {
             assertThat(resolved.url()).isEqualTo("https://covers.openlibrary.org/b/id/1-L.jpg");
             assertThat(resolved.fromS3()).isFalse();
         } finally {
+            restoreSystemProperty("S3_CDN_URL", previousSystemCdnUrl);
             CoverUrlResolver.setCdnBase(null);
+        }
+    }
+
+    private void restoreSystemProperty(String key, String previousValue) {
+        if (previousValue == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, previousValue);
         }
     }
 }


### PR DESCRIPTION
## Summary
Search and ingest now preserve distinct book editions instead of merging them through loose title or slug aliases, and disabled S3 storage can no longer leak stale CDN URLs into cover responses.

## Changes

### Bug Fixes
- **Disabled S3 cover storage no longer resolves bare storage keys through stale CDN environment values**: when configured S3 storage is off, cover responses now use external fallbacks instead of rebuilding CDN URLs from ambient `S3_CDN_URL` (`CoverUrlResolver.setCdnBase`, `S3CoverUrlSupport.configureResolver`).
- **Search results keep different ISBN editions even when title and author match**: fallback and realtime search dedupe now treats conflicting canonical ISBNs as separate identities while still collapsing title-only duplicates (`CandidateKeyResolver.hasIdentityOverlap`, `SearchPaginationService`, `SearchRealtimeCoordinator`).
- **Realtime search updates publish on the same topic returned by the API**: realtime query hashes now use the clamped page size after pagination rules are applied (`SearchRealtimeCoordinator.trigger`).
- **Book upserts no longer merge unrelated numeric slug suffixes**: slug identity lookup now requires an exact slug match, so titles like `ai-2024` do not match the base `ai` slug (`BookUpsertService.findBookBySlug`).
- **Non-Latin titles no longer share the generic `book` slug base**: fallback slugs now include a deterministic hash from title and author input so unrelated books without Latin slug text stay separate (`SlugGenerator.generateBookSlug`).

## Validation
- `./gradlew test -PskipFrontend`
- Pre-push hook: frontend check, frontend lint, frontend test, Gradle check

## Breaking Changes
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core search deduplication and book upsert matching logic, which can alter result counts and which rows merge on ingest; cover URL behavior shifts when S3 is off.
> 
> **Overview**
> Search and book ingest now treat **distinct ISBNs as separate editions** while still deduping equivalent identities across providers, via `CandidateKeyResolver.hasIdentityOverlap` / `overlapsAny` and updated paths in pagination, page assembly, and realtime streaming.
> 
> **Book identity:** upsert slug lookup is **exact match only** (no numeric-suffix slug aliasing). Non-Latin titles get **hashed fallback slug bases** so unrelated books no longer share `book`.
> 
> **Covers:** when S3/CDN is disabled, `CoverUrlResolver` no longer rebuilds CDN URLs from ambient env; external fallbacks are used instead.
> 
> **Realtime search:** SSE topic keys use the **clamped** `page.maxResults()` so clients subscribe on the same hash the API returns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c567cbd522e036b8d491d3e56e7200562ed96939. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->