### PR TITLE
fix(reliability): harden error and scheduler paths

### DIFF
--- a/src/main/java/net/findmybook/controller/ErrorDiagnosticsController.java
+++ b/src/main/java/net/findmybook/controller/ErrorDiagnosticsController.java
@@ -2,6 +2,7 @@ package net.findmybook.controller;
 
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import net.findmybook.domain.seo.SeoMetadata;
 import net.findmybook.service.BookSeoMetadataService;
 import org.springframework.beans.factory.ObjectProvider;
@@ -19,6 +20,7 @@ import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.View;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.Set;
 
@@ -182,9 +184,9 @@ public class ErrorDiagnosticsController implements ErrorViewResolver {
         }
 
         @Override
-        public void render(Map<String, ?> model, HttpServletRequest request, jakarta.servlet.http.HttpServletResponse response) throws Exception {
+        public void render(Map<String, ?> model, HttpServletRequest request, HttpServletResponse response) throws Exception {
             response.setContentType(MediaType.TEXT_HTML_VALUE);
-            response.getWriter().write(html);
+            response.getOutputStream().write(html.getBytes(Charset.forName(response.getCharacterEncoding())));
         }
     }
 }

--- a/src/main/java/net/findmybook/repository/SitemapRepository.java
+++ b/src/main/java/net/findmybook/repository/SitemapRepository.java
@@ -4,6 +4,7 @@ import net.findmybook.support.sitemap.SitemapBookLastModifiedSqlSupport;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -30,8 +31,12 @@ public class SitemapRepository {
     private static final String AUTHOR_UPDATED_AT_ALIAS = "author_updated_at";
     private static final String AUTHOR_PAGE_NUMBER_ALIAS = "author_page_number";
     private static final String SQL_EPOCH_TIMESTAMP = "TIMESTAMP 'epoch'";
+    private static final String DISABLE_PARALLEL_QUERY_FOR_TRANSACTION =
+            "SET LOCAL max_parallel_workers_per_gather = 0";
     private static final String BOOK_CHANGE_EVENTS_CTE =
             SitemapBookLastModifiedSqlSupport.globalBookLastModifiedCte(BOOK_UPDATED_AT_ALIAS);
+    private static final String BOOK_FINGERPRINT_QUERY =
+            SitemapBookLastModifiedSqlSupport.bookFingerprintQuery(BOOK_UPDATED_AT_ALIAS);
 
     private static final RowMapper<BookRow> BOOK_ROW_MAPPER = (rs, rowNum) -> new BookRow(
             rs.getString("id"),
@@ -239,14 +244,18 @@ public class SitemapRepository {
         ), htmlPageSize, xmlPageSize);
     }
 
+    /**
+     * Reads the hourly book fingerprint without parallel workers so constrained
+     * PostgreSQL containers never need dynamic shared memory for this maintenance query.
+     *
+     * @return current sitemap book count and latest related-data timestamp
+     */
+    @Transactional(readOnly = true)
     public DatasetFingerprint fetchBookFingerprint() {
-        String sql = BOOK_CHANGE_EVENTS_CTE +
-                "SELECT COUNT(*) AS total_records, " +
-                "COALESCE(MAX(" + BOOK_UPDATED_AT_ALIAS + "), " + SQL_EPOCH_TIMESTAMP + ") AS last_modified " +
-                "FROM book_last_modified";
-        return jdbcTemplate.queryForObject(sql, (rs, rowNum) -> new DatasetFingerprint(
+        jdbcTemplate.execute(DISABLE_PARALLEL_QUERY_FOR_TRANSACTION);
+        return jdbcTemplate.queryForObject(BOOK_FINGERPRINT_QUERY, (rs, rowNum) -> new DatasetFingerprint(
                 rs.getInt("total_records"),
-                rs.getTimestamp("last_modified").toInstant()
+                rs.getTimestamp(BOOK_UPDATED_AT_ALIAS).toInstant()
         ));
     }
 

--- a/src/main/java/net/findmybook/service/OutboxRelay.java
+++ b/src/main/java/net/findmybook/service/OutboxRelay.java
@@ -2,6 +2,7 @@ package net.findmybook.service;
 
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.messaging.MessagingException;
@@ -9,44 +10,20 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
- * Relays events from transactional outbox table to WebSocket clients.
- * <p>
- * Implements the Transactional Outbox Pattern:
- * 1. Services write events to events_outbox table (same transaction as business logic)
- * 2. This relay polls the outbox and publishes to WebSocket
- * 3. Successfully sent events are marked with sent_at timestamp
- * <p>
- * Benefits:
- * - Guaranteed event delivery (transactional with database writes)
- * - No lost events if WebSocket publish fails
- * - Automatic retry for failed publishes
- * - Decouples event production from delivery
- * <p>
- * Processing:
- * - Runs every 1 second via @Scheduled
- * - Fetches up to 100 unsent events per batch
- * - Publishes to WebSocket via SimpMessagingTemplate
- * - Marks successful events with sent_at = NOW()
- * <p>
- * Example event flow:
- * <pre>
- * BookUpsertService → INSERT INTO events_outbox (SAME TX)
- *                  ↓
- * OutboxRelay (every 1s) → Poll unsent events
- *                        → Publish to /topic/book.{id}
- *                        → Mark as sent
- * </pre>
- * <p>
- * Topics:
- * - /topic/book.{bookId} - Book upsert events
- * - /topic/search.{searchId} - Search result updates
- * <p>
- * Monitoring:
- * Use getOutboxStats() to monitor pending/sent events.
+ * Relays committed transactional-outbox events to WebSocket clients and marks
+ * successful deliveries as sent.
+ *
+ * <p>Publish failures remain pending for retry. Database failures pause polling
+ * with bounded exponential backoff so one outage remains visible without making
+ * Spring's scheduler log the same exception again.</p>
  */
 @Service
 @Slf4j
@@ -55,15 +32,31 @@ public class OutboxRelay {
     private final JdbcTemplate jdbcTemplate;
     private final SimpMessagingTemplate messagingTemplate;
 
-    // Batch size for processing
     private static final int BATCH_SIZE = 100;
-
-    // Processing interval (1 second for near-real-time)
     private static final long PROCESS_INTERVAL_MS = 1000;
+    private static final long INITIAL_DATABASE_RETRY_DELAY_MS = 5_000;
+    private static final long MAX_DATABASE_RETRY_DELAY_MS = 60_000;
+    private static final int MAX_DATABASE_RETRY_SHIFT = 4;
 
+    private final Clock clock;
+    private int consecutiveDatabaseFailures;
+    private Instant nextDatabaseAttemptAt = Instant.MIN;
+
+    /**
+     * Creates the scheduled relay with a system UTC clock for database retry timing.
+     *
+     * @param jdbcTemplate transactional outbox database access
+     * @param messagingTemplate WebSocket publisher
+     */
+    @Autowired
     public OutboxRelay(JdbcTemplate jdbcTemplate, SimpMessagingTemplate messagingTemplate) {
+        this(jdbcTemplate, messagingTemplate, Clock.systemUTC());
+    }
+
+    OutboxRelay(JdbcTemplate jdbcTemplate, SimpMessagingTemplate messagingTemplate, Clock clock) {
         this.jdbcTemplate = jdbcTemplate;
         this.messagingTemplate = messagingTemplate;
+        this.clock = Objects.requireNonNull(clock, "clock");
     }
 
     /**
@@ -81,6 +74,20 @@ public class OutboxRelay {
      */
     @Scheduled(fixedDelay = PROCESS_INTERVAL_MS)
     public void relayEvents() {
+        Instant pollStartedAt = clock.instant();
+        if (pollStartedAt.isBefore(nextDatabaseAttemptAt)) {
+            return;
+        }
+
+        try {
+            relayAvailableEvents();
+            recordDatabaseRecovery();
+        } catch (DataAccessException databaseFailure) {
+            recordDatabaseFailure(pollStartedAt, databaseFailure);
+        }
+    }
+
+    private void relayAvailableEvents() {
         List<OutboxEvent> events = fetchUnsentEvents(BATCH_SIZE);
 
         if (events.isEmpty()) {
@@ -101,31 +108,12 @@ public class OutboxRelay {
                     ex.getMessage()
                 );
 
-                // Increment retry count
-                try {
-                    incrementRetryCount(event.getEventId());
-                } catch (IllegalStateException retryEx) {
-                    log.error(
-                        "Stopping outbox relay cycle because retry count update failed for event {}",
-                        event.getEventId(),
-                        retryEx
-                    );
-                    throw retryEx;
-                }
+                incrementRetryCount(event.getEventId());
                 continue;
             }
 
             // Mark as sent
-            try {
-                markSent(event.getEventId());
-            } catch (IllegalStateException markSentException) {
-                log.error(
-                    "Stopping outbox relay cycle because mark-sent failed for event {}",
-                    event.getEventId(),
-                    markSentException
-                );
-                throw markSentException;
-            }
+            markSent(event.getEventId());
 
             if (event.getTopic() != null && event.getTopic().startsWith("/topic/cluster.")) {
                 clusterEventsRelayed++;
@@ -136,6 +124,48 @@ public class OutboxRelay {
         if (clusterEventsRelayed > 0) {
             log.info("Relayed {} work-cluster primary change event(s) this cycle", clusterEventsRelayed);
         }
+    }
+
+    private void recordDatabaseFailure(Instant pollStartedAt, DataAccessException databaseFailure) {
+        consecutiveDatabaseFailures++;
+        long retryDelayMillis = Math.min(
+            INITIAL_DATABASE_RETRY_DELAY_MS << Math.min(consecutiveDatabaseFailures - 1, MAX_DATABASE_RETRY_SHIFT),
+            MAX_DATABASE_RETRY_DELAY_MS
+        );
+        nextDatabaseAttemptAt = pollStartedAt.plus(Duration.ofMillis(retryDelayMillis));
+
+        if (consecutiveDatabaseFailures == 1) {
+            log.error(
+                "Outbox relay database access failed; pausing polls for {} ms",
+                retryDelayMillis,
+                databaseFailure
+            );
+            return;
+        }
+        if (retryDelayMillis == MAX_DATABASE_RETRY_DELAY_MS) {
+            log.error(
+                "Outbox relay database access still unavailable after {} attempts; next retry in {} ms: {}",
+                consecutiveDatabaseFailures,
+                retryDelayMillis,
+                databaseFailure.getMostSpecificCause().getMessage()
+            );
+            return;
+        }
+        log.warn(
+            "Outbox relay database access still unavailable after {} attempts; next retry in {} ms: {}",
+            consecutiveDatabaseFailures,
+            retryDelayMillis,
+            databaseFailure.getMostSpecificCause().getMessage()
+        );
+    }
+
+    private void recordDatabaseRecovery() {
+        if (consecutiveDatabaseFailures == 0) {
+            return;
+        }
+        log.info("Outbox relay database access recovered after {} failed attempts", consecutiveDatabaseFailures);
+        consecutiveDatabaseFailures = 0;
+        nextDatabaseAttemptAt = Instant.MIN;
     }
 
     /**
@@ -159,9 +189,8 @@ public class OutboxRelay {
                 ),
                 limit
             );
-        } catch (DataAccessException ex) {
-            log.error("Failed to fetch unsent outbox events", ex);
-            throw new IllegalStateException("Failed to fetch unsent outbox events", ex);
+        } catch (DataAccessException databaseFailure) {
+            throw new OutboxPersistenceException("Failed to fetch unsent outbox events", databaseFailure);
         }
     }
 
@@ -174,9 +203,11 @@ public class OutboxRelay {
                 "UPDATE events_outbox SET sent_at = NOW() WHERE event_id = ?",
                 eventId
             );
-        } catch (DataAccessException ex) {
-            log.error("Failed to mark outbox event {} as sent", eventId, ex);
-            throw new IllegalStateException("Failed to mark outbox event as sent: " + eventId, ex);
+        } catch (DataAccessException databaseFailure) {
+            throw new OutboxPersistenceException(
+                "Failed to mark outbox event " + eventId + " as sent",
+                databaseFailure
+            );
         }
     }
 
@@ -190,9 +221,11 @@ public class OutboxRelay {
                 "UPDATE events_outbox SET retry_count = retry_count + 1 WHERE event_id = ?",
                 eventId
             );
-        } catch (DataAccessException ex) {
-            log.error("Failed to increment retry count for outbox event {}", eventId, ex);
-            throw new IllegalStateException("Failed to increment retry count for outbox event: " + eventId, ex);
+        } catch (DataAccessException databaseFailure) {
+            throw new OutboxPersistenceException(
+                "Failed to increment retry count for outbox event " + eventId,
+                databaseFailure
+            );
         }
     }
 
@@ -254,6 +287,12 @@ public class OutboxRelay {
         } catch (DataAccessException ex) {
             log.error("Failed to reset retry count for stuck outbox events", ex);
             throw new IllegalStateException("Failed to reset retry count for stuck outbox events", ex);
+        }
+    }
+
+    private static final class OutboxPersistenceException extends DataAccessException {
+        private OutboxPersistenceException(String message, DataAccessException cause) {
+            super(message, cause);
         }
     }
 

--- a/src/main/java/net/findmybook/support/sitemap/SitemapBookLastModifiedSqlSupport.java
+++ b/src/main/java/net/findmybook/support/sitemap/SitemapBookLastModifiedSqlSupport.java
@@ -145,6 +145,34 @@ public final class SitemapBookLastModifiedSqlSupport {
     }
 
     /**
+     * Builds the hourly book fingerprint query without the per-book hash aggregation
+     * required by the full sitemap metadata projection.
+     *
+     * <p>The change-event rows stream into one global aggregate, preserving the
+     * dataset count and latest joined-data timestamp while keeping aggregation state
+     * independent of the number of sitemap books.</p>
+     *
+     * @param bookUpdatedAtAlias SQL alias for the latest dataset timestamp
+     * @return SQL for the streaming book dataset fingerprint
+     */
+    public static String bookFingerprintQuery(String bookUpdatedAtAlias) {
+        validateSqlIdentifier(bookUpdatedAtAlias, "bookUpdatedAtAlias");
+        return """
+                WITH requested_books AS NOT MATERIALIZED (
+                    SELECT b.id AS book_id
+                    FROM books b
+                    WHERE b.slug IS NOT NULL
+                ),
+                change_events AS NOT MATERIALIZED (
+                    %s
+                )
+                SELECT (SELECT COUNT(*) FROM requested_books) AS total_records,
+                       COALESCE(MAX(change_events.changed_at), TIMESTAMP 'epoch') AS %s
+                FROM change_events
+                """.formatted(UNION_ALL_CHANGE_EVENTS, bookUpdatedAtAlias);
+    }
+
+    /**
      * Builds a bounded XML sitemap query that selects the requested book page before
      * aggregating joined-data timestamps.
      *

--- a/src/test/java/net/findmybook/controller/ErrorDiagnosticsControllerTest.java
+++ b/src/test/java/net/findmybook/controller/ErrorDiagnosticsControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.View;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -25,8 +26,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ErrorDiagnosticsControllerTest {
 
     @Test
-    @DisplayName("Error view resolver returns SPA shell for 404 HTML responses")
-    void errorDiagnostics_resolvesNotFoundSpaShellForHtml() throws Exception {
+    @DisplayName("Error view resolver writes the SPA shell through an already-selected output stream")
+    void should_RenderNotFoundSpaShell_When_OutputStreamWasAlreadySelected() throws Exception {
         LocalDiskCoverCacheService localDiskCoverCacheService = Mockito.mock(LocalDiskCoverCacheService.class);
         BookSeoMetadataService seoMetadataService = new BookSeoMetadataService(localDiskCoverCacheService);
         ErrorDiagnosticsController resolver = errorDiagnosticsController(seoMetadataService);
@@ -42,7 +43,9 @@ class ErrorDiagnosticsControllerTest {
         View view = modelAndView.getView();
         assertNotNull(view);
         MockHttpServletResponse response = new MockHttpServletResponse();
-        view.render(Map.of(), request, response);
+        response.getOutputStream();
+
+        assertDoesNotThrow(() -> view.render(Map.of(), request, response));
 
         assertEquals(MediaType.TEXT_HTML_VALUE, response.getContentType());
         assertTrue(response.getContentAsString().contains("Page Not Found | findmybook"));

--- a/src/test/java/net/findmybook/repository/SitemapBookLastModifiedSqlSupportTest.java
+++ b/src/test/java/net/findmybook/repository/SitemapBookLastModifiedSqlSupportTest.java
@@ -61,6 +61,18 @@ class SitemapBookLastModifiedSqlSupportTest {
     }
 
     @Test
+    void should_UseOneGlobalAggregateWithoutPerBookGrouping_When_RenderingFingerprintQuery() {
+        String sql = SitemapBookLastModifiedSqlSupport.bookFingerprintQuery("book_updated_at");
+
+        assertThat(sql)
+            .contains("SELECT (SELECT COUNT(*) FROM requested_books) AS total_records")
+            .contains("MAX(change_events.changed_at)")
+            .contains("AS book_updated_at")
+            .doesNotContain("book_last_modified")
+            .doesNotContain("GROUP BY");
+    }
+
+    @Test
     void should_ThrowIllegalArgument_When_AliasContainsSqlInjection() {
         assertThatThrownBy(() ->
             SitemapBookLastModifiedSqlSupport.globalBookLastModifiedCte("x; DROP TABLE books"))
@@ -144,5 +156,31 @@ class SitemapBookLastModifiedSqlSupportTest {
             .contains("requested_books AS MATERIALIZED")
             .contains("LIMIT ? OFFSET ?")
             .doesNotContain("FROM book_last_modified ORDER BY");
+    }
+
+    @Test
+    void should_DisableParallelWorkersForTransaction_When_BookFingerprintIsRequested() {
+        JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+        SitemapRepository sitemapRepository = new SitemapRepository(jdbcTemplate);
+        SitemapRepository.DatasetFingerprint expected = new SitemapRepository.DatasetFingerprint(
+            42,
+            Instant.parse("2026-07-15T00:00:00Z")
+        );
+        when(jdbcTemplate.queryForObject(
+            anyString(),
+            org.mockito.ArgumentMatchers.<RowMapper<SitemapRepository.DatasetFingerprint>>any()
+        )).thenReturn(expected);
+
+        assertThat(sitemapRepository.fetchBookFingerprint()).isEqualTo(expected);
+
+        verify(jdbcTemplate).execute("SET LOCAL max_parallel_workers_per_gather = 0");
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(jdbcTemplate).queryForObject(
+            sqlCaptor.capture(),
+            org.mockito.ArgumentMatchers.<RowMapper<SitemapRepository.DatasetFingerprint>>any()
+        );
+        assertThat(sqlCaptor.getValue())
+            .contains("MAX(change_events.changed_at)")
+            .doesNotContain("GROUP BY");
     }
 }

--- a/src/test/java/net/findmybook/service/OutboxRelayTest.java
+++ b/src/test/java/net/findmybook/service/OutboxRelayTest.java
@@ -1,11 +1,16 @@
 package net.findmybook.service;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
@@ -14,20 +19,26 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.Clock;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class OutboxRelayTest {
+
+    private static final Instant OUTAGE_STARTED_AT = Instant.parse("2026-07-15T00:00:00Z");
 
     @Mock
     private JdbcTemplate jdbcTemplate;
@@ -35,15 +46,19 @@ class OutboxRelayTest {
     @Mock
     private SimpMessagingTemplate messagingTemplate;
 
+    @Mock
+    private Clock clock;
+
     private OutboxRelay outboxRelay;
 
     @BeforeEach
     void setUp() {
-        outboxRelay = new OutboxRelay(jdbcTemplate, messagingTemplate);
+        when(clock.instant()).thenReturn(OUTAGE_STARTED_AT);
+        outboxRelay = new OutboxRelay(jdbcTemplate, messagingTemplate, clock);
     }
 
     @Test
-    void relayEvents_shouldIncrementRetryCount_WhenMessagingPublishFails() {
+    void should_IncrementRetryCount_When_MessagingPublishFails() {
         UUID eventId = UUID.randomUUID();
         stubSingleUnsentEvent(eventId, "/topic/book." + eventId, "{\"bookId\":\"" + eventId + "\"}");
 
@@ -56,7 +71,7 @@ class OutboxRelayTest {
             eventId
         )).thenReturn(1);
 
-        outboxRelay.relayEvents();
+        List<ILoggingEvent> logEvents = captureRelayLogs(outboxRelay::relayEvents);
 
         verify(jdbcTemplate).update(
             "UPDATE events_outbox SET retry_count = retry_count + 1 WHERE event_id = ?",
@@ -66,10 +81,14 @@ class OutboxRelayTest {
             "UPDATE events_outbox SET sent_at = NOW() WHERE event_id = ?",
             eventId
         );
+        assertThat(logEvents)
+            .filteredOn(event -> event.getLevel().isGreaterOrEqual(Level.WARN))
+            .extracting(ILoggingEvent::getLevel)
+            .containsExactly(Level.WARN);
     }
 
     @Test
-    void relayEvents_shouldStopCycle_WhenMarkSentPersistenceFails() {
+    void should_BackOffWithoutEscapingScheduledBoundary_When_MarkSentPersistenceFails() {
         UUID eventId = UUID.randomUUID();
         stubSingleUnsentEvent(eventId, "/topic/book." + eventId, "{\"bookId\":\"" + eventId + "\"}");
 
@@ -78,12 +97,88 @@ class OutboxRelayTest {
             eventId
         )).thenThrow(new DataAccessResourceFailureException("database unavailable"));
 
-        assertThrows(IllegalStateException.class, () -> outboxRelay.relayEvents());
+        List<ILoggingEvent> logEvents = captureRelayLogs(() -> assertDoesNotThrow(outboxRelay::relayEvents));
 
         verify(jdbcTemplate, never()).update(
             "UPDATE events_outbox SET retry_count = retry_count + 1 WHERE event_id = ?",
             eventId
         );
+        assertThat(logEvents)
+            .filteredOn(event -> event.getLevel().isGreaterOrEqual(Level.WARN))
+            .extracting(ILoggingEvent::getLevel)
+            .containsExactly(Level.ERROR);
+        ILoggingEvent errorEvent = logEvents.stream()
+            .filter(event -> event.getLevel() == Level.ERROR)
+            .findFirst()
+            .orElseThrow();
+        assertThat(errorEvent.getThrowableProxy().getMessage()).contains(eventId.toString());
+    }
+
+    @Test
+    void should_LogOneErrorThenBackOffToBoundAndRecover_When_DatabaseRemainsUnavailable() {
+        DataAccessResourceFailureException outage =
+            new DataAccessResourceFailureException("database unavailable");
+        when(jdbcTemplate.query(
+            ArgumentMatchers.contains("FROM events_outbox"),
+            ArgumentMatchers.<RowMapper<Object>>any(),
+            anyInt()
+        )).thenThrow(outage)
+            .thenThrow(outage)
+            .thenThrow(outage)
+            .thenThrow(outage)
+            .thenThrow(outage)
+            .thenThrow(outage)
+            .thenReturn(List.of());
+
+        List<ILoggingEvent> logEvents = captureRelayLogs(() -> {
+            assertDoesNotThrow(outboxRelay::relayEvents);
+            assertDoesNotThrow(outboxRelay::relayEvents);
+
+            when(clock.instant()).thenReturn(OUTAGE_STARTED_AT.plusSeconds(5));
+            assertDoesNotThrow(outboxRelay::relayEvents);
+
+            when(clock.instant()).thenReturn(OUTAGE_STARTED_AT.plusSeconds(14));
+            assertDoesNotThrow(outboxRelay::relayEvents);
+
+            when(clock.instant()).thenReturn(OUTAGE_STARTED_AT.plusSeconds(15));
+            assertDoesNotThrow(outboxRelay::relayEvents);
+
+            when(clock.instant()).thenReturn(OUTAGE_STARTED_AT.plusSeconds(35));
+            assertDoesNotThrow(outboxRelay::relayEvents);
+
+            when(clock.instant()).thenReturn(OUTAGE_STARTED_AT.plusSeconds(75));
+            assertDoesNotThrow(outboxRelay::relayEvents);
+
+            when(clock.instant()).thenReturn(OUTAGE_STARTED_AT.plusSeconds(135));
+            assertDoesNotThrow(outboxRelay::relayEvents);
+
+            when(clock.instant()).thenReturn(OUTAGE_STARTED_AT.plusSeconds(194));
+            assertDoesNotThrow(outboxRelay::relayEvents);
+
+            when(clock.instant()).thenReturn(OUTAGE_STARTED_AT.plusSeconds(195));
+            assertDoesNotThrow(outboxRelay::relayEvents);
+        });
+
+        verify(jdbcTemplate, times(7)).query(
+            ArgumentMatchers.contains("FROM events_outbox"),
+            ArgumentMatchers.<RowMapper<Object>>any(),
+            anyInt()
+        );
+        assertThat(logEvents).extracting(ILoggingEvent::getLevel)
+            .containsExactly(
+                Level.ERROR,
+                Level.WARN,
+                Level.WARN,
+                Level.WARN,
+                Level.ERROR,
+                Level.ERROR,
+                Level.INFO
+            );
+        assertThat(logEvents.get(0).getFormattedMessage()).contains("pausing polls for 5000 ms");
+        assertThat(logEvents.get(1).getFormattedMessage()).contains("next retry in 10000 ms");
+        assertThat(logEvents.get(4).getFormattedMessage()).contains("next retry in 60000 ms");
+        assertThat(logEvents.get(5).getFormattedMessage()).contains("next retry in 60000 ms");
+        assertThat(logEvents.get(6).getFormattedMessage()).contains("recovered after 6 failed attempts");
     }
 
     private void stubSingleUnsentEvent(UUID eventId, String topic, String payload) {
@@ -107,6 +202,27 @@ class OutboxRelayTest {
             return rowMapper.mapRow(resultSet, 0);
         } catch (SQLException exception) {
             throw new IllegalStateException("Failed to map outbox test row", exception);
+        }
+    }
+
+    private List<ILoggingEvent> captureRelayLogs(Runnable operation) {
+        Logger relayLogger = (Logger) LoggerFactory.getLogger(OutboxRelay.class);
+        ListAppender<ILoggingEvent> logEvents = new ListAppender<>();
+        boolean originalAdditivity = relayLogger.isAdditive();
+        Level originalLevel = relayLogger.getLevel();
+        relayLogger.setAdditive(false);
+        relayLogger.setLevel(Level.DEBUG);
+        logEvents.start();
+        relayLogger.addAppender(logEvents);
+
+        try {
+            operation.run();
+            return List.copyOf(logEvents.list);
+        } finally {
+            relayLogger.detachAppender(logEvents);
+            logEvents.stop();
+            relayLogger.setAdditive(originalAdditivity);
+            relayLogger.setLevel(originalLevel);
         }
     }
 }


### PR DESCRIPTION
Promotes verified dev commit 2855653ee5af696388b1b37ef7e9e790084d203f to production.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes outbox polling behavior during DB outages (delayed WebSocket delivery) and alters sitemap fingerprint SQL used for cache invalidation; error HTML path is low blast radius but user-facing.
> 
> **Overview**
> Hardens three operational paths: HTML error rendering, sitemap book fingerprint queries, and the transactional outbox WebSocket relay.
> 
> **SPA error shell** now writes HTML through `HttpServletResponse.getOutputStream()` using the response character encoding instead of the writer, so 404/error pages still render when the servlet container has already committed to the output stream.
> 
> **Sitemap book fingerprint** switches from the full `book_last_modified` CTE to a dedicated `bookFingerprintQuery` that aggregates change events globally (no per-book `GROUP BY`). `fetchBookFingerprint` runs in a read-only transaction and executes `SET LOCAL max_parallel_workers_per_gather = 0` so constrained PostgreSQL environments avoid parallel-query shared-memory issues on the hourly maintenance read.
> 
> **Outbox relay** adds injectable `Clock` timing and treats **database** `DataAccessException`s at the scheduled boundary: polls pause with bounded exponential backoff (5s–60s), log once then warn/error with recovery info, and no longer propagate failures that would spam Spring’s scheduler. Per-event WebSocket publish failures still only bump `retry_count`; persistence errors during fetch/mark/increment surface as `OutboxPersistenceException` and participate in the same backoff path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2855653ee5af696388b1b37ef7e9e790084d203f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->