### PR TITLE
Harden AI generation and cancellation lifecycle

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -160,6 +160,9 @@
     - `message_done`: `{ message }`
     - `done`: `{ message, aiContent }` where `aiContent` matches the `book.aiContent` contract
     - `error`: `{ error, code, retryable }`
+      - Queue wait is kept alive for at most ten minutes and then ends with `queue_busy`; the
+        `stream_timeout` generation deadline begins only after `started`, so queued work cannot
+        consume the model's inference budget.
       - `code` values include:
         - `identifier_required`
         - `book_not_found`

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,7 @@
   - `POST /api/covers/{identifier}/ingest`
   - `GET /api/books/ai/content/queue`
   - `POST /api/books/{identifier}/ai/content/stream?refresh={true|false}`
+  - `POST /api/books/ai/content/requests/{requestId}/cancel`
   - `GET /api/books/authors/search?query={author}`
 - **Page API (Svelte SPA):**
   - `GET /api/pages/home?popularWindow={30d|90d|all}&popularLimit={n}`
@@ -149,8 +150,12 @@
     - `refresh` (`false` by default; when `false`, cached Postgres AI snapshot is returned when present)
   - Response content type:
     - `text/event-stream`
+  - Response headers:
+    - `X-Book-AI-Request-Id`: opaque queue task ID, set before the first SSE event so clients can
+      cancel after receiving headers even when `queued` has not yet been parsed.
   - SSE events:
-    - `queued`: `{ position, running, pending, maxParallel }`
+    - `queued`: `{ requestId, position, running, pending, maxParallel }`
+      - `requestId` is an opaque identifier for this generation attempt and equals the queue task ID.
     - `queue`: periodic queue position update while pending
     - `started`: `{ running, pending, maxParallel, queueWaitMs }`
     - `message_start`: `{ id, model, apiMode }`
@@ -177,6 +182,12 @@
         - `description_too_short` (emitted only after canonical description enrichment attempts from Open Library and Google Books still fail to satisfy minimum content requirements)
         - `enrichment_failed` (emitted when book description enrichment providers are unavailable)
         - `generation_failed`
+- `POST /api/books/ai/content/requests/{requestId}/cancel`
+  - Sends no request body and returns `204 No Content`.
+  - Cancels pending or running generation through the same terminal owner used by SSE disconnects,
+    including model cancellation, queue interruption, and timer cleanup.
+  - Unknown, already-terminal, and active request IDs all return the same `204` response so the
+    endpoint does not disclose in-memory request state.
 
 ## Search Pagination
 - The `/api/books/search` endpoint defaults to 12 results per page.

--- a/docs/api.md
+++ b/docs/api.md
@@ -163,6 +163,9 @@
       - Queue wait is kept alive for at most ten minutes and then ends with `queue_busy`; the
         `stream_timeout` generation deadline begins only after `started`, so queued work cannot
         consume the model's inference budget.
+      - Cancellation and persistence share one atomic commitment boundary. Cancellation that claims
+        first prevents a new AI-content version; persistence that claims first completes its insert,
+        while the closed stream suppresses any later delivery.
       - `code` values include:
         - `identifier_required`
         - `book_not_found`
@@ -170,6 +173,7 @@
         - `stream_timeout`
         - `empty_generation`
         - `cache_serialization_failed`
+        - `queue_busy`
         - `description_too_short` (emitted only after canonical description enrichment attempts from Open Library and Google Books still fail to satisfy minimum content requirements)
         - `enrichment_failed` (emitted when book description enrichment providers are unavailable)
         - `generation_failed`

--- a/frontend/src/lib/components/BookAiContentPanel.svelte
+++ b/frontend/src/lib/components/BookAiContentPanel.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
   import { onMount, untrack } from "svelte";
   import BookAiContentPanelView from "$lib/components/BookAiContentPanelView.svelte";
-  import { isBookAiContentStreamError, streamBookAiContent } from "$lib/services/bookAiContentStream";
+  import {
+    BookAiContentRequestAttempt,
+    cancelBookAiContentRequest,
+    isBookAiContentStreamError,
+    streamBookAiContent,
+  } from "$lib/services/bookAiContentStream";
   import { getBookAiContentQueueStats } from "$lib/services/books";
   import {
     hasRenderableAiContent,
@@ -12,18 +17,15 @@
   import type {
     Book,
     BookAiContentModelStreamUpdate,
+    BookAiContentQueuedUpdate,
     BookAiContentQueueUpdate,
     BookAiContentSnapshot,
     BookAiErrorCode,
   } from "$lib/validation/schemas";
 
-  interface Props {
-    identifier: string;
-    book: Book;
-    onAiContentUpdate: (aiContent: BookAiContentSnapshot) => void;
-  }
-
-  let { identifier, book, onAiContentUpdate }: Props = $props();
+  let { identifier, book, onAiContentUpdate }: {
+    identifier: string; book: Book; onAiContentUpdate: (aiContent: BookAiContentSnapshot) => void;
+  } = $props();
 
   const COLLAPSE_STORAGE_KEY = "findmybook:ai-collapsed";
 
@@ -35,17 +37,11 @@
   let aiServiceAvailable = $state(true);
   let aiEnvironmentMode = $state(import.meta.env.DEV ? "development" : PRODUCTION_ENVIRONMENT_MODE);
   let collapsed = $state(false);
-  let aiAbortController: AbortController | null = null;
-  let activeRequestToken: symbol | null = null;
   let lastAutoTriggerIdentifier = $state<string | null>(null);
 
-  /** True when the auto-trigger $effect is about to fire but hasn't yet set aiLoading. */
-  let willAutoTrigger = $derived(
-    !!identifier
-      && !hasRenderableAiContent(book)
-      && !aiAutoTriggerDeferred
-      && lastAutoTriggerIdentifier !== identifier,
-  );
+  let activeGenerationAttempt: BookAiContentRequestAttempt | null = null;
+  let willAutoTrigger = $derived(!!identifier && !hasRenderableAiContent(book)
+    && !aiAutoTriggerDeferred && lastAutoTriggerIdentifier !== identifier);
 
   function readCollapseState(): boolean {
     try {
@@ -75,6 +71,18 @@
 
   function shouldDisplayPanel(): boolean {
     return shouldRenderPanel(aiFailureDiagnosticsEnabled(), aiServiceAvailable, book);
+  }
+
+  function isActiveAttempt(attempt: BookAiContentRequestAttempt): boolean {
+    return activeGenerationAttempt === attempt && identifier === attempt.identifier && !attempt.isCanceled;
+  }
+
+  function cancelActiveGeneration(): void {
+    const attempt = activeGenerationAttempt;
+    if (attempt !== null) {
+      attempt.cancel();
+      activeGenerationAttempt = null;
+    }
   }
 
   interface AiStreamFailure {
@@ -126,7 +134,19 @@
     }
   }
 
-  function handleAiQueueUpdate(update: BookAiContentQueueUpdate): void {
+  function handleAiQueued(attempt: BookAiContentRequestAttempt, update: BookAiContentQueuedUpdate): void {
+    attempt.captureRequestId(update.requestId);
+    if (!isActiveAttempt(attempt)) {
+      attempt.cancel();
+      return;
+    }
+    handleAiQueueUpdate(attempt, update);
+  }
+
+  function handleAiQueueUpdate(attempt: BookAiContentRequestAttempt, update: BookAiContentQueueUpdate): void {
+    if (!isActiveAttempt(attempt)) {
+      return;
+    }
     if (update.event === "queued" || update.event === "queue") {
       aiQueueMessage = update.position != null
         ? `Queued (position ${update.position}, ${update.running}/${update.maxParallel} running)`
@@ -138,22 +158,18 @@
     aiLoadingMessage = "Generating AI content...";
   }
 
-  function handleAiStreamEvent(event: BookAiContentModelStreamUpdate): void {
-    if (event.event === "message_start") {
+  function handleAiStreamEvent(attempt: BookAiContentRequestAttempt, event: BookAiContentModelStreamUpdate): void {
+    if (isActiveAttempt(attempt) && event.event === "message_start") {
       aiLoadingMessage = "Generating AI content...";
-      return;
-    }
-    if (event.event === "message_delta") {
-      return;
-    }
-    if (event.event === "message_done") {
-      /* noop — result arrives via the resolved promise */
     }
   }
 
-  async function hasQueueCapacity(refresh: boolean): Promise<boolean> {
+  async function hasQueueCapacity(refresh: boolean, attempt: BookAiContentRequestAttempt): Promise<boolean> {
     try {
       const queueStats = await getBookAiContentQueueStats();
+      if (!isActiveAttempt(attempt)) {
+        return false;
+      }
       aiEnvironmentMode = normalizeEnvironmentMode(queueStats.environmentMode);
       if (!queueStats.available) {
         aiServiceAvailable = false;
@@ -172,6 +188,9 @@
       aiServiceAvailable = true;
       return true;
     } catch (queueError) {
+      if (!isActiveAttempt(attempt)) {
+        return false;
+      }
       if (aiFailureDiagnosticsEnabled()) {
         console.error("[BookAiContentPanel] Queue stats failed:", queueError);
       } else {
@@ -202,8 +221,8 @@
     }
 
     const requestIdentifier = identifier;
-    const requestToken = Symbol("book-ai-content-request");
-    activeRequestToken = requestToken;
+    const attempt = new BookAiContentRequestAttempt(requestIdentifier, cancelBookAiContentRequest);
+    activeGenerationAttempt = attempt;
     aiLoading = true;
     aiErrorMessage = null;
     aiQueueMessage = null;
@@ -212,30 +231,35 @@
       ? "Refreshing AI content..."
       : "Generating AI content...";
 
-    const queueHasCapacity = await hasQueueCapacity(refresh);
-    if (activeRequestToken !== requestToken || identifier !== requestIdentifier) {
+    const queueHasCapacity = await hasQueueCapacity(refresh, attempt);
+    if (!isActiveAttempt(attempt)) {
       return;
     }
     if (!queueHasCapacity) {
-      activeRequestToken = null;
+      attempt.complete();
+      activeGenerationAttempt = null;
       aiLoading = false;
       return;
     }
 
-    aiAbortController?.abort();
-    aiAbortController = new AbortController();
     aiErrorMessage = null;
     aiQueueMessage = null;
 
     try {
       const result = await streamBookAiContent(requestIdentifier, {
         refresh,
-        signal: aiAbortController.signal,
-        onQueueUpdate: handleAiQueueUpdate,
-        onStreamEvent: handleAiStreamEvent,
+        signal: attempt.signal,
+        onRequestId: (requestId) => {
+          attempt.captureRequestId(requestId);
+          if (!isActiveAttempt(attempt)) attempt.cancel();
+        },
+        onQueued: (update) => handleAiQueued(attempt, update),
+        onQueueUpdate: (update) => update.event !== "queued" && handleAiQueueUpdate(attempt, update),
+        onStreamEvent: (event) => handleAiStreamEvent(attempt, event),
       });
 
-      if (activeRequestToken !== requestToken || identifier !== requestIdentifier) {
+      attempt.complete();
+      if (!isActiveAttempt(attempt)) {
         return;
       }
       onAiContentUpdate(result.aiContent);
@@ -243,10 +267,13 @@
       aiQueueMessage = null;
       aiErrorMessage = null;
     } catch (error) {
-      if (error instanceof DOMException && error.name === "AbortError") {
+      if (error instanceof DOMException && error.name === "AbortError" && attempt.isCanceled) {
         return;
       }
-      if (activeRequestToken !== requestToken) {
+      const attemptWasActive = isActiveAttempt(attempt);
+      if (!isBookAiContentStreamError(error)) attempt.cancel();
+      attempt.complete();
+      if (!attemptWasActive) {
         return;
       }
       const failure = resolveAiStreamFailure(error);
@@ -260,36 +287,26 @@
         });
       }
     } finally {
-      if (activeRequestToken === requestToken) {
-        activeRequestToken = null;
+      if (activeGenerationAttempt === attempt) {
+        activeGenerationAttempt = null;
         aiLoading = false;
       }
     }
   }
 
-  function refreshAiContent(): void {
-    void triggerAiGeneration(true);
-  }
+  function refreshAiContent(): void { void triggerAiGeneration(true); }
 
   onMount(() => {
     collapsed = readCollapseState();
-
-    return () => {
-      aiAbortController?.abort();
-    };
+    return cancelActiveGeneration;
   });
 
   $effect(() => {
-    // untrack lastAutoTriggerIdentifier so writing it doesn't create a
-    // tracked dependency that would trigger a re-run whose cleanup
-    // clearTimeout kills the pending auto-trigger before it can fire.
     if (!identifier || untrack(() => lastAutoTriggerIdentifier) === identifier) {
       return;
     }
 
-    aiAbortController?.abort();
-    aiAbortController = null;
-    activeRequestToken = null;
+    cancelActiveGeneration();
     aiLoading = false;
     aiErrorMessage = null;
     aiQueueMessage = null;
@@ -300,15 +317,11 @@
     const scheduledIdentifier = identifier;
 
     const autoTriggerDelay = setTimeout(() => {
-      // Mark this identifier as processed inside the callback so
-      // willAutoTrigger stays true (showing the spinner) until the
-      // trigger actually fires — avoiding a flash of empty content.
       lastAutoTriggerIdentifier = scheduledIdentifier;
       if (identifier !== scheduledIdentifier) {
         return;
       }
       if (!hasRenderableAiContent(book) && !aiLoading && !aiAutoTriggerDeferred) {
-        // Existing-but-degenerate snapshots must bypass cache to force regeneration.
         const requiresRefresh = Boolean(book?.aiContent);
         void triggerAiGeneration(requiresRefresh);
       }

--- a/frontend/src/lib/components/BookAiContentPanel.test.ts
+++ b/frontend/src/lib/components/BookAiContentPanel.test.ts
@@ -1,15 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
 import BookAiContentPanel from "$lib/components/BookAiContentPanel.svelte";
-import type { Book, BookAiErrorCode } from "$lib/validation/schemas";
+import type { StreamBookAiContentOptions } from "$lib/services/bookAiContentStream";
+import { BookAiContentQueuedUpdateSchema, type Book, type BookAiErrorCode } from "$lib/validation/schemas";
 
 const {
   getBookAiContentQueueStatsMock,
+  cancelBookAiContentRequestMock,
   isBookAiContentStreamErrorMock,
   streamBookAiContentMock,
   consoleErrorMock,
 } = vi.hoisted(() => ({
   getBookAiContentQueueStatsMock: vi.fn(),
+  cancelBookAiContentRequestMock: vi.fn(),
   isBookAiContentStreamErrorMock: vi.fn(() => false),
   streamBookAiContentMock: vi.fn(),
   consoleErrorMock: vi.fn(),
@@ -19,7 +22,9 @@ vi.mock("$lib/services/books", () => ({
   getBookAiContentQueueStats: getBookAiContentQueueStatsMock,
 }));
 
-vi.mock("$lib/services/bookAiContentStream", () => ({
+vi.mock("$lib/services/bookAiContentStream", async (importOriginal) => ({
+  ...await importOriginal<typeof import("$lib/services/bookAiContentStream")>(),
+  cancelBookAiContentRequest: cancelBookAiContentRequestMock,
   isBookAiContentStreamError: isBookAiContentStreamErrorMock,
   streamBookAiContent: streamBookAiContentMock,
 }));
@@ -57,8 +62,19 @@ describe("BookAiContentPanel production behavior", () => {
     };
   }
 
+  function queued(requestId: string) {
+    return BookAiContentQueuedUpdateSchema.parse({
+      event: "queued", requestId, position: 1, running: 0, pending: 1, maxParallel: 1,
+    });
+  }
+
+  function streamOptions(callIndex = 0): StreamBookAiContentOptions {
+    return streamBookAiContentMock.mock.calls[callIndex]?.[1] as StreamBookAiContentOptions;
+  }
+
   beforeEach(() => {
     getBookAiContentQueueStatsMock.mockReset();
+    cancelBookAiContentRequestMock.mockReset();
     consoleErrorMock.mockReset();
     vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(consoleErrorMock);
@@ -153,12 +169,13 @@ describe("BookAiContentPanel production behavior", () => {
 
   it("shouldKeepPreviousContentAndShowGenericErrorWhenRefreshFailsInProduction", async () => {
     const providerFailureDetail = "provider detail must remain private";
-    streamBookAiContentMock.mockRejectedValue(
-      createStreamError(providerFailureDetail, "generation_failed", true),
-    );
+    streamBookAiContentMock.mockImplementation((_identifier, options: StreamBookAiContentOptions) => {
+      options.onQueued?.(queued("terminal-error-request"));
+      return Promise.reject(createStreamError(providerFailureDetail, "generation_failed", true));
+    });
     const onAiContentUpdate = vi.fn();
 
-    render(BookAiContentPanel, {
+    const { unmount } = render(BookAiContentPanel, {
       props: {
         identifier: "existing-guide-book",
         book: createBookFixture({
@@ -196,21 +213,23 @@ describe("BookAiContentPanel production behavior", () => {
       { code: "generation_failed", retryable: true },
     );
     expect(onAiContentUpdate).not.toHaveBeenCalled();
+    unmount();
+    expect(cancelBookAiContentRequestMock).not.toHaveBeenCalled();
   });
 
   it("shouldAttemptRegenerationWhenExistingSummaryIsDegenerate", async () => {
-    streamBookAiContentMock.mockResolvedValue({
-      aiContent: {
-        summary: "This regenerated summary now contains enough descriptive prose to render safely.",
-        keyThemes: ["Theme"],
-        takeaways: ["Takeaway"],
-        readerFit: null,
-        context: null,
-      },
+    streamBookAiContentMock.mockImplementation((_identifier, options: StreamBookAiContentOptions) => {
+      options.onQueued?.(queued("terminal-done-request"));
+      return Promise.resolve({
+        aiContent: {
+          summary: "This regenerated summary now contains enough descriptive prose to render safely.",
+          keyThemes: ["Theme"], takeaways: ["Takeaway"], readerFit: null, context: null,
+        },
+      });
     });
     const onAiContentUpdate = vi.fn();
 
-    render(BookAiContentPanel, {
+    const { unmount } = render(BookAiContentPanel, {
       props: {
         identifier: "degenerate-summary-book",
         book: createBookFixture({
@@ -245,5 +264,60 @@ describe("BookAiContentPanel production behavior", () => {
       expect.objectContaining({ refresh: true }),
     );
     expect(onAiContentUpdate).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(cancelBookAiContentRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("shouldCancelQueuedGenerationExactlyOnceWhenUnmounted", async () => {
+    streamBookAiContentMock.mockImplementation(() => new Promise(() => {}));
+    const rendered = render(BookAiContentPanel, {
+      props: { identifier: "queued-book", book: createBookFixture({}), onAiContentUpdate: vi.fn() },
+    });
+    await waitFor(() => expect(streamBookAiContentMock).toHaveBeenCalledOnce());
+
+    const options = streamOptions();
+    options.onQueued?.(queued("queued-request"));
+    rendered.unmount();
+    options.onQueued?.(queued("queued-request"));
+
+    expect(cancelBookAiContentRequestMock).toHaveBeenCalledOnce();
+    expect(cancelBookAiContentRequestMock).toHaveBeenCalledWith("queued-request");
+    expect(options.signal?.aborted).toBe(true);
+  });
+
+  it("shouldCancelAfterResponseHeaderBeforeQueuedEventIsParsed", async () => {
+    streamBookAiContentMock.mockImplementation(() => new Promise(() => {}));
+    const rendered = render(BookAiContentPanel, {
+      props: { identifier: "late-queue-book", book: createBookFixture({}), onAiContentUpdate: vi.fn() },
+    });
+    await waitFor(() => expect(streamBookAiContentMock).toHaveBeenCalledOnce());
+
+    const options = streamOptions();
+    options.onRequestId?.("header-request");
+    rendered.unmount();
+
+    expect(cancelBookAiContentRequestMock).toHaveBeenCalledOnce();
+    expect(cancelBookAiContentRequestMock).toHaveBeenCalledWith("header-request");
+  });
+
+  it("shouldIgnoreStaleQueueCallbacksAfterIdentifierChange", async () => {
+    streamBookAiContentMock.mockImplementation(() => new Promise(() => {}));
+    const rendered = render(BookAiContentPanel, {
+      props: { identifier: "first-book", book: createBookFixture({}), onAiContentUpdate: vi.fn() },
+    });
+    await waitFor(() => expect(streamBookAiContentMock).toHaveBeenCalledOnce());
+    const firstOptions = streamOptions();
+    firstOptions.onRequestId?.("first-request");
+
+    await rendered.rerender({
+      identifier: "second-book", book: createBookFixture({ id: "second-book", slug: "second-book" }),
+      onAiContentUpdate: vi.fn(),
+    });
+    firstOptions.onQueued?.(queued("first-request"));
+    firstOptions.onQueueUpdate?.({ event: "queue", position: 99, running: 0, pending: 1, maxParallel: 1 });
+
+    expect(cancelBookAiContentRequestMock).toHaveBeenCalledOnce();
+    expect(cancelBookAiContentRequestMock).toHaveBeenCalledWith("first-request");
+    expect(screen.queryByText(/position 99/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/lib/services/bookAiContentStream.ts
+++ b/frontend/src/lib/services/bookAiContentStream.ts
@@ -2,6 +2,7 @@ import { validateWithSchema } from "$lib/validation/validate";
 import {
   type BookAiErrorCode,
   type BookAiContentModelStreamUpdate,
+  type BookAiContentQueuedUpdate,
   type BookAiContentQueueUpdate,
   type BookAiContentSnapshot,
   BookAiContentStreamErrorSchema,
@@ -13,6 +14,8 @@ import {
 export interface StreamBookAiContentOptions {
   refresh?: boolean;
   signal?: AbortSignal;
+  onRequestId?: (requestId: string) => void;
+  onQueued?: (update: BookAiContentQueuedUpdate) => void;
   onQueueUpdate?: (update: BookAiContentQueueUpdate) => void;
   onStreamEvent?: (event: BookAiContentModelStreamUpdate) => void;
 }
@@ -27,10 +30,78 @@ export interface BookAiContentStreamError extends Error {
   retryable: boolean;
 }
 
+/** Owns browser transport state for exactly one AI generation attempt. */
+export class BookAiContentRequestAttempt {
+  readonly abortController = new AbortController();
+  private requestId: string | null = null;
+  private canceled = false;
+  private cancellationSent = false;
+  private terminal = false;
+
+  constructor(readonly identifier: string,
+    private readonly deliverCancellation: (requestId: string) => void = cancelBookAiContentRequest,
+  ) {}
+
+  get signal(): AbortSignal { return this.abortController.signal; }
+
+  get isCanceled(): boolean { return this.canceled; }
+
+  captureRequestId(requestId: string): void {
+    if (this.requestId !== null && this.requestId !== requestId) {
+      throw new Error("Book AI request ID changed during one generation attempt");
+    }
+    this.requestId = requestId;
+    this.sendCancellationIfNeeded();
+  }
+
+  cancel(): void {
+    if (this.terminal) {
+      return;
+    }
+    this.canceled = true;
+    this.abortController.abort();
+    this.sendCancellationIfNeeded();
+  }
+
+  complete(): void {
+    this.requestId = null;
+    this.terminal = true;
+  }
+
+  private sendCancellationIfNeeded(): void {
+    if (!this.canceled || this.requestId === null || this.cancellationSent || this.terminal) {
+      return;
+    }
+    this.cancellationSent = true;
+    this.deliverCancellation(this.requestId);
+  }
+}
+
 export function isBookAiContentStreamError(error: unknown): error is BookAiContentStreamError {
   return error instanceof Error
     && typeof (error as { code?: unknown }).code === "string"
     && typeof (error as { retryable?: unknown }).retryable === "boolean";
+}
+
+/** Delivers a bodyless, same-origin cancellation without blocking route teardown. */
+export function cancelBookAiContentRequest(requestId: string): void {
+  const cancelUrl = `/api/books/ai/content/requests/${encodeURIComponent(requestId)}/cancel`;
+  if (typeof navigator !== "undefined" && typeof navigator.sendBeacon === "function") {
+    try {
+      if (navigator.sendBeacon(cancelUrl)) {
+        return;
+      }
+    } catch {
+      // A rejected beacon falls through to the keepalive fetch transport.
+    }
+  }
+
+  void fetch(cancelUrl, {
+    method: "POST",
+    keepalive: true,
+  }).then((response) => {
+    if (!response.ok) console.warn("[BookAiContentStream] Explicit cancellation delivery failed");
+  }, () => console.warn("[BookAiContentStream] Explicit cancellation delivery failed"));
 }
 
 function createBookAiContentStreamError(
@@ -98,6 +169,7 @@ async function assertSseContentType(response: Response): Promise<void> {
 async function readBookAiContentSseStream(
   response: Response,
   options: StreamBookAiContentOptions,
+  initialRequestId: string | null,
 ): Promise<StreamBookAiContentResult> {
   const reader = response.body?.getReader();
   if (!reader) {
@@ -107,6 +179,7 @@ async function readBookAiContentSseStream(
   const decoder = new TextDecoder();
   let buffer = "";
   let pendingCarriageReturn = false;
+  let requestId = initialRequestId;
 
   const processMessage = (message: { event: string; payloadText: string }): StreamBookAiContentResult | null => {
     if (message.event === "error") {
@@ -136,6 +209,16 @@ async function readBookAiContentSseStream(
         `bookAiContentQueueUpdate:${message.event}`,
       );
       if (queueUpdate.success) {
+        if (queueUpdate.data.event === "queued") {
+          if (requestId !== null && requestId !== queueUpdate.data.requestId) {
+            throw new Error("Book AI request ID did not match queued stream payload");
+          }
+          if (requestId === null) {
+            requestId = queueUpdate.data.requestId;
+            options.onRequestId?.(requestId);
+          }
+          options.onQueued?.(queueUpdate.data);
+        }
         options.onQueueUpdate?.(queueUpdate.data);
       }
       return null;
@@ -258,6 +341,10 @@ export async function streamBookAiContent(
     throw new Error(`Book AI stream failed (HTTP ${response.status}): ${responseText || response.statusText}`);
   }
 
+  const headerRequestId = response.headers.get("X-Book-AI-Request-Id")?.trim() || null;
+  if (headerRequestId !== null) {
+    options.onRequestId?.(headerRequestId);
+  }
   await assertSseContentType(response);
-  return readBookAiContentSseStream(response, options);
+  return readBookAiContentSseStream(response, options, headerRequestId);
 }

--- a/frontend/src/lib/validation/schemas.test.ts
+++ b/frontend/src/lib/validation/schemas.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from "vitest";
-import { resolveCoverDisplayUrl, CoverSchema, buildCover } from "$lib/validation/schemas";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cancelBookAiContentRequest, streamBookAiContent } from "$lib/services/bookAiContentStream";
+import {
+  BookAiContentQueuedUpdateSchema,
+  BookAiContentQueueUpdateSchema,
+  CoverSchema,
+  buildCover,
+  resolveCoverDisplayUrl,
+} from "$lib/validation/schemas";
 
 describe("resolveCoverDisplayUrl", () => {
   it("should_ReturnPreferredUrl_When_AllUrlsPresent", () => {
@@ -85,5 +92,107 @@ describe("buildCover", () => {
     const cover = buildCover({ externalImageUrl: "ext" });
 
     expect(cover.displayUrl).toBe("ext");
+  });
+});
+
+describe("BookAiContentQueueUpdateSchema", () => {
+  it("shouldRequireRequestIdForInitialQueuedEvent", () => {
+    const result = BookAiContentQueuedUpdateSchema.safeParse({
+      event: "queued", position: 1, running: 0, pending: 1, maxParallel: 1,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("shouldNotRequireRequestIdForPeriodicQueueEvent", () => {
+    const result = BookAiContentQueueUpdateSchema.safeParse({
+      event: "queue", position: 1, running: 0, pending: 1, maxParallel: 1,
+    });
+
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("cancelBookAiContentRequest", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("shouldUseBodylessBeaconWhenAvailable", () => {
+    const sendBeacon = vi.fn(() => true);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("navigator", { sendBeacon });
+    vi.stubGlobal("fetch", fetchMock);
+
+    cancelBookAiContentRequest("request/id");
+
+    expect(sendBeacon).toHaveBeenCalledWith("/api/books/ai/content/requests/request%2Fid/cancel");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("shouldFallbackToBodylessKeepaliveFetchWhenBeaconDeclines", () => {
+    const fetchMock = vi.fn<typeof fetch>(() => Promise.resolve(new Response(null, { status: 204 })));
+    vi.stubGlobal("navigator", { sendBeacon: vi.fn(() => false) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    cancelBookAiContentRequest("request-2");
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/books/ai/content/requests/request-2/cancel", {
+      method: "POST",
+      keepalive: true,
+    });
+    expect(fetchMock.mock.calls[0]?.[1]).not.toHaveProperty("body");
+  });
+
+  it("shouldWarnWithoutResponseDetailWhenKeepaliveCancellationIsRejected", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubGlobal("navigator", { sendBeacon: vi.fn(() => false) });
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>(() => Promise.resolve(new Response(null, { status: 503 }))));
+
+    cancelBookAiContentRequest("request-3");
+    await vi.waitFor(() => expect(warning).toHaveBeenCalledOnce());
+
+    expect(warning).toHaveBeenCalledWith("[BookAiContentStream] Explicit cancellation delivery failed");
+    expect(warning).not.toHaveBeenCalledWith(expect.stringContaining("503"));
+  });
+});
+
+describe("streamBookAiContent request identity", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  function streamBody(requestId: string): string {
+    return [
+      `event: queued\ndata: ${JSON.stringify({
+        requestId, position: 1, running: 0, pending: 1, maxParallel: 1,
+      })}`,
+      `event: done\ndata: ${JSON.stringify({
+        message: "complete", aiContent: { summary: "Summary", keyThemes: [] },
+      })}`,
+      "",
+    ].join("\n\n");
+  }
+
+  it("shouldExposeHeaderRequestIdBeforeQueuedEvent", async () => {
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>(() => Promise.resolve(new Response(streamBody("request-1"), {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream", "X-Book-AI-Request-Id": "request-1" },
+    }))));
+    const callbackOrder: string[] = [];
+
+    await streamBookAiContent("book", {
+      onRequestId: (requestId) => callbackOrder.push(`header:${requestId}`),
+      onQueued: (update) => callbackOrder.push(`queued:${update.requestId}`),
+    });
+
+    expect(callbackOrder).toEqual(["header:request-1", "queued:request-1"]);
+  });
+
+  it("shouldRejectWhenHeaderAndQueuedRequestIdsDiffer", async () => {
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>(() => Promise.resolve(new Response(streamBody("queued-request"), {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream", "X-Book-AI-Request-Id": "header-request" },
+    }))));
+
+    await expect(streamBookAiContent("book")).rejects.toThrow(
+      "Book AI request ID did not match queued stream payload",
+    );
   });
 });

--- a/frontend/src/lib/validation/schemas.ts
+++ b/frontend/src/lib/validation/schemas.ts
@@ -289,9 +289,19 @@ export const BookAiContentQueueStatsSchema = z.object({
   environmentMode: z.string().default("production"),
 });
 
+export const BookAiContentQueuedUpdateSchema = z.object({
+  event: z.literal("queued"),
+  requestId: z.string().min(1),
+  position: z.int().nullable().optional(),
+  running: z.int().nonnegative(),
+  pending: z.int().nonnegative(),
+  maxParallel: z.int().positive(),
+});
+
 export const BookAiContentQueueUpdateSchema = z.union([
+  BookAiContentQueuedUpdateSchema,
   z.object({
-    event: z.enum(["queued", "queue"]),
+    event: z.literal("queue"),
     position: z.int().nullable().optional(),
     running: z.int().nonnegative(),
     pending: z.int().nonnegative(),
@@ -382,6 +392,7 @@ export type Book = z.infer<typeof BookSchema>;
 export type ViewMetrics = z.infer<typeof ViewMetricsSchema>;
 export type BookAiContentSnapshot = z.infer<typeof BookAiContentSnapshotSchema>;
 export type BookAiContentQueueStats = z.infer<typeof BookAiContentQueueStatsSchema>;
+export type BookAiContentQueuedUpdate = z.infer<typeof BookAiContentQueuedUpdateSchema>;
 export type BookAiContentQueueUpdate = z.infer<typeof BookAiContentQueueUpdateSchema>;
 export type BookAiContentModelStreamUpdate = z.infer<typeof BookAiContentModelStreamUpdateSchema>;
 export type BookAiErrorCode = z.infer<typeof BookAiErrorCodeSchema>;

--- a/src/main/java/net/findmybook/application/ai/AiContentJsonParser.java
+++ b/src/main/java/net/findmybook/application/ai/AiContentJsonParser.java
@@ -1,9 +1,11 @@
 package net.findmybook.application.ai;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import net.findmybook.domain.ai.BookAiContent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,16 +17,17 @@ import tools.jackson.databind.ObjectMapper;
 /**
  * Parses raw LLM response text into a structured {@link BookAiContent} record.
  *
- * <p>Handles markdown fences, brace extraction fallback, and field-alias
- * resolution so the calling service stays free of JSON-level concerns.
+ * <p>Accepts only the canonical JSON object contract requested from the provider,
+ * so malformed or drifted responses are rejected and retried by the calling service.
  */
 class AiContentJsonParser {
 
     private static final Logger log = LoggerFactory.getLogger(AiContentJsonParser.class);
     private static final int MAX_KEY_THEME_COUNT = 6;
     private static final int MAX_TAKEAWAY_COUNT = 5;
-    private static final int SUMMARY_SENTENCE_LIMIT = 2;
-
+    private static final Set<String> CANONICAL_TOP_LEVEL_FIELDS = Arrays.stream(BookAiContent.class.getRecordComponents())
+        .map(recordComponent -> recordComponent.getName())
+        .collect(Collectors.toUnmodifiableSet());
     private final ObjectMapper objectMapper;
 
     AiContentJsonParser(ObjectMapper objectMapper) {
@@ -35,36 +38,26 @@ class AiContentJsonParser {
      * Parses AI response text into structured book content.
      *
      * <p>The returned {@link BookAiContent} always has a non-null {@code summary}
-     * and {@code keyThemes} list. The {@code readerFit}, {@code takeaways}, and
-     * {@code context} fields are {@code @Nullable} — they are null when the LLM
-     * response omits the field or provides an empty/whitespace-only value.</p>
+     * and {@code keyThemes} list. Every canonical top-level key is required in
+     * the response. The optional text values {@code readerFit} and {@code context}
+     * may be JSON {@code null}; the nullable {@code takeaways} domain field may
+     * also be JSON {@code null}, while an empty array remains valid.</p>
      *
-     * @param responseText raw LLM output (may include markdown fences)
+     * @param responseText raw LLM JSON output
      * @return parsed content with nullable optional fields per {@link BookAiContent}
-     * @throws IllegalStateException if the response is empty, not valid JSON, or missing {@code summary}
+     * @throws IllegalStateException if the response violates the canonical JSON contract
      */
     BookAiContent parse(String responseText) {
         if (!StringUtils.hasText(responseText)) {
             throw new IllegalStateException("AI content response was empty");
         }
 
-        JsonNode payload;
-        try {
-            payload = parseJsonPayload(responseText);
-        } catch (IllegalStateException parseFailure) {
-            Optional<BookAiContent> plainTextFallback = parsePlainTextFallback(responseText);
-            if (plainTextFallback.isPresent()) {
-                log.warn("AI response was non-JSON; applied plain-text parsing fallback");
-                return plainTextFallback.get();
-            }
-            log.warn("AI response parsing failed and fallback produced no content (length={}, error={})",
-                responseText.length(), parseFailure.getMessage());
-            throw parseFailure;
-        }
+        JsonNode payload = parseJsonPayload(responseText);
+        validateExactTopLevelKeys(payload);
         String summary = requiredText(payload, "summary");
-        Optional<String> readerFit = optionalText(payload, "readerFit", "reader_fit", "idealReader");
-        List<String> themes = stringList(payload, MAX_KEY_THEME_COUNT, "keyThemes", "key_themes", "themes");
-        List<String> takeaways = stringList(payload, MAX_TAKEAWAY_COUNT, "takeaways");
+        Optional<String> readerFit = optionalText(payload, "readerFit");
+        List<String> themes = requiredStringList(payload, MAX_KEY_THEME_COUNT, "keyThemes");
+        List<String> takeaways = nullableStringList(payload, MAX_TAKEAWAY_COUNT, "takeaways");
         Optional<String> context = optionalText(payload, "context");
 
         if (themes.isEmpty() && takeaways.isEmpty()) {
@@ -80,265 +73,96 @@ class AiContentJsonParser {
     }
 
     private JsonNode parseJsonPayload(String responseText) {
-        String cleaned = responseText.replace("```json", "").replace("```", "").trim();
         try {
-            return objectMapper.readTree(cleaned);
-        } catch (JacksonException initialParseException) {
-            int openBrace = cleaned.indexOf('{');
-            int closeBrace = cleaned.lastIndexOf('}');
-            if (openBrace < 0 || closeBrace <= openBrace) {
-                throw new IllegalStateException("AI response did not include a valid JSON object");
+            JsonNode payload = objectMapper.readTree(responseText.trim());
+            if (!payload.isObject()) {
+                throw new IllegalStateException("AI response must be a JSON object");
             }
-            log.warn("AI response required brace extraction fallback (initial parse failed: {})", initialParseException.getMessage());
-            String extracted = cleaned.substring(openBrace, closeBrace + 1);
-            try {
-                return objectMapper.readTree(extracted);
-            } catch (JacksonException exception) {
-                throw new IllegalStateException("AI response JSON parsing failed", exception);
-            }
+            return payload;
+        } catch (JacksonException exception) {
+            throw new IllegalStateException("AI response did not include a valid JSON object", exception);
         }
     }
 
-    private String requiredText(JsonNode payload, String field, String... aliases) {
-        return optionalText(payload, field, aliases)
-            .orElseThrow(() -> new IllegalStateException("AI response missing required field: " + field));
+    private String requiredText(JsonNode payload, String field) {
+        JsonNode fieldNode = payload.path(field);
+        if (!fieldNode.isString()) {
+            throw invalidFieldType(field, "a nonblank JSON string");
+        }
+        String text = fieldNode.stringValue();
+        if (!StringUtils.hasText(text)) {
+            throw new IllegalStateException("AI response field must be nonblank: " + field);
+        }
+        return text.trim();
     }
 
-    private Optional<String> optionalText(JsonNode payload, String field, String... aliases) {
-        return resolveJsonNode(payload, field, aliases)
-            .map(node -> node.asString(null))
-            .filter(StringUtils::hasText)
-            .map(String::trim);
+    private Optional<String> optionalText(JsonNode payload, String field) {
+        JsonNode fieldNode = payload.path(field);
+        if (fieldNode.isNull()) {
+            return Optional.empty();
+        }
+        if (!fieldNode.isString()) {
+            throw invalidFieldType(field, "a JSON string or null");
+        }
+        String text = fieldNode.stringValue();
+        return StringUtils.hasText(text) ? Optional.of(text.trim()) : Optional.empty();
     }
 
-    private List<String> stringList(JsonNode payload, int maxSize, String field, String... aliases) {
-        Optional<JsonNode> node = resolveJsonNode(payload, field, aliases);
-        if (node.isEmpty() || !node.get().isArray()) {
+    private List<String> requiredStringList(JsonNode payload, int maxSize, String field) {
+        return stringList(payload.path(field), maxSize, field);
+    }
+
+    private List<String> nullableStringList(JsonNode payload, int maxSize, String field) {
+        JsonNode fieldNode = payload.path(field);
+        if (fieldNode.isNull()) {
             return List.of();
         }
-        List<String> values = new ArrayList<>();
-        for (JsonNode elementNode : node.get()) {
-            if (elementNode == null || elementNode.isNull()) {
-                continue;
+        return stringList(fieldNode, maxSize, field);
+    }
+
+    private List<String> stringList(JsonNode fieldNode, int maxSize, String field) {
+        if (!fieldNode.isArray()) {
+            throw invalidFieldType(field, "an array of JSON strings");
+        }
+        if (fieldNode.size() > maxSize) {
+            throw new IllegalStateException(
+                "AI response field exceeds maximum item count for %s: %d > %d"
+                    .formatted(field, fieldNode.size(), maxSize)
+            );
+        }
+        List<String> values = new ArrayList<>(fieldNode.size());
+        for (int index = 0; index < fieldNode.size(); index++) {
+            JsonNode elementNode = fieldNode.get(index);
+            if (!elementNode.isString()) {
+                throw invalidFieldType("%s[%d]".formatted(field, index), "a nonblank JSON string");
             }
-            String text = elementNode.asString(null);
+            String text = elementNode.stringValue();
             if (!StringUtils.hasText(text)) {
-                continue;
+                throw new IllegalStateException(
+                    "AI response field item must be nonblank: %s[%d]".formatted(field, index)
+                );
             }
             values.add(text.trim());
-            if (values.size() == maxSize) {
-                break;
+        }
+        return List.copyOf(values);
+    }
+
+    private void validateExactTopLevelKeys(JsonNode payload) {
+        payload.properties().forEach(entry -> {
+            if (!CANONICAL_TOP_LEVEL_FIELDS.contains(entry.getKey())) {
+                throw new IllegalStateException("AI response contains unknown field: " + entry.getKey());
+            }
+        });
+        for (String field : CANONICAL_TOP_LEVEL_FIELDS) {
+            if (!payload.has(field)) {
+                throw new IllegalStateException("AI response missing required field: " + field);
             }
         }
-        return values.isEmpty() ? List.of() : List.copyOf(values);
     }
 
-    private Optional<JsonNode> resolveJsonNode(JsonNode payload, String field, String... aliases) {
-        JsonNode node = payload.get(field);
-        if (node != null && !node.isNull()) {
-            return Optional.of(node);
-        }
-        for (String alias : aliases) {
-            JsonNode aliasNode = payload.get(alias);
-            if (aliasNode != null && !aliasNode.isNull()) {
-                return Optional.of(aliasNode);
-            }
-        }
-        return Optional.empty();
-    }
-
-    private Optional<BookAiContent> parsePlainTextFallback(String responseText) {
-        String cleaned = responseText
-            .replace("```json", "")
-            .replace("```", "")
-            .trim();
-        if (!StringUtils.hasText(cleaned) || cleaned.startsWith("{") || cleaned.startsWith("[")) {
-            return Optional.empty();
-        }
-
-        List<String> summaryLines = new ArrayList<>();
-        List<String> readerFitLines = new ArrayList<>();
-        List<String> themeLines = new ArrayList<>();
-        List<String> takeawayLines = new ArrayList<>();
-        List<String> contextLines = new ArrayList<>();
-        List<String> unscopedLines = new ArrayList<>();
-
-        Section activeSection = Section.NONE;
-        for (String rawLine : cleaned.split("\\R")) {
-            String line = normalizeLine(rawLine);
-            if (!StringUtils.hasText(line)) {
-                continue;
-            }
-
-            Optional<SectionMatch> sectionMatch = matchSectionHeader(line);
-            if (sectionMatch.isPresent()) {
-                SectionMatch match = sectionMatch.get();
-                activeSection = match.section();
-                if (StringUtils.hasText(match.remainder())) {
-                    appendToSection(
-                        match.section(),
-                        match.remainder(),
-                        summaryLines,
-                        readerFitLines,
-                        themeLines,
-                        takeawayLines,
-                        contextLines,
-                        unscopedLines
-                    );
-                }
-                continue;
-            }
-
-            appendToSection(activeSection, line, summaryLines, readerFitLines, themeLines, takeawayLines, contextLines, unscopedLines);
-        }
-
-        Optional<String> summary = chooseSummary(summaryLines, unscopedLines);
-        if (summary.isEmpty()) {
-            return Optional.empty();
-        }
-
-        Optional<String> readerFit = joinLines(readerFitLines);
-        List<String> keyThemes = normalizeList(themeLines, MAX_KEY_THEME_COUNT);
-        List<String> takeaways = normalizeList(takeawayLines, MAX_TAKEAWAY_COUNT);
-        Optional<String> context = joinLines(contextLines);
-
-        if (keyThemes.isEmpty() && takeaways.isEmpty()) {
-            log.warn("Plain-text AI fallback produced no themes and no takeaways");
-        }
-
-        return Optional.of(new BookAiContent(
-            summary.get(),
-            readerFit.orElse(null),
-            keyThemes,
-            takeaways.isEmpty() ? null : takeaways,
-            context.orElse(null)
-        )).filter(AiContentQualityValidator::isValid);
-    }
-
-    private Optional<String> chooseSummary(List<String> summaryLines, List<String> unscopedLines) {
-        Optional<String> explicitSummary = joinLines(summaryLines);
-        if (explicitSummary.isPresent()) {
-            return explicitSummary;
-        }
-        return joinLines(unscopedLines).map(this::clampToTwoSentences);
-    }
-
-    private String clampToTwoSentences(String text) {
-        String[] sentences = text.split("(?<=[.!?])\\s+");
-        if (sentences.length <= SUMMARY_SENTENCE_LIMIT) {
-            return text;
-        }
-        return (sentences[0] + " " + sentences[1]).trim();
-    }
-
-    private Optional<String> joinLines(List<String> lines) {
-        if (lines == null || lines.isEmpty()) {
-            return Optional.empty();
-        }
-        String joined = String.join(" ", lines).replaceAll("\\s+", " ").trim();
-        if (!StringUtils.hasText(joined)) {
-            return Optional.empty();
-        }
-        return Optional.of(joined);
-    }
-
-    private List<String> normalizeList(List<String> lines, int maxSize) {
-        List<String> values = new ArrayList<>();
-        for (String line : lines) {
-            if (!StringUtils.hasText(line)) {
-                continue;
-            }
-            if (line.contains(", ")) {
-                for (String token : line.split(",\\s+")) {
-                    addDistinct(values, token, maxSize);
-                    if (values.size() == maxSize) {
-                        break;
-                    }
-                }
-            } else {
-                addDistinct(values, line, maxSize);
-            }
-            if (values.size() == maxSize) {
-                break;
-            }
-        }
-        return values.isEmpty() ? List.of() : List.copyOf(values);
-    }
-
-    private void addDistinct(List<String> values, String value, int maxSize) {
-        if (values.size() >= maxSize) {
-            return;
-        }
-        String normalized = normalizeLine(value);
-        if (!StringUtils.hasText(normalized) || values.contains(normalized)) {
-            return;
-        }
-        values.add(normalized);
-    }
-
-    private String normalizeLine(String raw) {
-        Objects.requireNonNull(raw, "raw line must not be null");
-        return raw
-            .replace('\t', ' ')
-            .replaceAll("^\\s*(?:[\\-*•]\\s+|\\d+[.)]\\s+)", "")
-            .replaceAll("\\s+", " ")
-            .trim();
-    }
-
-    private void appendToSection(Section section,
-                                 String line,
-                                 List<String> summaryLines,
-                                 List<String> readerFitLines,
-                                 List<String> themeLines,
-                                 List<String> takeawayLines,
-                                 List<String> contextLines,
-                                 List<String> unscopedLines) {
-        switch (section) {
-            case SUMMARY -> summaryLines.add(line);
-            case READER_FIT -> readerFitLines.add(line);
-            case KEY_THEMES -> themeLines.add(line);
-            case TAKEAWAYS -> takeawayLines.add(line);
-            case CONTEXT -> contextLines.add(line);
-            case NONE -> unscopedLines.add(line);
-        }
-    }
-
-    private Optional<SectionMatch> matchSectionHeader(String line) {
-        String normalized = line.replaceAll("\\s+", " ").trim();
-        return matchSection(normalized, "summary", Section.SUMMARY)
-            .or(() -> matchSection(normalized, "reader fit", Section.READER_FIT))
-            .or(() -> matchSection(normalized, "reader_fit", Section.READER_FIT))
-            .or(() -> matchSection(normalized, "ideal reader", Section.READER_FIT))
-            .or(() -> matchSection(normalized, "key themes", Section.KEY_THEMES))
-            .or(() -> matchSection(normalized, "themes", Section.KEY_THEMES))
-            .or(() -> matchSection(normalized, "takeaways", Section.TAKEAWAYS))
-            .or(() -> matchSection(normalized, "takeaway", Section.TAKEAWAYS))
-            .or(() -> matchSection(normalized, "context", Section.CONTEXT));
-    }
-
-    private Optional<SectionMatch> matchSection(String line, String label, Section section) {
-        String lowerLine = line.toLowerCase();
-        String lowerLabel = label.toLowerCase();
-        if (lowerLine.equals(lowerLabel)) {
-            return Optional.of(new SectionMatch(section, ""));
-        }
-        String prefix = lowerLabel + ":";
-        if (lowerLine.startsWith(prefix)) {
-            String remainder = line.substring(prefix.length()).trim();
-            return Optional.of(new SectionMatch(section, remainder));
-        }
-        return Optional.empty();
-    }
-
-    private enum Section {
-        NONE,
-        SUMMARY,
-        READER_FIT,
-        KEY_THEMES,
-        TAKEAWAYS,
-        CONTEXT
-    }
-
-    private record SectionMatch(Section section, String remainder) {
+    private IllegalStateException invalidFieldType(String field, String expectedType) {
+        return new IllegalStateException(
+            "AI response field %s must be %s".formatted(field, expectedType)
+        );
     }
 }

--- a/src/main/java/net/findmybook/application/ai/AiContentQualityValidator.java
+++ b/src/main/java/net/findmybook/application/ai/AiContentQualityValidator.java
@@ -29,21 +29,6 @@ class AiContentQualityValidator {
     }
 
     /**
-     * Returns true when all quality checks pass without throwing.
-     *
-     * <p>Used by the plain-text fallback path where rejection is silent
-     * rather than exceptional.</p>
-     */
-    static boolean isValid(BookAiContent content) {
-        try {
-            validate(content);
-            return true;
-        } catch (IllegalStateException _) {
-            return false;
-        }
-    }
-
-    /**
      * Validates all fields of the given AI content for quality.
      *
      * @param content parsed AI content to validate

--- a/src/main/java/net/findmybook/application/ai/BookAiContentService.java
+++ b/src/main/java/net/findmybook/application/ai/BookAiContentService.java
@@ -11,7 +11,6 @@ import com.openai.errors.OpenAIIoException;
 import com.openai.errors.OpenAIRetryableException;
 import com.openai.errors.OpenAIServiceException;
 import com.openai.models.ChatModel;
-import com.openai.models.ResponseFormatJsonObject;
 import com.openai.models.chat.completions.ChatCompletionChunk;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.models.chat.completions.ChatCompletionMessageParam;
@@ -298,7 +297,6 @@ public class BookAiContentService {
                 ChatCompletionMessageParam.ofUser(ChatCompletionUserMessageParam.builder().content(prompt).build())
             ))
             .maxCompletionTokens(tier.maxCompletionTokens())
-            .responseFormat(ResponseFormatJsonObject.builder().build())
             .temperature(SAMPLING_TEMPERATURE)
             .build();
 

--- a/src/main/java/net/findmybook/application/ai/BookAiContentService.java
+++ b/src/main/java/net/findmybook/application/ai/BookAiContentService.java
@@ -7,6 +7,9 @@ import com.openai.core.Timeout;
 import com.openai.core.http.StreamResponse;
 import com.openai.errors.OpenAIException;
 import com.openai.errors.OpenAIInvalidDataException;
+import com.openai.errors.OpenAIIoException;
+import com.openai.errors.OpenAIRetryableException;
+import com.openai.errors.OpenAIServiceException;
 import com.openai.models.ChatModel;
 import com.openai.models.chat.completions.ChatCompletionChunk;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
@@ -373,9 +376,23 @@ public class BookAiContentService {
         return switch (generationFailure.errorCode()) {
             case DEGENERATE_CONTENT, INCOMPLETE_RESPONSE, INVALID_RESPONSE -> true;
             case GENERATION_FAILED -> tier == LlmGatewayTier.LIVE_RENDER
-                && generationFailure.getCause() instanceof OpenAIException;
+                && isRetryableOpenAiFailure(generationFailure.getCause());
             case DESCRIPTION_TOO_SHORT, ENRICHMENT_FAILED -> false;
         };
+    }
+
+    private boolean isRetryableOpenAiFailure(Throwable failure) {
+        if (failure instanceof OpenAIIoException || failure instanceof OpenAIRetryableException) {
+            return true;
+        }
+        if (failure instanceof OpenAIServiceException serviceFailure) {
+            int statusCode = serviceFailure.statusCode();
+            return statusCode == 408
+                || statusCode == 409
+                || statusCode == 429
+                || (statusCode >= 500 && statusCode <= 599);
+        }
+        return false;
     }
 
     /** Indicates whether AI generation is currently configured and available. */

--- a/src/main/java/net/findmybook/application/ai/BookAiContentService.java
+++ b/src/main/java/net/findmybook/application/ai/BookAiContentService.java
@@ -11,6 +11,7 @@ import com.openai.errors.OpenAIIoException;
 import com.openai.errors.OpenAIRetryableException;
 import com.openai.errors.OpenAIServiceException;
 import com.openai.models.ChatModel;
+import com.openai.models.ResponseFormatJsonObject;
 import com.openai.models.chat.completions.ChatCompletionChunk;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.models.chat.completions.ChatCompletionMessageParam;
@@ -22,9 +23,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import net.findmybook.adapters.persistence.BookAiContentRepository;
 import net.findmybook.boot.OpenAiProperties;
 import net.findmybook.support.llm.LlmGatewayTier;
@@ -53,18 +56,17 @@ public class BookAiContentService {
     private static final int BACKGROUND_SDK_MAX_RETRIES = 2;
     private static final int MIN_DESCRIPTION_LENGTH = 50;
     private static final double SAMPLING_TEMPERATURE = 0.2;
-
     private static final String SYSTEM_PROMPT = """
         You are a knowledgeable book content writer. You receive a book's title, authors, publisher, and description. Use all context plus your genre/subject knowledge.
         ACCURACY RULES:
         - You MAY infer genre, audience, themes, and context from provided metadata.
         - You MUST NOT fabricate quotes, page counts, chapter titles, plot points, sales, awards, publication details, or biography claims absent from the description.
         - You MUST NOT invent statistics, studies, or research findings.
-        - If a field cannot be reasonably inferred, return null (string) or [] (array).
+        - If an optional field cannot be reasonably inferred, return null (string) or [] (array).
         Return ONLY strict JSON with this exact shape:
-        {"summary": string|null, "readerFit": string|null, "keyThemes": string[], "takeaways": string[], "context": string|null}
+        {"summary": string, "readerFit": string|null, "keyThemes": string[], "takeaways": string[], "context": string|null}
         Field rules:
-        - summary: 2 concise sentences. Null only if description is truly empty.
+        - summary: Exactly 2 concise, non-empty sentences grounded in the supplied description.
         - readerFit: 1-2 sentences on audience. Null if indeterminate.
         - keyThemes: 3-6 short phrases. [] only when source is too vague.
         - takeaways: 2-5 specific points. [] if unsupported.
@@ -150,11 +152,38 @@ public class BookAiContentService {
         Consumer<String> onValidatedBufferedPayload,
         LlmGatewayTier tier
     ) {
+        return generateAndPersist(bookId, onValidatedBufferedPayload, tier, new GenerationControl());
+    }
+
+    /**
+     * Generates and persists fresh AI content while honoring caller-owned cancellation.
+     *
+     * @param bookId canonical book UUID
+     * @param onValidatedBufferedPayload callback for the complete payload after validation and persistence
+     * @param tier gateway priority tier controlling the {@code X-Tier} header on outbound calls
+     * @param generationControl atomically coordinates cancellation with the persistence boundary
+     * @return generated content + persisted snapshot
+     */
+    public GeneratedContent generateAndPersist(
+        UUID bookId,
+        Consumer<String> onValidatedBufferedPayload,
+        LlmGatewayTier tier,
+        GenerationControl generationControl
+    ) {
+        requireGenerationControl(generationControl);
+        throwIfGenerationCancelled(generationControl);
         ensureAvailable();
         requireTier(tier);
         String prompt = buildPrompt(loadPromptContext(bookId));
         String promptHash = sha256(prompt);
-        return generateAndPersistFromPrompt(bookId, prompt, promptHash, onValidatedBufferedPayload, tier);
+        return generateAndPersistFromPrompt(
+            bookId,
+            prompt,
+            promptHash,
+            onValidatedBufferedPayload,
+            tier,
+            generationControl
+        );
     }
 
     /**
@@ -170,6 +199,8 @@ public class BookAiContentService {
         Consumer<String> onValidatedBufferedPayload,
         LlmGatewayTier tier
     ) {
+        GenerationControl generationControl = new GenerationControl();
+        throwIfGenerationCancelled(generationControl);
         ensureAvailable();
         requireTier(tier);
         String prompt = buildPrompt(loadPromptContext(bookId));
@@ -183,7 +214,8 @@ public class BookAiContentService {
             prompt,
             promptHash,
             onValidatedBufferedPayload,
-            tier
+            tier,
+            generationControl
         );
         return GenerationOutcome.generated(bookId, promptHash, Optional.of(generated.snapshot()));
     }
@@ -199,18 +231,21 @@ public class BookAiContentService {
         String prompt,
         String promptHash,
         Consumer<String> onValidatedBufferedPayload,
-        LlmGatewayTier tier
+        LlmGatewayTier tier,
+        GenerationControl generationControl
     ) {
         int maxGenerationAttempts = tier.maxGenerationAttempts();
         BookAiGenerationException lastGenerationFailure = null;
         for (int attempt = 1; attempt <= maxGenerationAttempts; attempt++) {
+            throwIfGenerationCancelled(generationControl);
             AtomicBoolean deliveredValidatedPayload = new AtomicBoolean(false);
             try {
                 return generateAndPersistSingleAttempt(bookId, prompt, promptHash, validatedBufferedPayload -> {
                     deliveredValidatedPayload.set(true);
                     onValidatedBufferedPayload.accept(validatedBufferedPayload);
-                }, tier);
+                }, tier, generationControl);
             } catch (BookAiGenerationException generationFailure) {
+                throwIfGenerationCancelled(generationControl);
                 lastGenerationFailure = generationFailure;
                 boolean retryDoesNotReplayValidatedPayload = tier == LlmGatewayTier.BACKGROUND_BATCH
                     || !deliveredValidatedPayload.get();
@@ -247,8 +282,10 @@ public class BookAiContentService {
         String prompt,
         String promptHash,
         Consumer<String> onValidatedBufferedPayload,
-        LlmGatewayTier tier
+        LlmGatewayTier tier,
+        GenerationControl generationControl
     ) {
+        throwIfGenerationCancelled(generationControl);
         OpenAIClient tieredClient = clientsByTier.get(tier);
         if (tieredClient == null) {
             throw new BookAiGenerationException(BookAiGenerationException.ErrorCode.GENERATION_FAILED,
@@ -261,6 +298,7 @@ public class BookAiContentService {
                 ChatCompletionMessageParam.ofUser(ChatCompletionUserMessageParam.builder().content(prompt).build())
             ))
             .maxCompletionTokens(tier.maxCompletionTokens())
+            .responseFormat(ResponseFormatJsonObject.builder().build())
             .temperature(SAMPLING_TEMPERATURE)
             .build();
 
@@ -281,6 +319,7 @@ public class BookAiContentService {
         AtomicBoolean refusalPresent = new AtomicBoolean(false);
         try (StreamResponse<ChatCompletionChunk> stream = tieredClient.chat().completions().createStreaming(params, options)) {
             stream.stream().forEach(chunk -> {
+                throwIfGenerationCancelled(generationControl);
                 if (chunk.choices().isEmpty()) {
                     return;
                 }
@@ -295,6 +334,7 @@ public class BookAiContentService {
                 }
             });
         } catch (OpenAIException ex) {
+            throwIfGenerationCancelled(generationControl);
             String detail = BookAiGenerationException.describeApiError(ex);
             log.warn("AI streaming failed for bookId={} model={} tier={}: {}", bookId, configuredModel, tier.headerValue(), detail);
             BookAiGenerationException.ErrorCode errorCode = ex instanceof OpenAIInvalidDataException
@@ -304,6 +344,7 @@ public class BookAiContentService {
                 "AI content generation failed (%s, tier=%s): %s".formatted(configuredModel, tier.headerValue(), detail), ex);
         }
 
+        throwIfGenerationCancelled(generationControl);
         if (ChatCompletionChunk.Choice.FinishReason.LENGTH.equals(finishReason.get())) {
             log.warn(
                 "AI content response exhausted completion token budget for bookId={} model={} tier={} maxCompletionTokens={} finishReason=length",
@@ -338,6 +379,7 @@ public class BookAiContentService {
         }
 
         String validatedBufferedPayload = fullResponseBuilder.toString();
+        throwIfGenerationCancelled(generationControl);
         BookAiContent aiContent;
         try {
             aiContent = jsonParser.parse(validatedBufferedPayload);
@@ -352,7 +394,11 @@ public class BookAiContentService {
             throw new BookAiGenerationException(errorCode,
                 "AI content generation failed (%s): %s".formatted(configuredModel, parseMessage), parseFailure);
         }
-        BookAiContentSnapshot snapshot = repository.insertNewCurrentVersion(bookId, aiContent, configuredModel, DEFAULT_PROVIDER, promptHash);
+        throwIfGenerationCancelled(generationControl);
+        BookAiContentSnapshot snapshot = generationControl.persistIfActive(
+            () -> repository.insertNewCurrentVersion(bookId, aiContent, configuredModel, DEFAULT_PROVIDER, promptHash)
+        );
+        throwIfGenerationCancelled(generationControl);
         try {
             onValidatedBufferedPayload.accept(validatedBufferedPayload);
         } catch (IllegalStateException deliveryFailure) {
@@ -367,6 +413,57 @@ public class BookAiContentService {
             throw deliveryFailure;
         }
         return new GeneratedContent(validatedBufferedPayload, snapshot);
+    }
+
+    private static void requireGenerationControl(GenerationControl generationControl) {
+        if (generationControl == null) {
+            throw new IllegalArgumentException("generationControl is required");
+        }
+    }
+
+    private static void throwIfGenerationCancelled(GenerationControl generationControl) {
+        if (generationControl.isCancellationRequested() || Thread.currentThread().isInterrupted()) {
+            throw new CancellationException("AI content generation cancelled");
+        }
+    }
+
+    /**
+     * One-generation state machine that gives either cancellation or persistence an atomic claim.
+     * Persistence that claims first is allowed to finish; cancellation that claims first prevents it.
+     */
+    public static final class GenerationControl {
+        private final AtomicReference<GenerationState> state = new AtomicReference<>(GenerationState.ACTIVE);
+
+        /**
+         * Claims cancellation while persistence has not started.
+         *
+         * @return true when cancellation won and the running queue task should be interrupted
+         */
+        public boolean cancel() {
+            return state.compareAndSet(GenerationState.ACTIVE, GenerationState.CANCELLED);
+        }
+
+        private boolean isCancellationRequested() {
+            return state.get() == GenerationState.CANCELLED;
+        }
+
+        <T> T persistIfActive(Supplier<T> persistence) {
+            if (!state.compareAndSet(GenerationState.ACTIVE, GenerationState.PERSISTING)) {
+                throw new CancellationException("AI content generation cancelled before persistence");
+            }
+            try {
+                return persistence.get();
+            } finally {
+                state.compareAndSet(GenerationState.PERSISTING, GenerationState.COMPLETED);
+            }
+        }
+
+        private enum GenerationState {
+            ACTIVE,
+            CANCELLED,
+            PERSISTING,
+            COMPLETED
+        }
     }
 
     private boolean isRetryableGenerationFailure(

--- a/src/main/java/net/findmybook/application/seo/BookSeoMetadataClient.java
+++ b/src/main/java/net/findmybook/application/seo/BookSeoMetadataClient.java
@@ -7,6 +7,7 @@ import com.openai.core.Timeout;
 import com.openai.errors.OpenAIException;
 import com.openai.errors.OpenAIInvalidDataException;
 import com.openai.models.ChatModel;
+import com.openai.models.ResponseFormatJsonObject;
 import com.openai.models.chat.completions.ChatCompletion;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.models.chat.completions.ChatCompletionMessageParam;
@@ -173,6 +174,7 @@ class BookSeoMetadataClient {
                 ChatCompletionMessageParam.ofUser(ChatCompletionUserMessageParam.builder().content(prompt).build())
             ))
             .maxCompletionTokens(tier.maxCompletionTokens())
+            .responseFormat(ResponseFormatJsonObject.builder().build())
             .temperature(SAMPLING_TEMPERATURE)
             .build();
 

--- a/src/main/java/net/findmybook/application/seo/BookSeoMetadataClient.java
+++ b/src/main/java/net/findmybook/application/seo/BookSeoMetadataClient.java
@@ -7,7 +7,6 @@ import com.openai.core.Timeout;
 import com.openai.errors.OpenAIException;
 import com.openai.errors.OpenAIInvalidDataException;
 import com.openai.models.ChatModel;
-import com.openai.models.ResponseFormatJsonObject;
 import com.openai.models.chat.completions.ChatCompletion;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.models.chat.completions.ChatCompletionMessageParam;
@@ -174,7 +173,6 @@ class BookSeoMetadataClient {
                 ChatCompletionMessageParam.ofUser(ChatCompletionUserMessageParam.builder().content(prompt).build())
             ))
             .maxCompletionTokens(tier.maxCompletionTokens())
-            .responseFormat(ResponseFormatJsonObject.builder().build())
             .temperature(SAMPLING_TEMPERATURE)
             .build();
 

--- a/src/main/java/net/findmybook/application/seo/SeoMetadataJsonParser.java
+++ b/src/main/java/net/findmybook/application/seo/SeoMetadataJsonParser.java
@@ -1,6 +1,9 @@
 package net.findmybook.application.seo;
 
+import java.util.Arrays;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.springframework.util.StringUtils;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
@@ -10,6 +13,10 @@ import tools.jackson.databind.ObjectMapper;
  * Parses raw LLM JSON responses into typed SEO metadata fields.
  */
 class SeoMetadataJsonParser {
+
+    private static final Set<String> CANONICAL_FIELDS = Arrays.stream(SeoMetadataCandidate.class.getRecordComponents())
+        .map(recordComponent -> recordComponent.getName())
+        .collect(Collectors.toUnmodifiableSet());
 
     private final ObjectMapper objectMapper;
 
@@ -28,32 +35,26 @@ class SeoMetadataJsonParser {
             throw invalidResponse("SEO metadata response was empty");
         }
         JsonNode payload = parseJsonPayload(responseText);
-        String seoTitle = requiredText(payload, "seoTitle", "seo_title", "title");
-        String seoDescription = requiredText(payload, "seoDescription", "seo_description", "description", "metaDescription");
+        validateCanonicalFields(payload);
+        String seoTitle = requiredText(payload, "seoTitle");
+        String seoDescription = requiredText(payload, "seoDescription");
         return new SeoMetadataCandidate(seoTitle, seoDescription);
     }
 
     private JsonNode parseJsonPayload(String responseText) {
-        String cleaned = responseText.replace("```json", "").replace("```", "").trim();
         try {
-            return objectMapper.readTree(cleaned);
-        } catch (JacksonException initialParseException) {
-            int openBrace = cleaned.indexOf('{');
-            int closeBrace = cleaned.lastIndexOf('}');
-            if (openBrace < 0 || closeBrace <= openBrace) {
-                throw invalidResponse("SEO metadata response did not include a valid JSON object");
+            JsonNode payload = objectMapper.readTree(responseText.trim());
+            if (!payload.isObject()) {
+                throw invalidResponse("SEO metadata response must be a JSON object");
             }
-            String extracted = cleaned.substring(openBrace, closeBrace + 1);
-            try {
-                return objectMapper.readTree(extracted);
-            } catch (JacksonException parseException) {
-                throw invalidResponse("SEO metadata response JSON parsing failed", parseException);
-            }
+            return payload;
+        } catch (JacksonException parseException) {
+            throw invalidResponse("SEO metadata response did not include a valid JSON object", parseException);
         }
     }
 
-    private String requiredText(JsonNode payload, String field, String... aliases) {
-        return optionalText(payload, field, aliases)
+    private String requiredText(JsonNode payload, String field) {
+        return optionalText(payload, field)
             .orElseThrow(() -> invalidResponse("SEO metadata response missing required field: " + field));
     }
 
@@ -65,24 +66,23 @@ class SeoMetadataJsonParser {
         return new BookSeoGenerationException(BookSeoGenerationException.ErrorCode.INVALID_RESPONSE, message, cause);
     }
 
-    private Optional<String> optionalText(JsonNode payload, String field, String... aliases) {
+    private Optional<String> optionalText(JsonNode payload, String field) {
         JsonNode fieldNode = payload.get(field);
-        if (fieldNode != null && !fieldNode.isNull()) {
-            String fieldValue = fieldNode.asString();
-            if (StringUtils.hasText(fieldValue)) {
-                return Optional.of(fieldValue.trim());
-            }
+        if (!fieldNode.isString()) {
+            throw invalidResponse("SEO metadata response field must be a string: " + field);
         }
-        for (String alias : aliases) {
-            JsonNode aliasNode = payload.get(alias);
-            if (aliasNode != null && !aliasNode.isNull()) {
-                String aliasValue = aliasNode.asString();
-                if (StringUtils.hasText(aliasValue)) {
-                    return Optional.of(aliasValue.trim());
-                }
-            }
+        String fieldValue = fieldNode.stringValue();
+        if (StringUtils.hasText(fieldValue)) {
+            return Optional.of(fieldValue.trim());
         }
         return Optional.empty();
+    }
+
+    private void validateCanonicalFields(JsonNode payload) {
+        Set<String> responseFields = Set.copyOf(payload.propertyNames());
+        if (!responseFields.equals(CANONICAL_FIELDS)) {
+            throw invalidResponse("SEO metadata response fields must exactly match the canonical contract: " + CANONICAL_FIELDS);
+        }
     }
 
 }

--- a/src/main/java/net/findmybook/controller/BookAiContentController.java
+++ b/src/main/java/net/findmybook/controller/BookAiContentController.java
@@ -60,6 +60,7 @@ public class BookAiContentController {
     private static final int MIN_QUEUE_TICKER_THREADS = 4;
     private static final int MAX_QUEUE_TICKER_THREADS = 16;
     private static final String PRODUCTION_ENVIRONMENT_MODE = "production";
+    private static final String REQUEST_ID_HEADER = "X-Book-AI-Request-Id";
 
     private final BookAiContentService aiContentService;
     private final BookAiContentRequestQueue requestQueue;
@@ -134,6 +135,13 @@ public class BookAiContentController {
             snapshot.running(), snapshot.pending(), snapshot.maxParallel(), aiContentService.isAvailable(), environmentMode));
     }
 
+    /** Cancels an active browser generation request without revealing whether the request exists. */
+    @PostMapping("/ai/content/requests/{requestId}/cancel")
+    public ResponseEntity<Void> cancelAiContentRequest(@PathVariable String requestId) {
+        sseOrchestrator.cancelRequest(requestId);
+        return ResponseEntity.noContent().build();
+    }
+
     /** Streams AI generation events for a single book. */
     @PostMapping(path = "/{identifier}/ai/content/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     @RateLimiter(name = "bookAiContentRateLimiter")
@@ -163,12 +171,13 @@ public class BookAiContentController {
                 resolveClientMessage(AiErrorCode.SERVICE_UNAVAILABLE, "AI content service is not configured"));
             return emitter;
         }
-        beginQueuedStream(emitter, bookId);
+        beginQueuedStream(emitter, bookId, response);
         return emitter;
     }
 
     @PreDestroy
     void shutdownTickerExecutor() {
+        sseOrchestrator.cancelAllRequests();
         queueTickerExecutor.shutdownNow();
     }
 
@@ -197,16 +206,18 @@ public class BookAiContentController {
     private record QueuedStreamState(
         SseEmitter emitter,
         UUID bookId,
+        HttpServletResponse response,
         AtomicBoolean streamClosed,
         AtomicReference<QueuedStreamPhase> phase,
         BookAiContentService.GenerationControl generationControl
     ) {}
 
-    private void beginQueuedStream(SseEmitter emitter, UUID bookId) {
+    private void beginQueuedStream(SseEmitter emitter, UUID bookId, HttpServletResponse response) {
         long enqueuedAtMs = System.currentTimeMillis();
         QueuedStreamState state = new QueuedStreamState(
             emitter,
             bookId,
+            response,
             new AtomicBoolean(false),
             new AtomicReference<>(QueuedStreamPhase.WAITING),
             new BookAiContentService.GenerationControl()
@@ -221,41 +232,52 @@ public class BookAiContentController {
     ) {
         SseEmitter emitter = state.emitter();
         UUID bookId = state.bookId();
-        sseOrchestrator.sendEvent(emitter, "queued", sseOrchestrator.toQueuePositionPayload(requestQueue.getPosition(queuedTask.id())));
-        AtomicReference<Optional<BookAiContentSseOrchestrator.Timers>> timersReference =
-            new AtomicReference<>(Optional.empty());
-        Runnable cancelWorkIfOpen = () -> timersReference.get().ifPresent(
-            timers -> claimTerminalOwnership(state, timers, queuedTask.id(), true)
-        );
-        ScheduledFuture<?> queueTicker = sseOrchestrator.scheduleQueuePositionTicker(
-            emitter,
-            bookId,
-            queuedTask.id(),
-            state.streamClosed(),
-            cancelWorkIfOpen
-        );
-        ScheduledFuture<?> keepaliveTicker = sseOrchestrator.scheduleKeepaliveTicker(
-            emitter,
-            bookId,
-            state.streamClosed(),
-            cancelWorkIfOpen
-        );
-        BookAiContentSseOrchestrator.Timers timers = new BookAiContentSseOrchestrator.Timers(queueTicker, keepaliveTicker);
-        timersReference.set(Optional.of(timers));
-        ScheduledFuture<?> queueWaitDeadline = sseOrchestrator.scheduleApplicationDeadline(() -> {
-            if (state.phase().compareAndSet(QueuedStreamPhase.WAITING, QueuedStreamPhase.CLOSED)
-                    && claimTerminalOwnership(state, timers, queuedTask.id(), true)) {
-                sseOrchestrator.emitTerminalError(
-                    emitter,
-                    AiErrorCode.QUEUE_BUSY,
-                    AiErrorCode.QUEUE_BUSY.defaultMessage()
-                );
+        String requestId = queuedTask.id();
+        BookAiContentSseOrchestrator.Timers timers = new BookAiContentSseOrchestrator.Timers();
+        Runnable cancelWorkIfOpen = () -> {
+            if (claimTerminalOwnership(state, timers, requestId, true)) {
+                sseOrchestrator.safelyComplete(emitter);
             }
-        }, queueWaitDeadlineMillis);
-        timers.replaceDeadline(queueWaitDeadline);
-        sseOrchestrator.wireEmitterLifecycle(emitter, bookId, cancelWorkIfOpen);
-        wireStartedHandler(state, queuedTask, enqueuedAtMs, timers);
-        wireResultHandler(state, queuedTask, timers);
+        };
+        sseOrchestrator.registerCancellation(requestId, cancelWorkIfOpen);
+        try {
+            state.response().setHeader(REQUEST_ID_HEADER, requestId);
+            sseOrchestrator.sendEvent(
+                emitter,
+                "queued",
+                sseOrchestrator.toQueuedPayload(requestId, requestQueue.getPosition(requestId))
+            );
+            timers.installQueueTicker(sseOrchestrator.scheduleQueuePositionTicker(
+                emitter,
+                bookId,
+                requestId,
+                state.streamClosed(),
+                cancelWorkIfOpen
+            ));
+            timers.installKeepaliveTicker(sseOrchestrator.scheduleKeepaliveTicker(
+                emitter,
+                bookId,
+                state.streamClosed(),
+                cancelWorkIfOpen
+            ));
+            ScheduledFuture<?> queueWaitDeadline = sseOrchestrator.scheduleApplicationDeadline(() -> {
+                if (state.phase().compareAndSet(QueuedStreamPhase.WAITING, QueuedStreamPhase.CLOSED)
+                        && claimTerminalOwnership(state, timers, requestId, true)) {
+                    sseOrchestrator.emitTerminalError(
+                        emitter,
+                        AiErrorCode.QUEUE_BUSY,
+                        AiErrorCode.QUEUE_BUSY.defaultMessage()
+                    );
+                }
+            }, queueWaitDeadlineMillis);
+            timers.replaceDeadline(queueWaitDeadline);
+            sseOrchestrator.wireEmitterLifecycle(emitter, bookId, cancelWorkIfOpen);
+            wireStartedHandler(state, queuedTask, enqueuedAtMs, timers);
+            wireResultHandler(state, queuedTask, timers);
+        } catch (RuntimeException setupFailure) {
+            cancelWorkIfOpen.run();
+            throw setupFailure;
+        }
     }
 
     private boolean claimTerminalOwnership(
@@ -264,6 +286,7 @@ public class BookAiContentController {
         String taskId,
         boolean cancelWork
     ) {
+        sseOrchestrator.unregisterCancellation(taskId);
         if (!state.streamClosed().compareAndSet(false, true)) {
             return false;
         }

--- a/src/main/java/net/findmybook/controller/BookAiContentController.java
+++ b/src/main/java/net/findmybook/controller/BookAiContentController.java
@@ -41,13 +41,18 @@ public class BookAiContentController {
     private static final Logger log = LoggerFactory.getLogger(BookAiContentController.class);
     private static final Duration LIVE_RENDER_ATTEMPT_TIMEOUT =
         Duration.ofSeconds(LlmGatewayTier.LIVE_RENDER.callTimeoutSeconds());
-    private static final Duration QUEUE_AND_DELIVERY_HEADROOM = Duration.ofMinutes(1);
-    private static final Duration APPLICATION_STREAM_TIMEOUT = LIVE_RENDER_ATTEMPT_TIMEOUT
+    private static final Duration GENERATION_DELIVERY_HEADROOM = Duration.ofMinutes(1);
+    private static final Duration GENERATION_DEADLINE = LIVE_RENDER_ATTEMPT_TIMEOUT
         .multipliedBy(LlmGatewayTier.LIVE_RENDER.maxGenerationAttempts())
-        .plus(QUEUE_AND_DELIVERY_HEADROOM);
+        .plus(GENERATION_DELIVERY_HEADROOM);
+    private static final Duration QUEUE_WAIT_DEADLINE = Duration.ofMinutes(10);
     private static final Duration EMITTER_TERMINAL_EVENT_HEADROOM = Duration.ofSeconds(5);
-    private static final long APPLICATION_STREAM_TIMEOUT_MILLIS = APPLICATION_STREAM_TIMEOUT.toMillis();
-    private static final long EMITTER_TIMEOUT_MILLIS = APPLICATION_STREAM_TIMEOUT.plus(EMITTER_TERMINAL_EVENT_HEADROOM).toMillis();
+    private static final long GENERATION_DEADLINE_MILLIS = GENERATION_DEADLINE.toMillis();
+    private static final long QUEUE_WAIT_DEADLINE_MILLIS = QUEUE_WAIT_DEADLINE.toMillis();
+    private static final long EMITTER_TIMEOUT_MILLIS = QUEUE_WAIT_DEADLINE
+        .plus(GENERATION_DEADLINE)
+        .plus(EMITTER_TERMINAL_EVENT_HEADROOM)
+        .toMillis();
     private static final long MIN_STREAM_TIMEOUT_MILLIS = 1L;
     private static final int DEFAULT_GENERATION_PRIORITY = 0;
     private static final int MIN_QUEUE_TICKER_THREADS = 4;
@@ -59,7 +64,8 @@ public class BookAiContentController {
     private final ObjectMapper objectMapper;
     private final BookAiContentSseOrchestrator sseOrchestrator;
     private final ScheduledExecutorService queueTickerExecutor;
-    private final long applicationStreamTimeoutMillis;
+    private final long queueWaitDeadlineMillis;
+    private final long generationDeadlineMillis;
     private final long emitterTimeoutMillis;
     private final String environmentMode;
     private final boolean exposeDetailedErrors;
@@ -76,7 +82,8 @@ public class BookAiContentController {
             objectMapper,
             environmentMode,
             createQueueTickerExecutor(),
-            APPLICATION_STREAM_TIMEOUT_MILLIS,
+            QUEUE_WAIT_DEADLINE_MILLIS,
+            GENERATION_DEADLINE_MILLIS,
             EMITTER_TIMEOUT_MILLIS
         );
     }
@@ -86,11 +93,13 @@ public class BookAiContentController {
                             ObjectMapper objectMapper,
                             String environmentMode,
                             ScheduledExecutorService queueTickerExecutor,
-                            long applicationStreamTimeoutMillis,
+                            long queueWaitDeadlineMillis,
+                            long generationDeadlineMillis,
                             long emitterTimeoutMillis) {
-        if (applicationStreamTimeoutMillis < MIN_STREAM_TIMEOUT_MILLIS
-                || emitterTimeoutMillis <= applicationStreamTimeoutMillis) {
-            throw new IllegalArgumentException("Emitter timeout must exceed the application stream deadline");
+        if (queueWaitDeadlineMillis < MIN_STREAM_TIMEOUT_MILLIS
+                || generationDeadlineMillis < MIN_STREAM_TIMEOUT_MILLIS
+                || emitterTimeoutMillis <= queueWaitDeadlineMillis + generationDeadlineMillis) {
+            throw new IllegalArgumentException("Emitter timeout must exceed queue and generation deadlines");
         }
         this.aiContentService = aiContentService;
         this.requestQueue = requestQueue;
@@ -98,7 +107,8 @@ public class BookAiContentController {
         this.environmentMode = normalizeEnvironmentMode(environmentMode);
         this.exposeDetailedErrors = !PRODUCTION_ENVIRONMENT_MODE.equals(this.environmentMode);
         this.queueTickerExecutor = queueTickerExecutor;
-        this.applicationStreamTimeoutMillis = applicationStreamTimeoutMillis;
+        this.queueWaitDeadlineMillis = queueWaitDeadlineMillis;
+        this.generationDeadlineMillis = generationDeadlineMillis;
         this.emitterTimeoutMillis = emitterTimeoutMillis;
         this.sseOrchestrator = new BookAiContentSseOrchestrator(requestQueue, queueTickerExecutor);
     }
@@ -176,22 +186,37 @@ public class BookAiContentController {
     }
 
     /** Immutable context shared across all phases of a single queued SSE stream. */
-    private record QueuedStreamState(SseEmitter emitter, UUID bookId, AtomicBoolean streamClosed) {}
+    private record QueuedStreamState(
+        SseEmitter emitter,
+        UUID bookId,
+        AtomicBoolean streamClosed,
+        AtomicBoolean queueWaitActive
+    ) {}
 
     private void beginQueuedStream(SseEmitter emitter, UUID bookId) {
         long enqueuedAtMs = System.currentTimeMillis();
-        QueuedStreamState state = new QueuedStreamState(emitter, bookId, new AtomicBoolean(false));
+        QueuedStreamState state = new QueuedStreamState(
+            emitter,
+            bookId,
+            new AtomicBoolean(false),
+            new AtomicBoolean(true)
+        );
         var queuedTask = enqueueGenerationTask(state);
         sseOrchestrator.sendEvent(emitter, "queued", sseOrchestrator.toQueuePositionPayload(requestQueue.getPosition(queuedTask.id())));
         ScheduledFuture<?> queueTicker = sseOrchestrator.scheduleQueuePositionTicker(emitter, bookId, queuedTask.id(), state.streamClosed());
         ScheduledFuture<?> keepaliveTicker = sseOrchestrator.scheduleKeepaliveTicker(emitter, bookId, queuedTask.id(), state.streamClosed());
         BookAiContentSseOrchestrator.Timers timers = new BookAiContentSseOrchestrator.Timers(queueTicker, keepaliveTicker);
-        ScheduledFuture<?> applicationDeadline = sseOrchestrator.scheduleApplicationDeadline(() -> {
-            if (claimTerminalOwnership(state, timers, queuedTask.id())) {
-                sseOrchestrator.emitTerminalError(emitter, AiErrorCode.STREAM_TIMEOUT, AiErrorCode.STREAM_TIMEOUT.defaultMessage());
+        ScheduledFuture<?> queueWaitDeadline = sseOrchestrator.scheduleApplicationDeadline(() -> {
+            if (state.queueWaitActive().compareAndSet(true, false)
+                    && claimTerminalOwnership(state, timers, queuedTask.id())) {
+                sseOrchestrator.emitTerminalError(
+                    emitter,
+                    AiErrorCode.QUEUE_BUSY,
+                    AiErrorCode.QUEUE_BUSY.defaultMessage()
+                );
             }
-        }, applicationStreamTimeoutMillis);
-        timers.attachDeadline(applicationDeadline);
+        }, queueWaitDeadlineMillis);
+        timers.replaceDeadline(queueWaitDeadline);
         Runnable cancelPendingIfOpen = () -> claimTerminalOwnership(state, timers, queuedTask.id());
         sseOrchestrator.wireEmitterLifecycle(emitter, bookId, cancelPendingIfOpen);
         wireStartedHandler(state, queuedTask, enqueuedAtMs, timers);
@@ -227,10 +252,24 @@ public class BookAiContentController {
                                      long enqueuedAtMs,
                                      BookAiContentSseOrchestrator.Timers timers) {
         queuedTask.started().thenRun(() -> {
-            if (state.streamClosed().get()) {
+            if (!state.queueWaitActive().compareAndSet(true, false) || state.streamClosed().get()) {
                 return;
             }
             timers.cancelQueueTicker();
+            ScheduledFuture<?> generationDeadline = sseOrchestrator.scheduleApplicationDeadline(() -> {
+                if (claimTerminalOwnership(state, timers, queuedTask.id())) {
+                    sseOrchestrator.emitTerminalError(
+                        state.emitter(),
+                        AiErrorCode.STREAM_TIMEOUT,
+                        AiErrorCode.STREAM_TIMEOUT.defaultMessage()
+                    );
+                }
+            }, generationDeadlineMillis);
+            timers.replaceDeadline(generationDeadline);
+            if (state.streamClosed().get()) {
+                timers.cancelAll();
+                return;
+            }
             long queueWaitMs = Math.max(0L, System.currentTimeMillis() - enqueuedAtMs);
             BookAiContentRequestQueue.QueueSnapshot snapshot = requestQueue.snapshot();
             sendEventIfOpen(state, "started", new QueueStartedPayload(

--- a/src/main/java/net/findmybook/controller/BookAiContentController.java
+++ b/src/main/java/net/findmybook/controller/BookAiContentController.java
@@ -6,12 +6,14 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import net.findmybook.application.ai.BookAiGenerationException;
 import net.findmybook.application.ai.BookAiContentService;
 import net.findmybook.controller.dto.BookAiContentSnapshotDto;
@@ -186,11 +188,17 @@ public class BookAiContentController {
     }
 
     /** Immutable context shared across all phases of a single queued SSE stream. */
+    private enum QueuedStreamPhase {
+        WAITING,
+        GENERATING,
+        CLOSED
+    }
+
     private record QueuedStreamState(
         SseEmitter emitter,
         UUID bookId,
         AtomicBoolean streamClosed,
-        AtomicBoolean queueWaitActive
+        AtomicReference<QueuedStreamPhase> phase
     ) {}
 
     private void beginQueuedStream(SseEmitter emitter, UUID bookId) {
@@ -199,7 +207,7 @@ public class BookAiContentController {
             emitter,
             bookId,
             new AtomicBoolean(false),
-            new AtomicBoolean(true)
+            new AtomicReference<>(QueuedStreamPhase.WAITING)
         );
         var queuedTask = enqueueGenerationTask(state);
         sseOrchestrator.sendEvent(emitter, "queued", sseOrchestrator.toQueuePositionPayload(requestQueue.getPosition(queuedTask.id())));
@@ -207,7 +215,7 @@ public class BookAiContentController {
         ScheduledFuture<?> keepaliveTicker = sseOrchestrator.scheduleKeepaliveTicker(emitter, bookId, queuedTask.id(), state.streamClosed());
         BookAiContentSseOrchestrator.Timers timers = new BookAiContentSseOrchestrator.Timers(queueTicker, keepaliveTicker);
         ScheduledFuture<?> queueWaitDeadline = sseOrchestrator.scheduleApplicationDeadline(() -> {
-            if (state.queueWaitActive().compareAndSet(true, false)
+            if (state.phase().compareAndSet(QueuedStreamPhase.WAITING, QueuedStreamPhase.CLOSED)
                     && claimTerminalOwnership(state, timers, queuedTask.id())) {
                 sseOrchestrator.emitTerminalError(
                     emitter,
@@ -227,6 +235,7 @@ public class BookAiContentController {
         if (!state.streamClosed().compareAndSet(false, true)) {
             return false;
         }
+        state.phase().set(QueuedStreamPhase.CLOSED);
         timers.cancelAll();
         requestQueue.cancelPending(taskId);
         return true;
@@ -236,6 +245,9 @@ public class BookAiContentController {
             QueuedStreamState state) {
         AtomicBoolean messageStarted = new AtomicBoolean(false);
         return requestQueue.enqueueForeground(DEFAULT_GENERATION_PRIORITY, () -> {
+            if (state.streamClosed().get() || state.phase().get() != QueuedStreamPhase.GENERATING) {
+                throw new CancellationException("AI stream closed before generation started");
+            }
             sendMessageStartEvent(state, messageStarted);
             BookAiContentService.GeneratedContent generated = aiContentService.generateAndPersist(
                 state.bookId(),
@@ -252,7 +264,8 @@ public class BookAiContentController {
                                      long enqueuedAtMs,
                                      BookAiContentSseOrchestrator.Timers timers) {
         queuedTask.started().thenRun(() -> {
-            if (!state.queueWaitActive().compareAndSet(true, false) || state.streamClosed().get()) {
+            if (!state.phase().compareAndSet(QueuedStreamPhase.WAITING, QueuedStreamPhase.GENERATING)
+                    || state.streamClosed().get()) {
                 return;
             }
             timers.cancelQueueTicker();

--- a/src/main/java/net/findmybook/controller/BookAiContentController.java
+++ b/src/main/java/net/findmybook/controller/BookAiContentController.java
@@ -198,7 +198,8 @@ public class BookAiContentController {
         SseEmitter emitter,
         UUID bookId,
         AtomicBoolean streamClosed,
-        AtomicReference<QueuedStreamPhase> phase
+        AtomicReference<QueuedStreamPhase> phase,
+        BookAiContentService.GenerationControl generationControl
     ) {}
 
     private void beginQueuedStream(SseEmitter emitter, UUID bookId) {
@@ -207,16 +208,43 @@ public class BookAiContentController {
             emitter,
             bookId,
             new AtomicBoolean(false),
-            new AtomicReference<>(QueuedStreamPhase.WAITING)
+            new AtomicReference<>(QueuedStreamPhase.WAITING),
+            new BookAiContentService.GenerationControl()
         );
-        var queuedTask = enqueueGenerationTask(state);
+        enqueueGenerationTask(state, enqueuedAtMs);
+    }
+
+    private void wireQueuedTaskLifecycle(
+        QueuedStreamState state,
+        BookAiContentRequestQueue.EnqueuedTask<BookAiContentService.GeneratedContent> queuedTask,
+        long enqueuedAtMs
+    ) {
+        SseEmitter emitter = state.emitter();
+        UUID bookId = state.bookId();
         sseOrchestrator.sendEvent(emitter, "queued", sseOrchestrator.toQueuePositionPayload(requestQueue.getPosition(queuedTask.id())));
-        ScheduledFuture<?> queueTicker = sseOrchestrator.scheduleQueuePositionTicker(emitter, bookId, queuedTask.id(), state.streamClosed());
-        ScheduledFuture<?> keepaliveTicker = sseOrchestrator.scheduleKeepaliveTicker(emitter, bookId, queuedTask.id(), state.streamClosed());
+        AtomicReference<Optional<BookAiContentSseOrchestrator.Timers>> timersReference =
+            new AtomicReference<>(Optional.empty());
+        Runnable cancelWorkIfOpen = () -> timersReference.get().ifPresent(
+            timers -> claimTerminalOwnership(state, timers, queuedTask.id(), true)
+        );
+        ScheduledFuture<?> queueTicker = sseOrchestrator.scheduleQueuePositionTicker(
+            emitter,
+            bookId,
+            queuedTask.id(),
+            state.streamClosed(),
+            cancelWorkIfOpen
+        );
+        ScheduledFuture<?> keepaliveTicker = sseOrchestrator.scheduleKeepaliveTicker(
+            emitter,
+            bookId,
+            state.streamClosed(),
+            cancelWorkIfOpen
+        );
         BookAiContentSseOrchestrator.Timers timers = new BookAiContentSseOrchestrator.Timers(queueTicker, keepaliveTicker);
+        timersReference.set(Optional.of(timers));
         ScheduledFuture<?> queueWaitDeadline = sseOrchestrator.scheduleApplicationDeadline(() -> {
             if (state.phase().compareAndSet(QueuedStreamPhase.WAITING, QueuedStreamPhase.CLOSED)
-                    && claimTerminalOwnership(state, timers, queuedTask.id())) {
+                    && claimTerminalOwnership(state, timers, queuedTask.id(), true)) {
                 sseOrchestrator.emitTerminalError(
                     emitter,
                     AiErrorCode.QUEUE_BUSY,
@@ -225,24 +253,33 @@ public class BookAiContentController {
             }
         }, queueWaitDeadlineMillis);
         timers.replaceDeadline(queueWaitDeadline);
-        Runnable cancelPendingIfOpen = () -> claimTerminalOwnership(state, timers, queuedTask.id());
-        sseOrchestrator.wireEmitterLifecycle(emitter, bookId, cancelPendingIfOpen);
+        sseOrchestrator.wireEmitterLifecycle(emitter, bookId, cancelWorkIfOpen);
         wireStartedHandler(state, queuedTask, enqueuedAtMs, timers);
         wireResultHandler(state, queuedTask, timers);
     }
 
-    private boolean claimTerminalOwnership(QueuedStreamState state, BookAiContentSseOrchestrator.Timers timers, String taskId) {
+    private boolean claimTerminalOwnership(
+        QueuedStreamState state,
+        BookAiContentSseOrchestrator.Timers timers,
+        String taskId,
+        boolean cancelWork
+    ) {
         if (!state.streamClosed().compareAndSet(false, true)) {
             return false;
         }
         state.phase().set(QueuedStreamPhase.CLOSED);
         timers.cancelAll();
-        requestQueue.cancelPending(taskId);
+        if (cancelWork) {
+            if (state.generationControl().cancel()) {
+                requestQueue.cancel(taskId);
+            }
+        }
         return true;
     }
 
     private BookAiContentRequestQueue.EnqueuedTask<BookAiContentService.GeneratedContent> enqueueGenerationTask(
-            QueuedStreamState state) {
+            QueuedStreamState state,
+            long enqueuedAtMs) {
         AtomicBoolean messageStarted = new AtomicBoolean(false);
         return requestQueue.enqueueForeground(DEFAULT_GENERATION_PRIORITY, () -> {
             if (state.streamClosed().get() || state.phase().get() != QueuedStreamPhase.GENERATING) {
@@ -252,11 +289,12 @@ public class BookAiContentController {
             BookAiContentService.GeneratedContent generated = aiContentService.generateAndPersist(
                 state.bookId(),
                 delta -> sendEventIfOpen(state, "message_delta", new MessageDeltaPayload(delta)),
-                LlmGatewayTier.LIVE_RENDER
+                LlmGatewayTier.LIVE_RENDER,
+                state.generationControl()
             );
             sendEventIfOpen(state, "message_done", new MessageDonePayload(generated.rawMessage()));
             return generated;
-        });
+        }, queuedTask -> wireQueuedTaskLifecycle(state, queuedTask, enqueuedAtMs));
     }
 
     private void wireStartedHandler(QueuedStreamState state,
@@ -270,7 +308,7 @@ public class BookAiContentController {
             }
             timers.cancelQueueTicker();
             ScheduledFuture<?> generationDeadline = sseOrchestrator.scheduleApplicationDeadline(() -> {
-                if (claimTerminalOwnership(state, timers, queuedTask.id())) {
+                if (claimTerminalOwnership(state, timers, queuedTask.id(), true)) {
                     sseOrchestrator.emitTerminalError(
                         state.emitter(),
                         AiErrorCode.STREAM_TIMEOUT,
@@ -288,7 +326,7 @@ public class BookAiContentController {
             sendEventIfOpen(state, "started", new QueueStartedPayload(
                 snapshot.running(), snapshot.pending(), snapshot.maxParallel(), queueWaitMs));
         }).exceptionally(throwable -> {
-            if (claimTerminalOwnership(state, timers, queuedTask.id())) {
+            if (claimTerminalOwnership(state, timers, queuedTask.id(), true)) {
                 AiErrorDescriptor descriptor = resolveThrowableError(throwable);
                 sseOrchestrator.emitTerminalError(state.emitter(), descriptor.code(), resolveClientMessage(descriptor.code(), descriptor.message()));
             } else {
@@ -302,7 +340,7 @@ public class BookAiContentController {
                                     BookAiContentRequestQueue.EnqueuedTask<BookAiContentService.GeneratedContent> queuedTask,
                                     BookAiContentSseOrchestrator.Timers timers) {
         queuedTask.result().whenComplete((result, throwable) -> {
-            if (!claimTerminalOwnership(state, timers, queuedTask.id())) {
+            if (!claimTerminalOwnership(state, timers, queuedTask.id(), false)) {
                 if (throwable != null) {
                     log.debug("Stream already closed when result-handler exception occurred: {}", throwable.getMessage());
                 }

--- a/src/main/java/net/findmybook/controller/BookAiContentSseOrchestrator.java
+++ b/src/main/java/net/findmybook/controller/BookAiContentSseOrchestrator.java
@@ -70,7 +70,8 @@ class BookAiContentSseOrchestrator {
      * Schedules periodic queue-position SSE events until the stream is closed or the task leaves the queue.
      */
     ScheduledFuture<?> scheduleQueuePositionTicker(SseEmitter emitter, UUID bookId,
-                                                    String taskId, AtomicBoolean streamClosed) {
+                                                    String taskId, AtomicBoolean streamClosed,
+                                                    Runnable claimTerminalOwnership) {
         return queueTickerExecutor.scheduleAtFixedRate(() -> {
             if (streamClosed.get()) {
                 return;
@@ -83,8 +84,7 @@ class BookAiContentSseOrchestrator {
                 sendEvent(emitter, "queue", toQueuePositionPayload(position));
             } catch (IllegalStateException queueDeliveryException) {
                 log.warn("Queue position delivery failed for bookId={} taskId={}", bookId, taskId, queueDeliveryException);
-                streamClosed.set(true);
-                requestQueue.cancelPending(taskId);
+                claimTerminalOwnership.run();
             }
         }, QUEUE_POSITION_TICK_MILLIS, QUEUE_POSITION_TICK_MILLIS, TimeUnit.MILLISECONDS);
     }
@@ -93,7 +93,8 @@ class BookAiContentSseOrchestrator {
      * Schedules periodic SSE comment keepalives to prevent proxy/client timeouts.
      */
     ScheduledFuture<?> scheduleKeepaliveTicker(SseEmitter emitter, UUID bookId,
-                                                String taskId, AtomicBoolean streamClosed) {
+                                                AtomicBoolean streamClosed,
+                                                Runnable claimTerminalOwnership) {
         return queueTickerExecutor.scheduleAtFixedRate(() -> {
             if (streamClosed.get()) {
                 return;
@@ -102,8 +103,7 @@ class BookAiContentSseOrchestrator {
                 sendSseComment(emitter, "keepalive");
             } catch (IllegalStateException keepaliveException) {
                 log.warn("Keepalive delivery failed for bookId={}", bookId, keepaliveException);
-                streamClosed.set(true);
-                requestQueue.cancelPending(taskId);
+                claimTerminalOwnership.run();
             }
         }, KEEPALIVE_INTERVAL_MILLIS, KEEPALIVE_INTERVAL_MILLIS, TimeUnit.MILLISECONDS);
     }
@@ -116,12 +116,12 @@ class BookAiContentSseOrchestrator {
     /**
      * Wires completion, timeout, and error callbacks onto the SSE emitter.
      */
-    void wireEmitterLifecycle(SseEmitter emitter, UUID bookId, Runnable cancelPendingIfOpen) {
-        emitter.onCompletion(cancelPendingIfOpen);
-        emitter.onTimeout(cancelPendingIfOpen);
+    void wireEmitterLifecycle(SseEmitter emitter, UUID bookId, Runnable claimTerminalOwnership) {
+        emitter.onCompletion(claimTerminalOwnership);
+        emitter.onTimeout(claimTerminalOwnership);
         emitter.onError(error -> {
             log.warn("AI stream failed for bookId={}", bookId, error);
-            cancelPendingIfOpen.run();
+            claimTerminalOwnership.run();
         });
     }
 

--- a/src/main/java/net/findmybook/controller/BookAiContentSseOrchestrator.java
+++ b/src/main/java/net/findmybook/controller/BookAiContentSseOrchestrator.java
@@ -2,6 +2,7 @@ package net.findmybook.controller;
 
 import java.io.IOException;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -27,43 +28,106 @@ class BookAiContentSseOrchestrator {
 
     /** Owns cancellation of every scheduled task associated with one SSE stream. */
     static final class Timers {
-        private final ScheduledFuture<?> queueTicker;
-        private final ScheduledFuture<?> keepaliveTicker;
+        private final AtomicBoolean cancelled = new AtomicBoolean(false);
+        private final AtomicReference<ScheduledFuture<?>> queueTicker = new AtomicReference<>();
+        private final AtomicReference<ScheduledFuture<?>> keepaliveTicker = new AtomicReference<>();
         private final AtomicReference<ScheduledFuture<?>> applicationDeadline = new AtomicReference<>();
 
-        Timers(ScheduledFuture<?> queueTicker, ScheduledFuture<?> keepaliveTicker) {
-            this.queueTicker = queueTicker;
-            this.keepaliveTicker = keepaliveTicker;
+        void installQueueTicker(ScheduledFuture<?> scheduledQueueTicker) {
+            installTimer(queueTicker, scheduledQueueTicker);
+        }
+
+        void installKeepaliveTicker(ScheduledFuture<?> scheduledKeepaliveTicker) {
+            installTimer(keepaliveTicker, scheduledKeepaliveTicker);
         }
 
         void replaceDeadline(ScheduledFuture<?> scheduledDeadline) {
-            ScheduledFuture<?> previousDeadline = applicationDeadline.getAndSet(scheduledDeadline);
-            if (previousDeadline != null) {
-                previousDeadline.cancel(false);
-            }
+            installTimer(applicationDeadline, scheduledDeadline);
         }
 
         void cancelQueueTicker() {
-            queueTicker.cancel(false);
+            cancelTimer(queueTicker.get());
         }
 
         void cancelAll() {
-            queueTicker.cancel(false);
-            keepaliveTicker.cancel(false);
-            ScheduledFuture<?> deadline = applicationDeadline.get();
-            if (deadline != null) {
-                deadline.cancel(false);
+            if (!cancelled.compareAndSet(false, true)) {
+                return;
+            }
+            cancelTimer(queueTicker.get());
+            cancelTimer(keepaliveTicker.get());
+            cancelTimer(applicationDeadline.get());
+        }
+
+        private void installTimer(
+            AtomicReference<ScheduledFuture<?>> timerReference,
+            ScheduledFuture<?> scheduledTimer
+        ) {
+            ScheduledFuture<?> previousTimer = timerReference.getAndSet(scheduledTimer);
+            cancelTimer(previousTimer);
+            if (cancelled.get()) {
+                cancelTimer(scheduledTimer);
+            }
+        }
+
+        private void cancelTimer(ScheduledFuture<?> scheduledTimer) {
+            if (scheduledTimer != null) {
+                scheduledTimer.cancel(false);
             }
         }
     }
 
     private final BookAiContentRequestQueue requestQueue;
     private final ScheduledExecutorService queueTickerExecutor;
+    private final ConcurrentHashMap<String, Runnable> activeRequestCancellations = new ConcurrentHashMap<>();
+    private final AtomicBoolean acceptingRequestCancellations = new AtomicBoolean(true);
 
     BookAiContentSseOrchestrator(BookAiContentRequestQueue requestQueue,
                                   ScheduledExecutorService queueTickerExecutor) {
         this.requestQueue = requestQueue;
         this.queueTickerExecutor = queueTickerExecutor;
+    }
+
+    /** Registers the one terminal cancellation callback before its request ID is exposed to the client. */
+    synchronized void registerCancellation(String requestId, Runnable cancellation) {
+        if (!acceptingRequestCancellations.get()) {
+            cancellation.run();
+            throw new IllegalStateException("AI cancellation registry is shutting down");
+        }
+        Runnable previousCancellation = activeRequestCancellations.putIfAbsent(requestId, cancellation);
+        if (previousCancellation != null) {
+            throw new IllegalStateException("Duplicate AI content request ID: " + requestId);
+        }
+    }
+
+    /** Claims cancellation when the request is active; unknown and terminal IDs are intentionally indistinguishable. */
+    void cancelRequest(String requestId) {
+        Runnable cancellation = activeRequestCancellations.get(requestId);
+        if (cancellation != null) {
+            cancellation.run();
+        }
+    }
+
+    /** Removes a terminal request without exposing whether it was previously registered. */
+    void unregisterCancellation(String requestId) {
+        activeRequestCancellations.remove(requestId);
+    }
+
+    int activeRequestCount() {
+        return activeRequestCancellations.size();
+    }
+
+    void cancelAllRequests() {
+        Runnable[] cancellations;
+        synchronized (this) {
+            if (!acceptingRequestCancellations.compareAndSet(true, false)) {
+                return;
+            }
+            cancellations = activeRequestCancellations.values().toArray(Runnable[]::new);
+            activeRequestCancellations.clear();
+        }
+        for (Runnable cancellation : cancellations) {
+            cancellation.run();
+        }
     }
 
     /**
@@ -160,6 +224,16 @@ class BookAiContentSseOrchestrator {
 
     QueuePositionPayload toQueuePositionPayload(BookAiContentRequestQueue.QueuePosition position) {
         return new QueuePositionPayload(
+            position.position(),
+            position.running(),
+            position.pending(),
+            position.maxParallel()
+        );
+    }
+
+    QueuedPayload toQueuedPayload(String requestId, BookAiContentRequestQueue.QueuePosition position) {
+        return new QueuedPayload(
+            requestId,
             position.position(),
             position.running(),
             position.pending(),

--- a/src/main/java/net/findmybook/controller/BookAiContentSseOrchestrator.java
+++ b/src/main/java/net/findmybook/controller/BookAiContentSseOrchestrator.java
@@ -36,10 +36,10 @@ class BookAiContentSseOrchestrator {
             this.keepaliveTicker = keepaliveTicker;
         }
 
-        void attachDeadline(ScheduledFuture<?> scheduledDeadline) {
-            if (!applicationDeadline.compareAndSet(null, scheduledDeadline)) {
-                scheduledDeadline.cancel(false);
-                throw new IllegalStateException("Application deadline is already attached");
+        void replaceDeadline(ScheduledFuture<?> scheduledDeadline) {
+            ScheduledFuture<?> previousDeadline = applicationDeadline.getAndSet(scheduledDeadline);
+            if (previousDeadline != null) {
+                previousDeadline.cancel(false);
             }
         }
 

--- a/src/main/java/net/findmybook/controller/BookAiContentSsePayloads.java
+++ b/src/main/java/net/findmybook/controller/BookAiContentSsePayloads.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 import net.findmybook.controller.dto.BookAiContentSnapshotDto;
 
 sealed interface BookAiContentSsePayload
-    permits QueuePositionPayload, QueueStartedPayload, MessageStartPayload,
+    permits QueuedPayload, QueuePositionPayload, QueueStartedPayload, MessageStartPayload,
             MessageDeltaPayload, MessageDonePayload, DonePayload, ErrorPayload {
 }
 
@@ -51,6 +51,10 @@ record OptionalResolution(UUID bookId, AiErrorCode errorCode, String error) {
 }
 
 record QueueStatsPayload(int running, int pending, int maxParallel, boolean available, String environmentMode) {
+}
+
+record QueuedPayload(String requestId, Integer position, int running, int pending, int maxParallel)
+    implements BookAiContentSsePayload {
 }
 
 record QueuePositionPayload(Integer position, int running, int pending, int maxParallel)

--- a/src/main/java/net/findmybook/support/ai/BookAiContentRequestQueue.java
+++ b/src/main/java/net/findmybook/support/ai/BookAiContentRequestQueue.java
@@ -247,8 +247,13 @@ public class BookAiContentRequestQueue {
                     task.result.complete(supplierResult);
                 } else {
                     Throwable failure = unwrapCompletionFailure(throwable);
-                    log.warn("AI queue task failed [id={}, lane={}, priority={}]",
-                        task.id, task.lane, task.priority, failure);
+                    if (failure instanceof CancellationException) {
+                        log.debug("AI queue task cancelled [id={}, lane={}, priority={}]",
+                            task.id, task.lane, task.priority);
+                    } else {
+                        log.warn("AI queue task failed [id={}, lane={}, priority={}]",
+                            task.id, task.lane, task.priority, failure);
+                    }
                     task.result.completeExceptionally(failure);
                 }
                 synchronized (this) {

--- a/src/main/java/net/findmybook/support/ai/BookAiContentRequestQueue.java
+++ b/src/main/java/net/findmybook/support/ai/BookAiContentRequestQueue.java
@@ -7,13 +7,16 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -118,7 +121,27 @@ public class BookAiContentRequestQueue {
      * any pending background ingestion tasks.
      */
     public synchronized <T> EnqueuedTask<T> enqueueForeground(int priority, Supplier<T> supplier) {
-        return enqueueInternal(BookAiQueueLane.FOREGROUND_SVELTE, priority, supplier);
+        return enqueueInternal(BookAiQueueLane.FOREGROUND_SVELTE, priority, supplier, ignored -> { });
+    }
+
+    /**
+     * Enqueues an interactive task after its owner has atomically installed lifecycle handlers.
+     *
+     * <p>The setup callback runs after the task is visible as pending and before the queue can
+     * dequeue it. This guarantees that an immediately available execution slot cannot run the
+     * supplier before its started/result handlers are wired.</p>
+     *
+     * @param priority higher values run earlier
+     * @param supplier task execution callback
+     * @param lifecycleSetup callback that wires the returned handle before execution becomes eligible
+     * @return queued task metadata (id + lifecycle futures)
+     */
+    public synchronized <T> EnqueuedTask<T> enqueueForeground(
+        int priority,
+        Supplier<T> supplier,
+        Consumer<EnqueuedTask<T>> lifecycleSetup
+    ) {
+        return enqueueInternal(BookAiQueueLane.FOREGROUND_SVELTE, priority, supplier, lifecycleSetup);
     }
 
     /**
@@ -128,17 +151,26 @@ public class BookAiContentRequestQueue {
         if (pendingBackgroundCount >= maxBackgroundPending) {
             throw new BookAiQueueCapacityExceededException(maxBackgroundPending, pendingBackgroundCount);
         }
-        return enqueueInternal(BookAiQueueLane.BACKGROUND_INGESTION, priority, supplier);
+        return enqueueInternal(BookAiQueueLane.BACKGROUND_INGESTION, priority, supplier, ignored -> { });
     }
 
-    private <T> EnqueuedTask<T> enqueueInternal(BookAiQueueLane lane, int priority, Supplier<T> supplier) {
+    private <T> EnqueuedTask<T> enqueueInternal(
+        BookAiQueueLane lane,
+        int priority,
+        Supplier<T> supplier,
+        Consumer<EnqueuedTask<T>> lifecycleSetup
+    ) {
         if (supplier == null) {
             throw new IllegalArgumentException("supplier is required");
+        }
+        if (lifecycleSetup == null) {
+            throw new IllegalArgumentException("lifecycleSetup is required");
         }
         String taskId = UUID.randomUUID().toString();
         CompletableFuture<Void> started = new CompletableFuture<>();
         CompletableFuture<T> result = new CompletableFuture<>();
         QueuedTask<T> queuedTask = new QueuedTask<>(taskId, lane, priority, supplier, started, result);
+        EnqueuedTask<T> enqueuedTask = new EnqueuedTask<>(taskId, started, result);
 
         TreeMap<Integer, Deque<QueuedTask<?>>> targetQueue = lane == BookAiQueueLane.FOREGROUND_SVELTE
             ? pendingForegroundByPriority
@@ -151,27 +183,66 @@ public class BookAiContentRequestQueue {
             pendingBackgroundCount += 1;
         }
 
+        try {
+            lifecycleSetup.accept(enqueuedTask);
+        } catch (RuntimeException setupFailure) {
+            removePendingTask(queuedTask);
+            queuedTask.started.completeExceptionally(setupFailure);
+            queuedTask.result.completeExceptionally(setupFailure);
+            drain();
+            throw setupFailure;
+        }
         drain();
-        return new EnqueuedTask<>(taskId, started, result);
+        return enqueuedTask;
     }
 
     /**
-     * Cancels a pending task by ID.
+     * Cancels a pending or running task by ID.
      *
-     * @return true when the task was pending and removed
+     * <p>Running work receives a thread interrupt through its executor future. Its concurrency
+     * slot remains occupied until the supplier wrapper exits, preserving the configured parallelism
+     * ceiling even when a supplier needs time to respond to interruption.</p>
+     *
+     * @return true when cancellation was claimed for a pending or running task
      */
-    public synchronized boolean cancelPending(String taskId) {
-        QueuedTask<?> queuedTask = pendingById.remove(taskId);
-        if (queuedTask == null) {
-            return false;
+    public synchronized boolean cancel(String taskId) {
+        QueuedTask<?> queuedTask = pendingById.get(taskId);
+        if (queuedTask != null) {
+            removePendingTask(queuedTask);
+            CancellationException cancellation = cancellationBeforeStart();
+            queuedTask.started.completeExceptionally(cancellation);
+            queuedTask.result.completeExceptionally(cancellation);
+            drain();
+            return true;
         }
 
+        QueuedTask<?> runningTask = runningById.get(taskId);
+        if (runningTask == null || runningTask.cancellationRequested) {
+            return false;
+        }
+        runningTask.cancellationRequested = true;
+        CancellationException cancellation = cancellationDuringExecution();
+        runningTask.result.completeExceptionally(cancellation);
+        Future<?> executionFuture = runningTask.executionFuture.orElseThrow(
+            () -> new IllegalStateException("Running queue task has no execution future: " + taskId)
+        );
+        boolean interruptRequested = executionFuture.cancel(true);
+        if (!runningTask.executionStarted) {
+            releaseRunningSlot(runningTask);
+        }
+        return interruptRequested;
+    }
+
+    private boolean removePendingTask(QueuedTask<?> queuedTask) {
+        if (pendingById.remove(queuedTask.id) == null) {
+            return false;
+        }
         TreeMap<Integer, Deque<QueuedTask<?>>> pendingByPriority = queuedTask.lane == BookAiQueueLane.FOREGROUND_SVELTE
             ? pendingForegroundByPriority
             : pendingBackgroundByPriority;
         Deque<QueuedTask<?>> priorityQueue = pendingByPriority.get(queuedTask.priority);
         if (priorityQueue != null) {
-            priorityQueue.removeIf(task -> task.id.equals(taskId));
+            priorityQueue.removeIf(task -> task.id.equals(queuedTask.id));
             if (priorityQueue.isEmpty()) {
                 pendingByPriority.remove(queuedTask.priority);
             }
@@ -181,10 +252,6 @@ public class BookAiContentRequestQueue {
         } else {
             pendingBackgroundCount = Math.max(0, pendingBackgroundCount - 1);
         }
-
-        CancellationException cancellation = new CancellationException("Queue task cancelled before start");
-        queuedTask.started.completeExceptionally(cancellation);
-        queuedTask.result.completeExceptionally(cancellation);
         return true;
     }
 
@@ -202,8 +269,15 @@ public class BookAiContentRequestQueue {
 
             runningCount += 1;
             runningById.put(next.id, next);
+            FutureTask<Void> executionFuture = new FutureTask<>(() -> {
+                runTask(next);
+                return null;
+            });
+            next.executionFuture = Optional.of(executionFuture);
             next.started.complete(null);
-            executeTask(next);
+            if (runningById.containsKey(next.id) && !next.cancellationRequested) {
+                executorService.execute(executionFuture);
+            }
         }
     }
 
@@ -240,35 +314,77 @@ public class BookAiContentRequestQueue {
         return null;
     }
 
-    private <T> void executeTask(QueuedTask<T> task) {
-        CompletableFuture.supplyAsync(task.supplier, executorService)
-            .whenComplete((supplierResult, throwable) -> {
-                if (throwable == null) {
-                    task.result.complete(supplierResult);
-                } else {
-                    Throwable failure = unwrapCompletionFailure(throwable);
-                    if (failure instanceof CancellationException) {
-                        log.debug("AI queue task cancelled [id={}, lane={}, priority={}]",
-                            task.id, task.lane, task.priority);
-                    } else {
-                        log.warn("AI queue task failed [id={}, lane={}, priority={}]",
-                            task.id, task.lane, task.priority, failure);
-                    }
-                    task.result.completeExceptionally(failure);
-                }
-                synchronized (this) {
-                    runningById.remove(task.id);
-                    runningCount = Math.max(0, runningCount - 1);
-                    drain();
-                }
-            });
+    private <T> void runTask(QueuedTask<T> task) {
+        if (!markExecutionStarted(task)) {
+            return;
+        }
+        try {
+            T supplierResult = task.supplier.get();
+            finishSuccessfully(task, supplierResult);
+        } catch (CancellationException cancellation) {
+            finishExceptionally(task, cancellation);
+        } catch (RuntimeException runtimeFailure) {
+            finishExceptionally(task, runtimeFailure);
+        } catch (Error fatalFailure) {
+            finishExceptionally(task, fatalFailure);
+            throw fatalFailure;
+        }
     }
 
-    private Throwable unwrapCompletionFailure(Throwable failure) {
-        if (failure instanceof CompletionException completionException && completionException.getCause() != null) {
-            return completionException.getCause();
+    private synchronized boolean markExecutionStarted(QueuedTask<?> task) {
+        if (task.cancellationRequested || runningById.get(task.id) != task) {
+            return false;
         }
-        return failure;
+        task.executionStarted = true;
+        return true;
+    }
+
+    private <T> void finishSuccessfully(QueuedTask<T> task, T supplierResult) {
+        boolean cancelled;
+        synchronized (this) {
+            cancelled = task.cancellationRequested;
+            releaseRunningSlot(task);
+        }
+        if (cancelled) {
+            task.result.completeExceptionally(cancellationDuringExecution());
+            return;
+        }
+        task.result.complete(supplierResult);
+    }
+
+    private void finishExceptionally(QueuedTask<?> task, Throwable failure) {
+        boolean cancelled;
+        synchronized (this) {
+            cancelled = task.cancellationRequested;
+            releaseRunningSlot(task);
+        }
+        Throwable terminalFailure = cancelled ? cancellationDuringExecution() : failure;
+        if (terminalFailure instanceof CancellationException) {
+            log.debug("AI queue task cancelled [id={}, lane={}, priority={}]",
+                task.id, task.lane, task.priority);
+        } else {
+            log.warn("AI queue task failed [id={}, lane={}, priority={}]",
+                task.id, task.lane, task.priority, terminalFailure);
+        }
+        task.result.completeExceptionally(terminalFailure);
+    }
+
+    private synchronized void releaseRunningSlot(QueuedTask<?> task) {
+        if (task.slotReleased) {
+            return;
+        }
+        task.slotReleased = true;
+        runningById.remove(task.id, task);
+        runningCount = Math.max(0, runningCount - 1);
+        drain();
+    }
+
+    private CancellationException cancellationBeforeStart() {
+        return new CancellationException("Queue task cancelled before start");
+    }
+
+    private CancellationException cancellationDuringExecution() {
+        return new CancellationException("Queue task cancelled during execution");
     }
 
     private static int coerceParallelism(int configuredParallelism) {
@@ -312,6 +428,10 @@ public class BookAiContentRequestQueue {
         private final Supplier<T> supplier;
         private final CompletableFuture<Void> started;
         private final CompletableFuture<T> result;
+        private Optional<Future<?>> executionFuture;
+        private boolean executionStarted;
+        private boolean cancellationRequested;
+        private boolean slotReleased;
 
         private QueuedTask(String id,
                            BookAiQueueLane lane,
@@ -325,6 +445,10 @@ public class BookAiContentRequestQueue {
             this.supplier = supplier;
             this.started = started;
             this.result = result;
+            this.executionFuture = Optional.empty();
+            this.executionStarted = false;
+            this.cancellationRequested = false;
+            this.slotReleased = false;
         }
     }
 

--- a/src/test/java/net/findmybook/application/ai/AiContentQualityValidatorTest.java
+++ b/src/test/java/net/findmybook/application/ai/AiContentQualityValidatorTest.java
@@ -272,20 +272,6 @@ class AiContentQualityValidatorTest {
         AiContentQualityValidator.validate(content);
     }
 
-    // -- isValid: boolean wrapper ----------------------------------------------
-
-    @Test
-    void should_ReturnTrue_When_ContentIsValid() {
-        BookAiContent content = withSummary(VALID_SUMMARY);
-        assertThat(AiContentQualityValidator.isValid(content)).isTrue();
-    }
-
-    @Test
-    void should_ReturnFalse_When_ContentIsInvalid() {
-        BookAiContent content = withSummary("@".repeat(999));
-        assertThat(AiContentQualityValidator.isValid(content)).isFalse();
-    }
-
     // -- exceedsSingleCharRepetitionThreshold: edge cases ----------------------
 
     @Test

--- a/src/test/java/net/findmybook/application/ai/BookAiContentServiceTest.java
+++ b/src/test/java/net/findmybook/application/ai/BookAiContentServiceTest.java
@@ -3,7 +3,10 @@ package net.findmybook.application.ai;
 import com.openai.errors.OpenAIServiceException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -11,6 +14,11 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import net.findmybook.adapters.persistence.BookAiContentRepository;
 import net.findmybook.boot.OpenAiProperties;
 import net.findmybook.domain.ai.BookAiContent;
@@ -90,6 +98,105 @@ class BookAiContentServiceTest {
         assertThat(context).isNotNull();
         assertThat(context.toString()).contains(enrichedDescription);
         verify(bookDataOrchestrator).enrichDescriptionForAiIfNeeded(bookId, detail, "short", 50);
+    }
+
+    @Test
+    void should_StopBeforeGenerationAndPersistence_When_RequestIsCancelledAfterPromptLoad() {
+        BookAiContentService service = newService();
+        UUID bookId = UUID.randomUUID();
+        String description = "A sufficiently detailed description that can support grounded reader guide generation.";
+        BookDetail detail = bookDetailWithDescription(description);
+        BookAiContentService.GenerationControl generationControl = new BookAiContentService.GenerationControl();
+        when(bookSearchService.fetchBookDetail(bookId)).thenReturn(java.util.Optional.of(detail));
+        when(bookDataOrchestrator.enrichDescriptionForAiIfNeeded(bookId, detail, description, 50))
+            .thenAnswer(invocation -> {
+                generationControl.cancel();
+                return description;
+            });
+
+        assertThatThrownBy(() -> service.generateAndPersist(
+            bookId,
+            ignored -> { },
+            net.findmybook.support.llm.LlmGatewayTier.LIVE_RENDER,
+            generationControl
+        )).isInstanceOf(CancellationException.class)
+            .hasMessage("AI content generation cancelled");
+
+        verify(repository, never()).insertNewCurrentVersion(any(), any(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void should_AllowClaimedPersistenceToFinish_When_CancellationArrivesAfterClaim() throws Exception {
+        BookAiContentService.GenerationControl generationControl = new BookAiContentService.GenerationControl();
+        CountDownLatch persistenceClaimed = new CountDownLatch(1);
+        CountDownLatch releasePersistence = new CountDownLatch(1);
+
+        CompletableFuture<String> persistenceResult = CompletableFuture.supplyAsync(() ->
+            generationControl.persistIfActive(() -> {
+                persistenceClaimed.countDown();
+                try {
+                    if (!releasePersistence.await(5, TimeUnit.SECONDS)) {
+                        throw new IllegalStateException("Persistence release timed out");
+                    }
+                } catch (InterruptedException interruptedException) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("Persistence was interrupted", interruptedException);
+                }
+                return "persisted";
+            })
+        );
+
+        assertThat(persistenceClaimed.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(generationControl.cancel()).isFalse();
+        releasePersistence.countDown();
+
+        assertThat(persistenceResult.get(5, TimeUnit.SECONDS)).isEqualTo("persisted");
+    }
+
+    @Test
+    void should_NotInsert_When_CancellationClaimsPersistenceBoundaryFirst() throws Exception {
+        BookAiContentService.GenerationControl generationControl = new BookAiContentService.GenerationControl();
+        CountDownLatch persistenceBoundaryReached = new CountDownLatch(1);
+        CountDownLatch allowPersistenceClaim = new CountDownLatch(1);
+        AtomicReference<Throwable> persistenceFailure = new AtomicReference<>();
+        BookAiContent aiContent = new BookAiContent(
+            "Summary",
+            "Reader fit",
+            List.of("Theme"),
+            List.of("Takeaway"),
+            "Context"
+        );
+        UUID bookId = UUID.randomUUID();
+
+        Thread persistenceThread = Thread.ofPlatform().start(() -> {
+            persistenceBoundaryReached.countDown();
+            try {
+                boolean released = allowPersistenceClaim.await(5, TimeUnit.SECONDS);
+                if (!released) {
+                    persistenceFailure.set(new IllegalStateException("Persistence boundary release timed out"));
+                    return;
+                }
+                generationControl.persistIfActive(
+                    () -> repository.insertNewCurrentVersion(bookId, aiContent, "model", "provider", "hash")
+                );
+            } catch (InterruptedException interruptedException) {
+                Thread.currentThread().interrupt();
+                persistenceFailure.set(interruptedException);
+            } catch (CancellationException cancellation) {
+                persistenceFailure.set(cancellation);
+            }
+        });
+
+        assertThat(persistenceBoundaryReached.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(generationControl.cancel()).isTrue();
+        allowPersistenceClaim.countDown();
+        persistenceThread.join(TimeUnit.SECONDS.toMillis(5));
+
+        assertThat(persistenceThread.isAlive()).isFalse();
+        assertThat(persistenceFailure.get())
+            .isInstanceOf(CancellationException.class)
+            .hasMessage("AI content generation cancelled before persistence");
+        verify(repository, never()).insertNewCurrentVersion(any(), any(), anyString(), anyString(), anyString());
     }
 
     @Test
@@ -193,7 +300,7 @@ class BookAiContentServiceTest {
     }
 
     @Test
-    void should_ParsePlainTextFallback_When_ModelReturnsNonJsonSections() {
+    void should_RejectPlainText_When_ModelReturnsNonJsonSections() {
         AiContentJsonParser parser = new AiContentJsonParser(new ObjectMapper());
 
         String plainTextResponse = """
@@ -209,13 +316,9 @@ class BookAiContentServiceTest {
             Context: Aligns modern SRE ideas with day-to-day delivery pressure.
             """;
 
-        BookAiContent parsed = parser.parse(plainTextResponse);
-
-        assertThat(parsed.summary()).contains("practical guide");
-        assertThat(parsed.readerFit()).contains("Engineers and technical leads");
-        assertThat(parsed.keyThemes()).contains("incident response", "observability");
-        assertThat(parsed.takeaways()).contains("Establish shared ownership for reliability outcomes.");
-        assertThat(parsed.context()).contains("SRE ideas");
+        assertThatThrownBy(() -> parser.parse(plainTextResponse))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("valid JSON object");
     }
 
     @Test
@@ -238,6 +341,105 @@ class BookAiContentServiceTest {
         assertThatThrownBy(() -> parser.parse(truncatedResponse))
             .isInstanceOf(IllegalStateException.class)
             .hasMessageContaining("valid JSON object");
+    }
+
+    @Test
+    void should_RejectUnknownTopLevelField_When_ResponseDriftsFromCanonicalContract() {
+        AiContentJsonParser parser = new AiContentJsonParser(new ObjectMapper());
+        String response = validAiContentJson().replace("}", ",\"unexpected\":true}");
+
+        assertThatThrownBy(() -> parser.parse(response))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("unknown field: unexpected");
+    }
+
+    @Test
+    void should_RejectNonStringSummary_When_ResponseHasWrongScalarType() {
+        AiContentJsonParser parser = new AiContentJsonParser(new ObjectMapper());
+        String response = validAiContentJson().replace("\"A reliable summary with enough words for validation.\"", "42");
+
+        assertThatThrownBy(() -> parser.parse(response))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("summary must be a nonblank JSON string");
+    }
+
+    @Test
+    void should_RejectBlankSummary_When_ResponseHasNoRequiredProse() {
+        AiContentJsonParser parser = new AiContentJsonParser(new ObjectMapper());
+        String response = validAiContentJson().replace("\"A reliable summary with enough words for validation.\"", "\"  \"");
+
+        assertThatThrownBy(() -> parser.parse(response))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("field must be nonblank: summary");
+    }
+
+    @Test
+    void should_RejectNonStringReaderFit_When_OptionalTextHasWrongScalarType() {
+        AiContentJsonParser parser = new AiContentJsonParser(new ObjectMapper());
+        String response = validAiContentJson().replace("\"Readers who value grounded recommendations.\"", "false");
+
+        assertThatThrownBy(() -> parser.parse(response))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("readerFit must be a JSON string or null");
+    }
+
+    @Test
+    void should_RejectNonArrayKeyThemes_When_ResponseHasWrongCollectionType() {
+        AiContentJsonParser parser = new AiContentJsonParser(new ObjectMapper());
+        String response = validAiContentJson().replace("[\"reliability\"]", "\"reliability\"");
+
+        assertThatThrownBy(() -> parser.parse(response))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("keyThemes must be an array of JSON strings");
+    }
+
+    @Test
+    void should_RejectNonStringTheme_When_ResponseHasWrongArrayElementType() {
+        AiContentJsonParser parser = new AiContentJsonParser(new ObjectMapper());
+        String response = validAiContentJson().replace("\"reliability\"", "42");
+
+        assertThatThrownBy(() -> parser.parse(response))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("keyThemes[0] must be a nonblank JSON string");
+    }
+
+    @Test
+    void should_RejectAliasField_When_ResponseOmitsCanonicalFieldName() {
+        AiContentJsonParser parser = new AiContentJsonParser(new ObjectMapper());
+        String response = validAiContentJson().replace("\"readerFit\":", "\"reader_fit\":");
+
+        assertThatThrownBy(() -> parser.parse(response))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("unknown field: reader_fit");
+    }
+
+    @Test
+    void should_AcceptNullOptionalTextAndEmptyArrays_When_ResponseUsesCanonicalShape() {
+        AiContentJsonParser parser = new AiContentJsonParser(new ObjectMapper());
+        String response = new ObjectMapper().valueToTree(new BookAiContent(
+            "A reliable summary with enough words for validation.",
+            null,
+            List.of(),
+            null,
+            null
+        )).toString();
+
+        BookAiContent content = parser.parse(response);
+
+        assertThat(content.readerFit()).isNull();
+        assertThat(content.keyThemes()).isEmpty();
+        assertThat(content.takeaways()).isNull();
+        assertThat(content.context()).isNull();
+    }
+
+    private String validAiContentJson() {
+        return new ObjectMapper().valueToTree(new BookAiContent(
+            "A reliable summary with enough words for validation.",
+            "Readers who value grounded recommendations.",
+            List.of("reliability"),
+            List.of("Keep contracts explicit."),
+            "A concise context for the reader guide."
+        )).toString();
     }
 
     private BookAiContentService newService() {

--- a/src/test/java/net/findmybook/application/ai/BookAiContentServiceTest.java
+++ b/src/test/java/net/findmybook/application/ai/BookAiContentServiceTest.java
@@ -1,6 +1,6 @@
 package net.findmybook.application.ai;
 
-import com.openai.errors.OpenAIException;
+import com.openai.errors.OpenAIServiceException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
@@ -20,6 +20,8 @@ import net.findmybook.service.BookIdentifierResolver;
 import net.findmybook.service.BookSearchService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.test.util.ReflectionTestUtils;
 import tools.jackson.databind.ObjectMapper;
 
@@ -93,7 +95,8 @@ class BookAiContentServiceTest {
     @Test
     void should_ReturnTrueForRetryableFailure_When_LiveTransportFailsBeforeContent() {
         BookAiContentService service = newService();
-        OpenAIException openAiException = mock(OpenAIException.class);
+        OpenAIServiceException openAiException = mock(OpenAIServiceException.class);
+        when(openAiException.statusCode()).thenReturn(503);
         BookAiGenerationException generationFailure = new BookAiGenerationException(
             BookAiGenerationException.ErrorCode.GENERATION_FAILED,
             "AI content generation failed (gpt-5-mini): HTTP 503 server error",
@@ -113,7 +116,8 @@ class BookAiContentServiceTest {
     @Test
     void should_ReturnFalseForRetryableFailure_When_BackgroundSdkOwnsTransportRetries() {
         BookAiContentService service = newService();
-        OpenAIException openAiException = mock(OpenAIException.class);
+        OpenAIServiceException openAiException = mock(OpenAIServiceException.class);
+        when(openAiException.statusCode()).thenReturn(503);
         BookAiGenerationException generationFailure = new BookAiGenerationException(
             BookAiGenerationException.ErrorCode.GENERATION_FAILED,
             "AI content generation failed (gpt-5-mini): HTTP 503 server error",
@@ -125,6 +129,28 @@ class BookAiContentServiceTest {
             "isRetryableGenerationFailure",
             generationFailure,
             net.findmybook.support.llm.LlmGatewayTier.BACKGROUND_BATCH
+        );
+
+        assertThat(retryable).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {400, 401, 403, 404, 422})
+    void should_ReturnFalseForRetryableFailure_When_LiveRequestHasNonRetryableStatus(int statusCode) {
+        BookAiContentService service = newService();
+        OpenAIServiceException openAiException = mock(OpenAIServiceException.class);
+        when(openAiException.statusCode()).thenReturn(statusCode);
+        BookAiGenerationException generationFailure = new BookAiGenerationException(
+            BookAiGenerationException.ErrorCode.GENERATION_FAILED,
+            "AI content generation failed (gpt-5-mini): HTTP %d".formatted(statusCode),
+            openAiException
+        );
+
+        Boolean retryable = ReflectionTestUtils.invokeMethod(
+            service,
+            "isRetryableGenerationFailure",
+            generationFailure,
+            net.findmybook.support.llm.LlmGatewayTier.LIVE_RENDER
         );
 
         assertThat(retryable).isFalse();

--- a/src/test/java/net/findmybook/application/seo/GemmaInferenceReliabilityTest.java
+++ b/src/test/java/net/findmybook/application/seo/GemmaInferenceReliabilityTest.java
@@ -103,10 +103,8 @@ class GemmaInferenceReliabilityTest {
 
         assertThat(second.snapshot()).get().extracting(BookSeoMetadataSnapshot::provider).isEqualTo("openai");
         assertThat(third.generated()).isFalse();
-        assertThat(server.requestBodies()).hasSize(4).allSatisfy(body -> {
-            assertThat(body).contains("\"max_completion_tokens\":" + LlmGatewayTier.BACKGROUND_BATCH.maxCompletionTokens());
-            assertThat(body).contains("\"response_format\":{\"type\":\"json_object\"}");
-        });
+        assertThat(server.requestBodies()).hasSize(4).allSatisfy(body ->
+            assertThat(body).contains("\"max_completion_tokens\":" + LlmGatewayTier.BACKGROUND_BATCH.maxCompletionTokens()));
     }
 
     @Test
@@ -199,10 +197,8 @@ class GemmaInferenceReliabilityTest {
             .isInstanceOf(BookAiGenerationException.class)
             .hasMessageContaining("completion token budget");
         verify(repository, never()).insertNewCurrentVersion(any(), any(), anyString(), anyString(), anyString());
-        assertThat(server.requestBodies()).hasSize(2).allSatisfy(body -> {
-            assertThat(body).contains("\"max_completion_tokens\":" + LlmGatewayTier.LIVE_RENDER.maxCompletionTokens());
-            assertThat(body).contains("\"response_format\":{\"type\":\"json_object\"}");
-        });
+        assertThat(server.requestBodies()).hasSize(2).allSatisfy(body ->
+            assertThat(body).contains("\"max_completion_tokens\":" + LlmGatewayTier.LIVE_RENDER.maxCompletionTokens()));
     }
 
     @Test

--- a/src/test/java/net/findmybook/application/seo/GemmaInferenceReliabilityTest.java
+++ b/src/test/java/net/findmybook/application/seo/GemmaInferenceReliabilityTest.java
@@ -103,8 +103,10 @@ class GemmaInferenceReliabilityTest {
 
         assertThat(second.snapshot()).get().extracting(BookSeoMetadataSnapshot::provider).isEqualTo("openai");
         assertThat(third.generated()).isFalse();
-        assertThat(server.requestBodies()).hasSize(4).allSatisfy(body ->
-            assertThat(body).contains("\"max_completion_tokens\":" + LlmGatewayTier.BACKGROUND_BATCH.maxCompletionTokens()));
+        assertThat(server.requestBodies()).hasSize(4).allSatisfy(body -> {
+            assertThat(body).contains("\"max_completion_tokens\":" + LlmGatewayTier.BACKGROUND_BATCH.maxCompletionTokens());
+            assertThat(body).contains("\"response_format\":{\"type\":\"json_object\"}");
+        });
     }
 
     @Test
@@ -150,6 +152,25 @@ class GemmaInferenceReliabilityTest {
     }
 
     @Test
+    void should_RetryShapeDriftWithoutPersistence_When_SecondReaderResponseIsCanonical() {
+        server.enqueueSse(streamChunk(AI_JSON.replace("}", ",\"unexpected\":true}"), null) + streamChunk("", "stop"));
+        server.enqueueSse(streamChunk(AI_JSON, null) + streamChunk("", "stop"));
+        BookAiContentRepository repository = mock(BookAiContentRepository.class);
+        when(repository.insertNewCurrentVersion(any(), any(), anyString(), anyString(), anyString()))
+            .thenAnswer(invocation -> new BookAiContentSnapshot(
+                BOOK_ID, 1, Instant.EPOCH, invocation.getArgument(2), invocation.getArgument(3), invocation.getArgument(1)));
+        List<String> deltas = new ArrayList<>();
+
+        BookAiContentService.GeneratedContent generated = aiService(repository)
+            .generateAndPersist(BOOK_ID, deltas::add, LlmGatewayTier.LIVE_RENDER);
+
+        assertThat(generated.snapshot().aiContent().summary()).contains("grounded two-sentence summary");
+        assertThat(deltas).containsExactly(AI_JSON);
+        assertThat(server.requestBodies()).hasSize(2);
+        verify(repository).insertNewCurrentVersion(any(), any(), anyString(), anyString(), anyString());
+    }
+
+    @Test
     void should_RetryLiveTransportFailureWithoutReplayingContent_When_SecondAttemptSucceeds() {
         server.enqueueJson(503, "{\"error\":{\"message\":\"temporarily unavailable\"}}");
         server.enqueueSse(streamChunk(AI_JSON, null) + streamChunk("", "stop"));
@@ -178,8 +199,10 @@ class GemmaInferenceReliabilityTest {
             .isInstanceOf(BookAiGenerationException.class)
             .hasMessageContaining("completion token budget");
         verify(repository, never()).insertNewCurrentVersion(any(), any(), anyString(), anyString(), anyString());
-        assertThat(server.requestBodies()).hasSize(2).allSatisfy(body ->
-            assertThat(body).contains("\"max_completion_tokens\":" + LlmGatewayTier.LIVE_RENDER.maxCompletionTokens()));
+        assertThat(server.requestBodies()).hasSize(2).allSatisfy(body -> {
+            assertThat(body).contains("\"max_completion_tokens\":" + LlmGatewayTier.LIVE_RENDER.maxCompletionTokens());
+            assertThat(body).contains("\"response_format\":{\"type\":\"json_object\"}");
+        });
     }
 
     @Test
@@ -241,12 +264,31 @@ class GemmaInferenceReliabilityTest {
     }
 
     @Test
-    void should_ThrowTypedFailure_When_SeoResponseMissesRequiredField() {
+    void should_ThrowTypedFailure_When_SeoResponseMissesCanonicalField() {
         SeoMetadataJsonParser parser = new SeoMetadataJsonParser(new ObjectMapper());
 
         assertThatThrownBy(() -> parser.parse("{\"seoTitle\":\"Title only\"}"))
             .isInstanceOf(BookSeoGenerationException.class)
-            .hasMessageContaining("missing required field: seoDescription");
+            .hasMessageContaining("fields must exactly match the canonical contract");
+    }
+
+    @Test
+    void should_RejectNonCanonicalSeoResponse_When_GemmaDriftsFromJsonContract() {
+        SeoMetadataJsonParser parser = new SeoMetadataJsonParser(new ObjectMapper());
+
+        assertThatThrownBy(() -> parser.parse("SEO title: Test Book; description: useful details"))
+            .isInstanceOf(BookSeoGenerationException.class)
+            .hasMessageContaining("valid JSON object");
+        assertThatThrownBy(() -> parser.parse("{\"title\":\"Test Book\",\"description\":\"Useful details\"}"))
+            .isInstanceOf(BookSeoGenerationException.class)
+            .hasMessageContaining("exactly match the canonical contract");
+        assertThatThrownBy(() -> parser.parse("{\"seoTitle\":42,\"seoDescription\":true}"))
+            .isInstanceOf(BookSeoGenerationException.class)
+            .hasMessageContaining("field must be a string: seoTitle");
+        assertThatThrownBy(() -> parser.parse(
+            "{\"seoTitle\":\"Test Book\",\"seoDescription\":\"Useful details\",\"extra\":true}"
+        )).isInstanceOf(BookSeoGenerationException.class)
+            .hasMessageContaining("exactly match the canonical contract");
     }
 
     @Test

--- a/src/test/java/net/findmybook/controller/BookAiContentControllerTest.java
+++ b/src/test/java/net/findmybook/controller/BookAiContentControllerTest.java
@@ -250,25 +250,26 @@ class BookAiContentControllerTest {
     }
 
     @Test
-    @DisplayName("default stream deadline reserves queue and delivery time after all live render attempts")
-    void should_ReserveQueueAndDeliveryHeadroom_When_DefaultStreamDeadlineIsCalculated() {
-        long applicationDeadlineMillis = (Long) ReflectionTestUtils.getField(controller, "applicationStreamTimeoutMillis");
+    @DisplayName("default generation deadline reserves delivery time after all live render attempts")
+    void should_ReserveDeliveryHeadroom_When_DefaultGenerationDeadlineIsCalculated() {
+        long queueWaitDeadlineMillis = (Long) ReflectionTestUtils.getField(controller, "queueWaitDeadlineMillis");
+        long generationDeadlineMillis = (Long) ReflectionTestUtils.getField(controller, "generationDeadlineMillis");
         long emitterTimeoutMillis = (Long) ReflectionTestUtils.getField(controller, "emitterTimeoutMillis");
         long maximumLiveRenderAttemptsMillis = Duration.ofSeconds(LlmGatewayTier.LIVE_RENDER.callTimeoutSeconds())
             .multipliedBy(LlmGatewayTier.LIVE_RENDER.maxGenerationAttempts())
             .toMillis();
 
-        assertThat(applicationDeadlineMillis - maximumLiveRenderAttemptsMillis)
+        assertThat(generationDeadlineMillis - maximumLiveRenderAttemptsMillis)
             .isGreaterThanOrEqualTo(Duration.ofMinutes(1).toMillis());
-        assertThat(emitterTimeoutMillis).isGreaterThan(applicationDeadlineMillis);
+        assertThat(emitterTimeoutMillis).isGreaterThan(queueWaitDeadlineMillis + generationDeadlineMillis);
     }
 
     @Test
-    @DisplayName("POST stream emits stream_timeout before the emitter timeout")
-    void should_EmitStreamTimeout_When_ApplicationDeadlineExpires() throws Exception {
+    @DisplayName("POST stream starts the generation deadline only after leaving the queue")
+    void should_StartGenerationDeadline_When_QueuedTaskStarts() throws Exception {
         controller.shutdownTickerExecutor();
         ScheduledThreadPoolExecutor deadlineExecutor = new ScheduledThreadPoolExecutor(1);
-        configureController("development", deadlineExecutor, 20L, 200L);
+        configureController("development", deadlineExecutor, 200L, 20L, 500L);
         UUID bookId = UUID.randomUUID();
         CompletableFuture<Void> started = new CompletableFuture<>();
         CompletableFuture<BookAiContentService.GeneratedContent> result = new CompletableFuture<>();
@@ -280,14 +281,44 @@ class BookAiContentControllerTest {
         when(requestQueue.<BookAiContentService.GeneratedContent>enqueueForeground(anyInt(), any())).thenReturn(task);
         when(requestQueue.getPosition("task-timeout-1")).thenReturn(
             new BookAiContentRequestQueue.QueuePosition(true, 1, 0, 1, 1));
+        when(requestQueue.snapshot()).thenReturn(new BookAiContentRequestQueue.QueueSnapshot(1, 0, 1));
+
+        var response = mockMvc.perform(post("/api/books/slug/ai/content/stream"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        Thread.sleep(60L);
+        assertThat(response.getResponse().getContentAsString()).doesNotContain("stream_timeout");
+        started.complete(null);
+        assertThat(response.getAsyncResult(1_000L)).isNull();
+        assertThat(response.getResponse().getContentAsString()).contains("\"code\":\"stream_timeout\"");
+    }
+
+    @Test
+    @DisplayName("POST stream cancels pending work when the bounded queue wait expires")
+    void should_CancelPendingWork_When_QueueWaitDeadlineExpires() throws Exception {
+        controller.shutdownTickerExecutor();
+        ScheduledThreadPoolExecutor deadlineExecutor = new ScheduledThreadPoolExecutor(1);
+        configureController("development", deadlineExecutor, 20L, 200L, 500L);
+        UUID bookId = UUID.randomUUID();
+        CompletableFuture<Void> started = new CompletableFuture<>();
+        CompletableFuture<BookAiContentService.GeneratedContent> result = new CompletableFuture<>();
+        BookAiContentRequestQueue.EnqueuedTask<BookAiContentService.GeneratedContent> task =
+            new BookAiContentRequestQueue.EnqueuedTask<>("task-queue-timeout-1", started, result);
+        when(aiContentService.resolveBookId("slug")).thenReturn(Optional.of(bookId));
+        when(aiContentService.findCurrent(bookId)).thenReturn(Optional.empty());
+        when(aiContentService.isAvailable()).thenReturn(true);
+        when(requestQueue.<BookAiContentService.GeneratedContent>enqueueForeground(anyInt(), any())).thenReturn(task);
+        when(requestQueue.getPosition("task-queue-timeout-1")).thenReturn(
+            new BookAiContentRequestQueue.QueuePosition(true, 1, 0, 1, 1));
 
         var response = mockMvc.perform(post("/api/books/slug/ai/content/stream"))
             .andExpect(status().isOk())
             .andReturn();
 
         assertThat(response.getAsyncResult(1_000L)).isNull();
-        assertThat(response.getResponse().getContentAsString()).contains("\"code\":\"stream_timeout\"");
-        verify(requestQueue).cancelPending("task-timeout-1");
+        assertThat(response.getResponse().getContentAsString()).contains("\"code\":\"queue_busy\"");
+        verify(requestQueue).cancelPending("task-queue-timeout-1");
     }
 
     /**
@@ -332,9 +363,11 @@ class BookAiContentControllerTest {
     }
 
     private void configureController(String environmentMode, ScheduledThreadPoolExecutor executor,
-                                     long applicationDeadlineMillis, long emitterTimeoutMillis) {
+                                     long queueWaitDeadlineMillis,
+                                     long generationDeadlineMillis,
+                                     long emitterTimeoutMillis) {
         controller = new BookAiContentController(aiContentService, requestQueue, new ObjectMapper(), environmentMode,
-            executor, applicationDeadlineMillis, emitterTimeoutMillis);
+            executor, queueWaitDeadlineMillis, generationDeadlineMillis, emitterTimeoutMillis);
         mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
     }
 }

--- a/src/test/java/net/findmybook/controller/BookAiContentControllerTest.java
+++ b/src/test/java/net/findmybook/controller/BookAiContentControllerTest.java
@@ -1,10 +1,12 @@
 package net.findmybook.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -17,6 +19,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.function.Supplier;
@@ -32,6 +35,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -303,12 +307,14 @@ class BookAiContentControllerTest {
         UUID bookId = UUID.randomUUID();
         CompletableFuture<Void> started = new CompletableFuture<>();
         CompletableFuture<BookAiContentService.GeneratedContent> result = new CompletableFuture<>();
+        ArgumentCaptor<Supplier<BookAiContentService.GeneratedContent>> supplierCaptor = ArgumentCaptor.captor();
         BookAiContentRequestQueue.EnqueuedTask<BookAiContentService.GeneratedContent> task =
             new BookAiContentRequestQueue.EnqueuedTask<>("task-queue-timeout-1", started, result);
         when(aiContentService.resolveBookId("slug")).thenReturn(Optional.of(bookId));
         when(aiContentService.findCurrent(bookId)).thenReturn(Optional.empty());
         when(aiContentService.isAvailable()).thenReturn(true);
-        when(requestQueue.<BookAiContentService.GeneratedContent>enqueueForeground(anyInt(), any())).thenReturn(task);
+        when(requestQueue.<BookAiContentService.GeneratedContent>enqueueForeground(anyInt(), supplierCaptor.capture()))
+            .thenReturn(task);
         when(requestQueue.getPosition("task-queue-timeout-1")).thenReturn(
             new BookAiContentRequestQueue.QueuePosition(true, 1, 0, 1, 1));
 
@@ -319,6 +325,10 @@ class BookAiContentControllerTest {
         assertThat(response.getAsyncResult(1_000L)).isNull();
         assertThat(response.getResponse().getContentAsString()).contains("\"code\":\"queue_busy\"");
         verify(requestQueue).cancelPending("task-queue-timeout-1");
+        assertThatThrownBy(() -> supplierCaptor.getValue().get())
+            .isInstanceOf(CancellationException.class)
+            .hasMessage("AI stream closed before generation started");
+        verify(aiContentService, never()).generateAndPersist(any(), any(), any());
     }
 
     /**

--- a/src/test/java/net/findmybook/controller/BookAiContentControllerTest.java
+++ b/src/test/java/net/findmybook/controller/BookAiContentControllerTest.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import net.findmybook.application.ai.BookAiGenerationException;
 import net.findmybook.application.ai.BookAiContentService;
@@ -132,10 +133,7 @@ class BookAiContentControllerTest {
         BookAiContentRequestQueue.EnqueuedTask<BookAiContentService.GeneratedContent> task =
             new BookAiContentRequestQueue.EnqueuedTask<>("task-1", new CompletableFuture<>(), new CompletableFuture<>());
 
-        when(requestQueue.<BookAiContentService.GeneratedContent>enqueueForeground(
-            anyInt(),
-            org.mockito.ArgumentMatchers.<Supplier<BookAiContentService.GeneratedContent>>any()
-        )).thenReturn(task);
+        stubForegroundEnqueue(task);
         when(requestQueue.getPosition("task-1")).thenReturn(
             new BookAiContentRequestQueue.QueuePosition(true, 1, 0, 1, 5)
         );
@@ -144,7 +142,58 @@ class BookAiContentControllerTest {
             .andExpect(status().isOk())
             .andExpect(content().contentType("text/event-stream"));
 
-        verify(requestQueue).enqueueForeground(eq(0), any());
+        verify(requestQueue).enqueueForeground(eq(0), any(), any());
+    }
+
+    @Test
+    @DisplayName("POST stream cannot invoke an immediately started supplier before controller lifecycle wiring")
+    void should_GenerateSuccessfully_When_QueueStartsSupplierBeforeEnqueueReturns() throws Exception {
+        UUID bookId = UUID.randomUUID();
+        BookAiContentSnapshot snapshot = new BookAiContentSnapshot(
+            bookId,
+            1,
+            Instant.EPOCH,
+            "gemma-4-26b-a4b",
+            "openai",
+            new BookAiContent("Summary", "Audience", List.of("Theme"), List.of("Insight"), "Context")
+        );
+        BookAiContentService.GeneratedContent generated =
+            new BookAiContentService.GeneratedContent("{\"summary\":\"Summary\"}", snapshot);
+        CompletableFuture<Void> started = new CompletableFuture<>();
+        CompletableFuture<BookAiContentService.GeneratedContent> result = new CompletableFuture<>();
+        BookAiContentRequestQueue.EnqueuedTask<BookAiContentService.GeneratedContent> task =
+            new BookAiContentRequestQueue.EnqueuedTask<>("task-immediate-1", started, result);
+
+        when(aiContentService.resolveBookId("immediate-slug")).thenReturn(Optional.of(bookId));
+        when(aiContentService.isAvailable()).thenReturn(true);
+        when(aiContentService.configuredModel()).thenReturn("gemma-4-26b-a4b");
+        when(aiContentService.apiMode()).thenReturn("openai");
+        when(aiContentService.generateAndPersist(eq(bookId), any(), eq(LlmGatewayTier.LIVE_RENDER), any()))
+            .thenReturn(generated);
+        when(requestQueue.<BookAiContentService.GeneratedContent>enqueueForeground(anyInt(), any(), any()))
+            .thenAnswer(invocation -> {
+                Supplier<BookAiContentService.GeneratedContent> supplier = invocation.getArgument(1);
+                Consumer<BookAiContentRequestQueue.EnqueuedTask<BookAiContentService.GeneratedContent>> lifecycleSetup =
+                    invocation.getArgument(2);
+                lifecycleSetup.accept(task);
+                started.complete(null);
+                result.complete(supplier.get());
+                return task;
+            });
+        when(requestQueue.getPosition("task-immediate-1")).thenReturn(
+            new BookAiContentRequestQueue.QueuePosition(false, null, 1, 0, 1));
+        when(requestQueue.snapshot()).thenReturn(new BookAiContentRequestQueue.QueueSnapshot(1, 0, 1));
+
+        var response = mockMvc.perform(post("/api/books/immediate-slug/ai/content/stream?refresh=true"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        assertThat(response.getAsyncResult(1_000L)).isNull();
+        assertThat(response.getResponse().getContentAsString())
+            .contains("event:message_start")
+            .contains("event:done")
+            .doesNotContain("event:error");
+        verify(aiContentService).generateAndPersist(eq(bookId), any(), eq(LlmGatewayTier.LIVE_RENDER), any());
     }
 
     @Test
@@ -157,10 +206,7 @@ class BookAiContentControllerTest {
 
         BookAiContentRequestQueue.EnqueuedTask<BookAiContentService.GeneratedContent> task =
             new BookAiContentRequestQueue.EnqueuedTask<>("task-busy-1", new CompletableFuture<>(), new CompletableFuture<>());
-        when(requestQueue.<BookAiContentService.GeneratedContent>enqueueForeground(
-            anyInt(),
-            org.mockito.ArgumentMatchers.<Supplier<BookAiContentService.GeneratedContent>>any()
-        )).thenReturn(task);
+        stubForegroundEnqueue(task);
         when(requestQueue.getPosition("task-busy-1")).thenReturn(
             new BookAiContentRequestQueue.QueuePosition(true, 1, 1, 6000, 1)
         );
@@ -169,7 +215,7 @@ class BookAiContentControllerTest {
             .andExpect(status().isOk())
             .andExpect(content().contentType("text/event-stream"));
 
-        verify(requestQueue).enqueueForeground(eq(0), any());
+        verify(requestQueue).enqueueForeground(eq(0), any(), any());
     }
 
     @Test
@@ -282,7 +328,7 @@ class BookAiContentControllerTest {
         when(aiContentService.resolveBookId("slug")).thenReturn(Optional.of(bookId));
         when(aiContentService.findCurrent(bookId)).thenReturn(Optional.empty());
         when(aiContentService.isAvailable()).thenReturn(true);
-        when(requestQueue.<BookAiContentService.GeneratedContent>enqueueForeground(anyInt(), any())).thenReturn(task);
+        stubForegroundEnqueue(task);
         when(requestQueue.getPosition("task-timeout-1")).thenReturn(
             new BookAiContentRequestQueue.QueuePosition(true, 1, 0, 1, 1));
         when(requestQueue.snapshot()).thenReturn(new BookAiContentRequestQueue.QueueSnapshot(1, 0, 1));
@@ -296,6 +342,7 @@ class BookAiContentControllerTest {
         started.complete(null);
         assertThat(response.getAsyncResult(1_000L)).isNull();
         assertThat(response.getResponse().getContentAsString()).contains("\"code\":\"stream_timeout\"");
+        verify(requestQueue).cancel("task-timeout-1");
     }
 
     @Test
@@ -313,8 +360,14 @@ class BookAiContentControllerTest {
         when(aiContentService.resolveBookId("slug")).thenReturn(Optional.of(bookId));
         when(aiContentService.findCurrent(bookId)).thenReturn(Optional.empty());
         when(aiContentService.isAvailable()).thenReturn(true);
-        when(requestQueue.<BookAiContentService.GeneratedContent>enqueueForeground(anyInt(), supplierCaptor.capture()))
-            .thenReturn(task);
+        when(requestQueue.<BookAiContentService.GeneratedContent>enqueueForeground(
+            anyInt(), supplierCaptor.capture(), any()
+        )).thenAnswer(invocation -> {
+            Consumer<BookAiContentRequestQueue.EnqueuedTask<BookAiContentService.GeneratedContent>> lifecycleSetup =
+                invocation.getArgument(2);
+            lifecycleSetup.accept(task);
+            return task;
+        });
         when(requestQueue.getPosition("task-queue-timeout-1")).thenReturn(
             new BookAiContentRequestQueue.QueuePosition(true, 1, 0, 1, 1));
 
@@ -324,11 +377,11 @@ class BookAiContentControllerTest {
 
         assertThat(response.getAsyncResult(1_000L)).isNull();
         assertThat(response.getResponse().getContentAsString()).contains("\"code\":\"queue_busy\"");
-        verify(requestQueue).cancelPending("task-queue-timeout-1");
+        verify(requestQueue).cancel("task-queue-timeout-1");
         assertThatThrownBy(() -> supplierCaptor.getValue().get())
             .isInstanceOf(CancellationException.class)
             .hasMessage("AI stream closed before generation started");
-        verify(aiContentService, never()).generateAndPersist(any(), any(), any());
+        verify(aiContentService, never()).generateAndPersist(any(), any(), any(), any());
     }
 
     /**
@@ -351,10 +404,7 @@ class BookAiContentControllerTest {
 
         BookAiContentRequestQueue.EnqueuedTask<BookAiContentService.GeneratedContent> task =
             new BookAiContentRequestQueue.EnqueuedTask<>("task-failed-1", started, failedResult);
-        when(requestQueue.<BookAiContentService.GeneratedContent>enqueueForeground(
-            anyInt(),
-            org.mockito.ArgumentMatchers.<Supplier<BookAiContentService.GeneratedContent>>any()
-        )).thenReturn(task);
+        stubForegroundEnqueue(task);
         when(requestQueue.getPosition("task-failed-1")).thenReturn(
             new BookAiContentRequestQueue.QueuePosition(true, 1, 0, 1, 0)
         );
@@ -370,6 +420,18 @@ class BookAiContentControllerTest {
     private void configureController(String environmentMode) {
         controller = new BookAiContentController(aiContentService, requestQueue, new ObjectMapper(), environmentMode);
         mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    private void stubForegroundEnqueue(
+        BookAiContentRequestQueue.EnqueuedTask<BookAiContentService.GeneratedContent> task
+    ) {
+        when(requestQueue.<BookAiContentService.GeneratedContent>enqueueForeground(anyInt(), any(), any()))
+            .thenAnswer(invocation -> {
+                Consumer<BookAiContentRequestQueue.EnqueuedTask<BookAiContentService.GeneratedContent>> lifecycleSetup =
+                    invocation.getArgument(2);
+                lifecycleSetup.accept(task);
+                return task;
+            });
     }
 
     private void configureController(String environmentMode, ScheduledThreadPoolExecutor executor,

--- a/src/test/java/net/findmybook/controller/BookAiContentControllerTest.java
+++ b/src/test/java/net/findmybook/controller/BookAiContentControllerTest.java
@@ -7,10 +7,12 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -22,6 +24,7 @@ import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import net.findmybook.application.ai.BookAiGenerationException;
@@ -138,11 +141,106 @@ class BookAiContentControllerTest {
             new BookAiContentRequestQueue.QueuePosition(true, 1, 0, 1, 5)
         );
 
-        mockMvc.perform(post("/api/books/slug/ai/content/stream"))
+        String responseBody = mockMvc.perform(post("/api/books/slug/ai/content/stream"))
             .andExpect(status().isOk())
-            .andExpect(content().contentType("text/event-stream"));
+            .andExpect(content().contentType("text/event-stream"))
+            .andExpect(header().string("X-Book-AI-Request-Id", "task-1"))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
 
+        assertThat(responseBody)
+            .contains("event:queued")
+            .contains("\"requestId\":\"task-1\"");
         verify(requestQueue).enqueueForeground(eq(0), any(), any());
+    }
+
+    @Test
+    @DisplayName("POST cancel is idempotent for pending and unknown request IDs")
+    void should_CancelPendingTaskOnce_When_CancelRequestIsRepeated() throws Exception {
+        UUID bookId = UUID.randomUUID();
+        CompletableFuture<Void> started = new CompletableFuture<>();
+        CompletableFuture<BookAiContentService.GeneratedContent> result = new CompletableFuture<>();
+        ArgumentCaptor<Supplier<BookAiContentService.GeneratedContent>> supplierCaptor = ArgumentCaptor.captor();
+        BookAiContentRequestQueue.EnqueuedTask<BookAiContentService.GeneratedContent> task =
+            new BookAiContentRequestQueue.EnqueuedTask<>("pending-request", started, result);
+        when(aiContentService.resolveBookId("pending-book")).thenReturn(Optional.of(bookId));
+        when(aiContentService.isAvailable()).thenReturn(true);
+        when(requestQueue.<BookAiContentService.GeneratedContent>enqueueForeground(
+            anyInt(), supplierCaptor.capture(), any()
+        )).thenAnswer(invocation -> {
+            Consumer<BookAiContentRequestQueue.EnqueuedTask<BookAiContentService.GeneratedContent>> lifecycleSetup =
+                invocation.getArgument(2);
+            lifecycleSetup.accept(task);
+            return task;
+        });
+        when(requestQueue.getPosition("pending-request")).thenReturn(
+            new BookAiContentRequestQueue.QueuePosition(true, 1, 0, 1, 1));
+
+        mockMvc.perform(post("/api/books/pending-book/ai/content/stream?refresh=true"))
+            .andExpect(status().isOk());
+        assertThat(activeRequestCount()).isEqualTo(1);
+
+        mockMvc.perform(post("/api/books/ai/content/requests/unknown-request/cancel"))
+            .andExpect(status().isNoContent())
+            .andExpect(content().string(""));
+        mockMvc.perform(post("/api/books/ai/content/requests/pending-request/cancel"))
+            .andExpect(status().isNoContent())
+            .andExpect(content().string(""));
+        mockMvc.perform(post("/api/books/ai/content/requests/pending-request/cancel"))
+            .andExpect(status().isNoContent())
+            .andExpect(content().string(""));
+
+        verify(requestQueue, times(1)).cancel("pending-request");
+        assertThat(activeRequestCount()).isZero();
+        assertThatThrownBy(() -> supplierCaptor.getValue().get())
+            .isInstanceOf(CancellationException.class);
+    }
+
+    @Test
+    @DisplayName("POST cancel claims GenerationControl for a running request")
+    void should_CancelGenerationControl_When_RunningRequestIsCanceled() throws Exception {
+        UUID bookId = UUID.randomUUID();
+        BookAiContentSnapshot snapshot = new BookAiContentSnapshot(
+            bookId, 1, Instant.EPOCH, "test-model", "openai",
+            new BookAiContent("Summary", "Audience", List.of("Theme"), List.of("Insight"), "Context")
+        );
+        BookAiContentService.GeneratedContent generated =
+            new BookAiContentService.GeneratedContent("{\"summary\":\"Summary\"}", snapshot);
+        CompletableFuture<Void> started = new CompletableFuture<>();
+        CompletableFuture<BookAiContentService.GeneratedContent> result = new CompletableFuture<>();
+        ArgumentCaptor<Supplier<BookAiContentService.GeneratedContent>> supplierCaptor = ArgumentCaptor.captor();
+        ArgumentCaptor<BookAiContentService.GenerationControl> controlCaptor = ArgumentCaptor.captor();
+        BookAiContentRequestQueue.EnqueuedTask<BookAiContentService.GeneratedContent> task =
+            new BookAiContentRequestQueue.EnqueuedTask<>("running-request", started, result);
+        when(aiContentService.resolveBookId("running-book")).thenReturn(Optional.of(bookId));
+        when(aiContentService.isAvailable()).thenReturn(true);
+        when(aiContentService.configuredModel()).thenReturn("test-model");
+        when(aiContentService.apiMode()).thenReturn("openai");
+        when(aiContentService.generateAndPersist(eq(bookId), any(), eq(LlmGatewayTier.LIVE_RENDER), controlCaptor.capture()))
+            .thenReturn(generated);
+        when(requestQueue.<BookAiContentService.GeneratedContent>enqueueForeground(
+            anyInt(), supplierCaptor.capture(), any()
+        )).thenAnswer(invocation -> {
+            Consumer<BookAiContentRequestQueue.EnqueuedTask<BookAiContentService.GeneratedContent>> lifecycleSetup =
+                invocation.getArgument(2);
+            lifecycleSetup.accept(task);
+            return task;
+        });
+        when(requestQueue.getPosition("running-request")).thenReturn(
+            new BookAiContentRequestQueue.QueuePosition(true, 1, 0, 1, 1));
+        when(requestQueue.snapshot()).thenReturn(new BookAiContentRequestQueue.QueueSnapshot(1, 0, 1));
+
+        mockMvc.perform(post("/api/books/running-book/ai/content/stream?refresh=true"))
+            .andExpect(status().isOk());
+        started.complete(null);
+        supplierCaptor.getValue().get();
+        mockMvc.perform(post("/api/books/ai/content/requests/running-request/cancel"))
+            .andExpect(status().isNoContent());
+
+        verify(requestQueue).cancel("running-request");
+        assertThat(controlCaptor.getValue().cancel()).isFalse();
+        assertThat(activeRequestCount()).isZero();
     }
 
     @Test
@@ -193,7 +291,56 @@ class BookAiContentControllerTest {
             .contains("event:message_start")
             .contains("event:done")
             .doesNotContain("event:error");
+        assertThat(activeRequestCount()).isZero();
         verify(aiContentService).generateAndPersist(eq(bookId), any(), eq(LlmGatewayTier.LIVE_RENDER), any());
+    }
+
+    @Test
+    @DisplayName("POST stream removes cancellation registration when lifecycle setup fails")
+    void should_RemoveCancellationRegistration_When_LifecycleSetupFails() {
+        controller.shutdownTickerExecutor();
+        ScheduledThreadPoolExecutor rejectedExecutor = new ScheduledThreadPoolExecutor(1);
+        rejectedExecutor.shutdownNow();
+        configureController("development", rejectedExecutor, 200L, 200L, 500L);
+        UUID bookId = UUID.randomUUID();
+        CompletableFuture<Void> started = new CompletableFuture<>();
+        CompletableFuture<BookAiContentService.GeneratedContent> result = new CompletableFuture<>();
+        BookAiContentRequestQueue.EnqueuedTask<BookAiContentService.GeneratedContent> task =
+            new BookAiContentRequestQueue.EnqueuedTask<>("setup-failure-request", started, result);
+        when(aiContentService.resolveBookId("setup-failure-book")).thenReturn(Optional.of(bookId));
+        when(aiContentService.isAvailable()).thenReturn(true);
+        when(requestQueue.getPosition("setup-failure-request")).thenReturn(
+            new BookAiContentRequestQueue.QueuePosition(true, 1, 0, 1, 1));
+        when(requestQueue.<BookAiContentService.GeneratedContent>enqueueForeground(anyInt(), any(), any()))
+            .thenAnswer(invocation -> {
+                Consumer<BookAiContentRequestQueue.EnqueuedTask<BookAiContentService.GeneratedContent>> lifecycleSetup =
+                    invocation.getArgument(2);
+                lifecycleSetup.accept(task);
+                return task;
+            });
+
+        assertThatThrownBy(() -> mockMvc.perform(
+            post("/api/books/setup-failure-book/ai/content/stream?refresh=true")
+        )).hasCauseInstanceOf(java.util.concurrent.RejectedExecutionException.class);
+
+        verify(requestQueue).cancel("setup-failure-request");
+        assertThat(activeRequestCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("shutdown rejects and cancels request registrations that arrive after registry closure")
+    void should_CancelLateRegistration_When_ShutdownHasStarted() {
+        BookAiContentSseOrchestrator orchestrator = sseOrchestrator();
+        AtomicBoolean cancellationInvoked = new AtomicBoolean(false);
+        orchestrator.cancelAllRequests();
+
+        assertThatThrownBy(() -> orchestrator.registerCancellation(
+            "late-request", () -> cancellationInvoked.set(true)
+        )).isInstanceOf(IllegalStateException.class)
+            .hasMessage("AI cancellation registry is shutting down");
+
+        assertThat(cancellationInvoked).isTrue();
+        assertThat(orchestrator.activeRequestCount()).isZero();
     }
 
     @Test
@@ -270,6 +417,7 @@ class BookAiContentControllerTest {
             .contains("\"code\":\"description_too_short\"")
             .contains("AI content is unavailable for this book")
             .doesNotContain("length=0");
+        assertThat(activeRequestCount()).isZero();
     }
 
     @Test
@@ -420,6 +568,14 @@ class BookAiContentControllerTest {
     private void configureController(String environmentMode) {
         controller = new BookAiContentController(aiContentService, requestQueue, new ObjectMapper(), environmentMode);
         mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    private int activeRequestCount() {
+        return sseOrchestrator().activeRequestCount();
+    }
+
+    private BookAiContentSseOrchestrator sseOrchestrator() {
+        return (BookAiContentSseOrchestrator) ReflectionTestUtils.getField(controller, "sseOrchestrator");
     }
 
     private void stubForegroundEnqueue(

--- a/src/test/java/net/findmybook/support/ai/BookAiContentRequestQueueTest.java
+++ b/src/test/java/net/findmybook/support/ai/BookAiContentRequestQueueTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
 class BookAiContentRequestQueueTest {
@@ -116,7 +117,7 @@ class BookAiContentRequestQueueTest {
 
         BookAiContentRequestQueue.EnqueuedTask<String> pending = queue.enqueue(0, () -> "second");
 
-        boolean cancelled = queue.cancelPending(pending.id());
+        boolean cancelled = queue.cancel(pending.id());
 
         assertThat(cancelled).isTrue();
         assertThat(queue.getPosition(pending.id()).inQueue()).isFalse();
@@ -181,7 +182,7 @@ class BookAiContentRequestQueueTest {
     @Test
     void should_ReturnFalse_When_CancellingNonExistentTask() {
         BookAiContentRequestQueue queue = new BookAiContentRequestQueue(1);
-        assertThat(queue.cancelPending("nonexistent-id")).isFalse();
+        assertThat(queue.cancel("nonexistent-id")).isFalse();
     }
 
     @Test
@@ -219,6 +220,66 @@ class BookAiContentRequestQueueTest {
         assertThat(foregroundTask.result().get(TASK_TIMEOUT.toSeconds(), TimeUnit.SECONDS)).isEqualTo("foreground");
     }
 
+    @Test
+    void should_WireLifecycleBeforeSupplier_When_ExecutionSlotIsImmediatelyAvailable() throws Exception {
+        BookAiContentRequestQueue queue = new BookAiContentRequestQueue(1);
+        AtomicBoolean startedHandlerRan = new AtomicBoolean(false);
+
+        BookAiContentRequestQueue.EnqueuedTask<String> task = queue.enqueueForeground(
+            0,
+            () -> {
+                if (!startedHandlerRan.get()) {
+                    throw new IllegalStateException("supplier ran before started handler");
+                }
+                return "generated";
+            },
+            enqueuedTask -> enqueuedTask.started().thenRun(() -> startedHandlerRan.set(true))
+        );
+
+        assertThat(task.result().get(TASK_TIMEOUT.toSeconds(), TimeUnit.SECONDS)).isEqualTo("generated");
+        assertThat(startedHandlerRan).isTrue();
+    }
+
+    @Test
+    void should_InterruptRunningSupplierAndReleaseSlotAfterWrapperExits_When_TaskIsCancelled() throws Exception {
+        BookAiContentRequestQueue queue = new BookAiContentRequestQueue(1);
+        CountDownLatch supplierStarted = new CountDownLatch(1);
+        CountDownLatch interruptionObserved = new CountDownLatch(1);
+        CountDownLatch allowSupplierExit = new CountDownLatch(1);
+        CountDownLatch nextSupplierStarted = new CountDownLatch(1);
+        List<String> executionOrder = new CopyOnWriteArrayList<>();
+
+        BookAiContentRequestQueue.EnqueuedTask<String> runningTask = queue.enqueue(0, () -> {
+            supplierStarted.countDown();
+            try {
+                allowSupplierExit.await();
+            } catch (InterruptedException interruptedException) {
+                interruptionObserved.countDown();
+                awaitLatchIgnoringInterrupt(allowSupplierExit);
+            }
+            executionOrder.add("cancelled-exit");
+            return "ignored";
+        });
+        BookAiContentRequestQueue.EnqueuedTask<String> nextTask = queue.enqueue(0, () -> {
+            executionOrder.add("next-start");
+            nextSupplierStarted.countDown();
+            return "next";
+        });
+
+        assertThat(supplierStarted.await(TASK_TIMEOUT.toSeconds(), TimeUnit.SECONDS)).isTrue();
+        assertThat(queue.cancel(runningTask.id())).isTrue();
+        assertThat(interruptionObserved.await(TASK_TIMEOUT.toSeconds(), TimeUnit.SECONDS)).isTrue();
+        assertThat(queue.snapshot()).isEqualTo(new BookAiContentRequestQueue.QueueSnapshot(1, 1, 1));
+        assertThat(nextSupplierStarted.getCount()).isEqualTo(1L);
+
+        allowSupplierExit.countDown();
+
+        assertThat(nextTask.result().get(TASK_TIMEOUT.toSeconds(), TimeUnit.SECONDS)).isEqualTo("next");
+        assertThatThrownBy(() -> runningTask.result().get(TASK_TIMEOUT.toSeconds(), TimeUnit.SECONDS))
+            .isInstanceOf(CancellationException.class);
+        assertThat(executionOrder).containsExactly("cancelled-exit", "next-start");
+    }
+
     private void awaitLatch(CountDownLatch latch) {
         try {
             boolean released = latch.await(TASK_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
@@ -228,6 +289,24 @@ class BookAiContentRequestQueueTest {
         } catch (InterruptedException interruptedException) {
             Thread.currentThread().interrupt();
             throw new IllegalStateException("Latch wait interrupted", interruptedException);
+        }
+    }
+
+    private void awaitLatchIgnoringInterrupt(CountDownLatch latch) {
+        boolean released = false;
+        boolean interrupted = false;
+        while (!released) {
+            try {
+                released = latch.await(TASK_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+                if (!released) {
+                    throw new IllegalStateException("Latch wait timed out");
+                }
+            } catch (InterruptedException interruptedException) {
+                interrupted = true;
+            }
+        }
+        if (interrupted) {
+            Thread.currentThread().interrupt();
         }
     }
 }


### PR DESCRIPTION
## Summary
- validate buffered Gemma JSON before delivery and persistence while preserving local routing
- bound queue, retry, timeout, and supplier cancellation lifecycles
- expose opaque request IDs before SSE body parsing and explicitly cancel abandoned browser generations
- prevent cancellation/persistence races and clean up timers/registrations on every terminal path

## Verification
- pre-push: Svelte check 0 errors/0 warnings; oxlint 0; frontend 102/102; backend 853 tests, 44 skipped
- focused cancellation lane: backend 42/42; frontend 28/28
- exact dev deploy: 81afadec0a8d7b055b559857645f6f1a1d12a5de, Coolify hg4af7k5cmo9xlvk4vikvez6, running:healthy, /readyz 200
- dev dogfood: Yesteryear Refresh navigated away 250ms after queue start; after 30s version 9, generation timestamp, and SHA-256 remained unchanged; no console/page errors
- desktop/mobile main routes, book, Explore, sitemap, and robots render over HTTPS; controlled iPhone 14 search click and Enter retests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches AI streaming, queue cancellation, persistence boundaries, and LLM response validation—core user-facing generation paths with race-sensitive behavior.
> 
> **Overview**
> Adds **end-to-end cancellation** for book AI content generation: opaque `requestId` on the `X-Book-AI-Request-Id` header and in the initial `queued` SSE event, `POST /api/books/ai/content/requests/{requestId}/cancel` (always `204`), and frontend `BookAiContentRequestAttempt` that aborts the stream and delivers cancel via `sendBeacon`/`keepalive` fetch on unmount or navigation.
> 
> **Backend lifecycle** ties SSE disconnect, explicit cancel, queue interruption, and `GenerationControl` so cancellation and DB insert race atomically; the in-memory queue can cancel **running** tasks (interrupt + slot held until the wrapper exits) and wires lifecycle handlers **before** a task can start. Queue wait is capped at **10 minutes** (`queue_busy`); **`stream_timeout`** starts only after `started`.
> 
> **Model output** is tightened: `AiContentJsonParser` and SEO parsing drop markdown/brace/plain-text fallbacks and require exact canonical JSON keys and types; the book AI prompt now requires a non-null `summary`. Live OpenAI retries narrow to retryable transport/status codes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81afadec0a8d7b055b559857645f6f1a1d12a5de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->