### PR TITLE
fix(book-detail): malformed book URLs render cleanly without 500s

### DIFF
--- a/frontend/src/lib/pages/BookPage.svelte
+++ b/frontend/src/lib/pages/BookPage.svelte
@@ -3,6 +3,7 @@
   import BookDetailCard from "$lib/components/book/BookDetailCard.svelte";
   import BookEditions from "$lib/components/BookEditions.svelte";
   import BookSimilarBooks from "$lib/components/BookSimilarBooks.svelte";
+  import NotFoundPage from "$lib/pages/NotFoundPage.svelte";
   import { previousSpaPath } from "$lib/router/router";
   import {
     getAffiliateLinks,
@@ -33,6 +34,7 @@
 
   let loading = $state(true);
   let errorMessage = $state<string | null>(null);
+  let bookNotFound = $state(false);
   let book = $state<Book | null>(null);
   let similarBooks = $state<Book[]>([]);
   let similarBooksFailed = $state(false);
@@ -82,6 +84,7 @@
     const sequence = ++loadSequence;
     loading = true;
     errorMessage = null;
+    bookNotFound = false;
     similarBooks = [];
     similarBooksFailed = false;
     affiliateLinks = {};
@@ -110,7 +113,13 @@
       if (sequence !== loadSequence) {
         return;
       }
-      errorMessage = loadError instanceof Error ? loadError.message : "Unable to load this book";
+      if (isHttpNotFoundError(loadError)) {
+        bookNotFound = true;
+        errorMessage = null;
+      } else {
+        errorMessage = loadError instanceof Error ? loadError.message : "Unable to load this book";
+        bookNotFound = false;
+      }
       book = null;
       similarBooks = [];
       similarBooksFailed = false;
@@ -323,6 +332,8 @@
 <section class="mx-auto flex max-w-6xl flex-col gap-6 px-4 py-8 md:px-6">
   {#if loading}
     <p class="text-sm text-anthracite-600 dark:text-slate-300">Loading book details...</p>
+  {:else if bookNotFound}
+    <NotFoundPage />
   {:else if errorMessage}
     <div class="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-950/40 dark:text-red-200">
       {errorMessage}

--- a/frontend/src/lib/router/router.book-page.test.ts
+++ b/frontend/src/lib/router/router.book-page.test.ts
@@ -207,6 +207,23 @@ describe("BookPage fallback lookup", () => {
     expect(getAffiliateLinksMock).toHaveBeenCalledWith("OL13535055W");
   });
 
+  it("shouldRenderNotFoundPageWhenBookLookupReturns404WithoutFallback", async () => {
+    getBookMock.mockRejectedValueOnce(new Error("HTTP 404: Not Found"));
+
+    const currentUrl = new URL("https://findmybook.net/book/heavens-");
+    render(BookPage, {
+      props: {
+        currentUrl,
+        identifier: "heavens-",
+      },
+    });
+
+    expect(await screen.findByRole("heading", { name: "Page not found" })).toBeInTheDocument();
+    expect(screen.queryByText("HTTP 404: Not Found")).not.toBeInTheDocument();
+    expect(getSimilarBooksMock).not.toHaveBeenCalled();
+    expect(getAffiliateLinksMock).not.toHaveBeenCalled();
+  });
+
   it("shouldBuildExploreBackLinkFromPopularWindowWhenSpaHistoryIsMissing", async () => {
     const currentUrl = new URL(
       "https://findmybook.net/book/book-1?bookId=book-1&popularWindow=90d&page=2&orderBy=newest&view=grid",

--- a/src/main/java/net/findmybook/service/BookIdentifierResolver.java
+++ b/src/main/java/net/findmybook/service/BookIdentifierResolver.java
@@ -78,7 +78,6 @@ public class BookIdentifierResolver {
 
         return bookLookupService.findBookIdByExternalIdentifier(trimmed)
             .or(() -> bookLookupService.findBookIdByIsbn(trimmed))
-            .or(() -> bookLookupService.findBookById(trimmed))
             .flatMap(this::resolveToPrimaryEdition);
     }
 

--- a/src/main/java/net/findmybook/service/BookLookupService.java
+++ b/src/main/java/net/findmybook/service/BookLookupService.java
@@ -4,6 +4,7 @@ import net.findmybook.model.ExternalIdentifierType;
 import net.findmybook.util.IdentifierClassifier;
 import net.findmybook.util.IsbnUtils;
 import net.findmybook.util.JdbcUtils;
+import net.findmybook.util.UuidUtils;
 import org.springframework.util.StringUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -186,6 +187,10 @@ public class BookLookupService {
      */
     public Optional<String> findBookById(String bookId) {
         if (!StringUtils.hasText(bookId)) {
+            return Optional.empty();
+        }
+        if (UuidUtils.parseUuidOrNull(bookId.trim()) == null) {
+            log.debug("Skipping canonical book ID lookup for non-UUID identifier: {}", bookId);
             return Optional.empty();
         }
 

--- a/src/main/java/net/findmybook/service/PostgresBookRepository.java
+++ b/src/main/java/net/findmybook/service/PostgresBookRepository.java
@@ -88,13 +88,6 @@ public class PostgresBookRepository {
         return idOptional.flatMap(this::loadAggregate);
     }
 
-
-
-
-
-
-
-
     private Optional<Book> loadAggregate(String canonicalId) {
         if (canonicalId == null || canonicalId.isBlank()) {
             return Optional.empty();
@@ -114,7 +107,7 @@ public class PostgresBookRepository {
                 WHERE id = ?
                 """;
         try {
-            return jdbcTemplate.query(sql, ps -> ps.setObject(1, canonicalId), rs -> {
+            Optional<Book> baseBook = jdbcTemplate.query(sql, ps -> ps.setObject(1, canonicalId), rs -> {
                 if (!rs.next()) {
                     return Optional.<Book>empty();
                 }
@@ -133,27 +126,31 @@ public class PostgresBookRepository {
                 book.setPublisher(rs.getString("publisher"));
                 Integer pageCount = (Integer) rs.getObject("page_count");
                 book.setPageCount(pageCount);
-
-                sectionHydrator.hydrateAuthors(book, canonicalId);
-                sectionHydrator.hydrateCategories(book, canonicalId);
-                sectionHydrator.hydrateCollections(book, canonicalId);
-                sectionHydrator.hydrateDimensions(book, canonicalId);
-                sectionHydrator.hydrateRawPayload(book, canonicalId);
-                sectionHydrator.hydrateTags(book, canonicalId);
-                detailHydrator.hydrateEditions(book, canonicalId);
-                detailHydrator.hydrateCover(book, canonicalId);
-                detailHydrator.hydrateRecommendations(book, canonicalId);
-                detailHydrator.hydrateProviderMetadata(book, canonicalId);
-
-                book.setRetrievedFrom("POSTGRES");
-                book.setInPostgres(true);
-                detailHydrator.hydrateDataSource(book, canonicalId);
-
                 return Optional.of(book);
             });
+
+            baseBook.ifPresent(book -> hydrateAggregateSections(book, canonicalId));
+            return baseBook;
         } catch (DataAccessException ex) {
             throw new IllegalStateException("Postgres reader failed to load canonical book " + canonicalId, ex);
         }
+    }
+
+    private void hydrateAggregateSections(Book book, UUID canonicalId) {
+        sectionHydrator.hydrateAuthors(book, canonicalId);
+        sectionHydrator.hydrateCategories(book, canonicalId);
+        sectionHydrator.hydrateCollections(book, canonicalId);
+        sectionHydrator.hydrateDimensions(book, canonicalId);
+        sectionHydrator.hydrateRawPayload(book, canonicalId);
+        sectionHydrator.hydrateTags(book, canonicalId);
+        detailHydrator.hydrateEditions(book, canonicalId);
+        detailHydrator.hydrateCover(book, canonicalId);
+        detailHydrator.hydrateRecommendations(book, canonicalId);
+        detailHydrator.hydrateProviderMetadata(book, canonicalId);
+
+        book.setRetrievedFrom("POSTGRES");
+        book.setInPostgres(true);
+        detailHydrator.hydrateDataSource(book, canonicalId);
     }
 
     private Optional<UUID> queryForUuid(String sql, Object param) {

--- a/src/test/java/net/findmybook/service/PersistenceSupportServicesTest.java
+++ b/src/test/java/net/findmybook/service/PersistenceSupportServicesTest.java
@@ -1,6 +1,8 @@
 package net.findmybook.service;
 
 import net.findmybook.dto.BookAggregate;
+import net.findmybook.model.Book;
+import net.findmybook.repository.BookQueryRepository;
 import net.findmybook.service.image.CoverPersistenceService;
 import net.findmybook.util.JdbcUtils;
 import org.junit.jupiter.api.Test;
@@ -10,17 +12,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.PreparedStatementSetter;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.ResultSetExtractor;
+import org.springframework.jdbc.core.RowCallbackHandler;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.ObjectMapper;
 
 import java.sql.ResultSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -34,6 +40,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -284,6 +291,92 @@ class PersistenceSupportServicesTest {
     }
 
     @Test
+    void bookLookupService_findBookById_shouldReturnEmptyWithoutQuery_When_IdentifierIsNotUuid() {
+        JdbcTemplate lookupJdbcTemplate = mock(JdbcTemplate.class);
+        BookLookupService lookupService = new BookLookupService(lookupJdbcTemplate);
+
+        Optional<String> bookId = lookupService.findBookById("heavens-");
+
+        assertThat(bookId).isEmpty();
+        verifyNoInteractions(lookupJdbcTemplate);
+    }
+
+    @Test
+    void bookIdentifierResolver_resolveCanonicalId_shouldNotQueryCanonicalId_When_UnknownSlugFragmentIsUnmatched() {
+        BookLookupService lookupService = mock(BookLookupService.class);
+        BookQueryRepository bookQueryRepository = mock(BookQueryRepository.class);
+        JdbcTemplate lookupJdbcTemplate = mock(JdbcTemplate.class);
+        BookIdentifierResolver resolver = new BookIdentifierResolver(
+            lookupService,
+            bookQueryRepository,
+            lookupJdbcTemplate
+        );
+        when(bookQueryRepository.fetchBookDetailBySlug("heavens-")).thenReturn(Optional.empty());
+        when(lookupService.findBookIdByExternalIdentifier("heavens-")).thenReturn(Optional.empty());
+        when(lookupService.findBookIdByIsbn("heavens-")).thenReturn(Optional.empty());
+
+        Optional<String> resolved = resolver.resolveCanonicalId("heavens-");
+
+        assertThat(resolved).isEmpty();
+        verify(lookupService, never()).findBookById("heavens-");
+        verifyNoInteractions(lookupJdbcTemplate);
+    }
+
+    @Test
+    void postgresBookRepository_fetchByCanonicalId_shouldHydrateSectionsAfterBaseQueryReturns() throws Exception {
+        JdbcTemplate repositoryJdbcTemplate = mock(JdbcTemplate.class);
+        UUID bookId = UUID.randomUUID();
+        AtomicBoolean baseQueryActive = new AtomicBoolean(false);
+        when(repositoryJdbcTemplate.query(
+            anyString(),
+            org.mockito.ArgumentMatchers.<PreparedStatementSetter>any(),
+            org.mockito.ArgumentMatchers.<ResultSetExtractor<?>>any()
+        )).thenAnswer(invocation -> {
+            String sql = invocation.getArgument(0);
+            ResultSetExtractor<?> extractor = invocation.getArgument(2);
+            if (sql.contains("SELECT id::text, slug, title")) {
+                baseQueryActive.set(true);
+                try {
+                    return extractor.extractData(baseBookResultSet(bookId));
+                } finally {
+                    baseQueryActive.set(false);
+                }
+            }
+            assertThat(baseQueryActive).isFalse();
+            ResultSet emptyResultSet = mock(ResultSet.class);
+            when(emptyResultSet.next()).thenReturn(false);
+            return extractor.extractData(emptyResultSet);
+        });
+        when(repositoryJdbcTemplate.query(
+            anyString(),
+            org.mockito.ArgumentMatchers.<PreparedStatementSetter>any(),
+            org.mockito.ArgumentMatchers.<RowMapper<?>>any()
+        )).thenAnswer(invocation -> {
+            assertThat(baseQueryActive).isFalse();
+            return List.of();
+        });
+        org.mockito.Mockito.doAnswer(invocation -> {
+            assertThat(baseQueryActive).isFalse();
+            return null;
+        }).when(repositoryJdbcTemplate).query(
+            anyString(),
+            org.mockito.ArgumentMatchers.<PreparedStatementSetter>any(),
+            org.mockito.ArgumentMatchers.<RowCallbackHandler>any()
+        );
+        PostgresBookRepository repository = new PostgresBookRepository(
+            repositoryJdbcTemplate,
+            new ObjectMapper(),
+            new BookLookupService(repositoryJdbcTemplate)
+        );
+
+        Optional<Book> result = repository.fetchByCanonicalId(bookId.toString());
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(bookId.toString());
+        assertThat(result.get().getInPostgres()).isTrue();
+    }
+
+    @Test
     void bookLookupService_shouldResolveEquivalentIsbn10_When_LookingUpIsbn13() {
         JdbcTemplate lookupJdbcTemplate = mock(JdbcTemplate.class);
         when(lookupJdbcTemplate.queryForObject(
@@ -370,5 +463,21 @@ class PersistenceSupportServicesTest {
             when(resultSet.next()).thenReturn(false);
             return extractor.extractData(resultSet);
         });
+    }
+
+    private ResultSet baseBookResultSet(UUID bookId) throws Exception {
+        ResultSet resultSet = mock(ResultSet.class);
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getString("id")).thenReturn(bookId.toString());
+        when(resultSet.getString("slug")).thenReturn("stable-book");
+        when(resultSet.getString("title")).thenReturn("Stable Book");
+        when(resultSet.getString("description")).thenReturn("A book that can hydrate without nested pool borrowing.");
+        when(resultSet.getString("isbn10")).thenReturn(null);
+        when(resultSet.getString("isbn13")).thenReturn(null);
+        when(resultSet.getDate("published_date")).thenReturn(null);
+        when(resultSet.getString("language")).thenReturn("en");
+        when(resultSet.getString("publisher")).thenReturn("findmybook");
+        when(resultSet.getObject("page_count")).thenReturn(null);
+        return resultSet;
     }
 }

--- a/src/test/java/net/findmybook/service/PostgresBookReaderDedupeTest.java
+++ b/src/test/java/net/findmybook/service/PostgresBookReaderDedupeTest.java
@@ -97,10 +97,16 @@ class PostgresBookReaderDedupeTest {
                         return canonical.getRawJsonResponse();
                     }
                     return null;
-                });
+        });
 
         lenient().<java.util.List<?>>when(jdbcTemplate.query(anyString(), any(PreparedStatementSetter.class), ArgumentMatchers.<RowMapper<?>>any()))
-                .thenReturn(List.of());
+                .thenAnswer(invocation -> {
+                    String sql = normalizeSql(invocation.getArgument(0));
+                    if (sql.startsWith("SELECT b.id::text as edition_id")) {
+                        return copyEditions(canonical.getOtherEditions());
+                    }
+                    return List.of();
+                });
 
         lenient().when(jdbcTemplate.queryForObject(anyString(), Mockito.eq(java.util.UUID.class), any()))
                 .thenThrow(new EmptyResultDataAccessException(1));
@@ -156,6 +162,23 @@ class PostgresBookReaderDedupeTest {
         clone.setRawJsonResponse(original.getRawJsonResponse());
         clone.setAuthors(new java.util.ArrayList<>(original.getAuthors()));
         clone.setOtherEditions(new java.util.ArrayList<>(original.getOtherEditions()));
+        return clone;
+    }
+
+    private List<Book.Edition> copyEditions(List<Book.Edition> editions) {
+        return editions.stream()
+                .map(this::copyEdition)
+                .toList();
+    }
+
+    private Book.Edition copyEdition(Book.Edition original) {
+        Book.Edition clone = new Book.Edition();
+        clone.setIdentifier(original.getIdentifier());
+        clone.setGoogleBooksId(original.getGoogleBooksId());
+        clone.setEditionIsbn13(original.getEditionIsbn13());
+        clone.setEditionIsbn10(original.getEditionIsbn10());
+        clone.setType(original.getType());
+        clone.setCoverImageUrl(original.getCoverImageUrl());
         return clone;
     }
 }


### PR DESCRIPTION
## Summary
Book detail pages now avoid the production 500 paths seen in live logs and render missing books as the normal not-found experience. This keeps malformed or stale book URLs explicit, recoverable, and free of raw HTTP error banners.

## Changes

### Bug Fixes
- **Malformed book slugs now miss safely instead of crashing the page**: unmatched paths such as `/book/heavens-` stop after slug/external-ID/ISBN resolution and no longer fall through to UUID-cast SQL (`BookIdentifierResolver.resolveCanonicalId`, `BookLookupService.findBookById`).
- **Book detail hydration no longer starves the JDBC pool under concurrent traffic**: section, edition, cover, recommendation, provider, and data-source queries now run after the base book row query returns its connection (`PostgresBookRepository.loadAggregate`).
- **Missing book detail routes now render the normal not-found recovery page**: true 404s show search and home actions instead of a red `HTTP 404` banner (`BookPage.svelte`, `NotFoundPage.svelte`).
- **Regression coverage now pins the live failure modes**: tests prove non-UUID IDs do not query canonical ID SQL, unresolved slug fragments do not call canonical ID lookup, section hydration starts after the base query exits, and no-fallback 404s render the not-found page (`PersistenceSupportServicesTest`, `PostgresBookReaderDedupeTest`, `router.book-page.test.ts`).

## Breaking Changes
None

## Verification
- `./gradlew test --tests "net.findmybook.service.PersistenceSupportServicesTest" -PskipFrontend`
- `./gradlew test --tests "net.findmybook.controller.HomeControllerTest" -PskipFrontend`
- `./gradlew test -PskipFrontend`
- `./gradlew clean test -PskipFrontend --rerun-tasks`
- `npm --prefix frontend run test -- src/lib/router/router.book-page.test.ts`
- `npm --prefix frontend run check`
- `npm --prefix frontend run lint:ox`
- `npm --prefix frontend run test`
- `npm --prefix frontend run build:css`
- pre-push hook: frontend `svelte-check`, `oxlint`, `vitest`, Gradle test

## Dev Dogfood
- `https://dev.findmybook.net` deployed `SOURCE_COMMIT=739ce8ab7d76582d7652bea030fe1f50534f8f8f`.
- `/book/heavens-` returns HTTP 404 and renders the normal “Page not found” UI on desktop and mobile, with no browser page errors or console errors.
- A direct real book route, `/book/the-martian-andy-weir`, renders the book detail page with no browser page errors or console errors.
- Parallel live book-detail probes against home-page slugs returned 200s, and the dev container log sweep found no `status 500`, UUID-cast errors, Hikari pool exhaustion, or JDBC connection exceptions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 739ce8ab7d76582d7652bea030fe1f50534f8f8f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->