### PR TITLE
Keep idle PostgreSQL pool connections alive

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,7 +64,7 @@ export SPRING_DATASOURCE_PASSWORD="<pass>"
 
 Startup now fails fast with a clear error when database-required profiles are active and no datasource URL is configured. Set one of `SPRING_DATASOURCE_URL`, `DATABASE_URL`, `POSTGRES_URL`, or `JDBC_DATABASE_URL`. For explicit database-less startup, set `SPRING_PROFILES_ACTIVE=nodb`.
 
-The base Hikari pool sends a PostgreSQL TCP keepalive after 60 seconds while retaining the 30-minute connection lifetime. This keeps idle pooled connections observable to the network path without replacing driver validation with a custom test query.
+The base Hikari pool validates idle JDBC connections every 60 seconds while retaining the 30-minute connection lifetime. PostgreSQL `tcpKeepAlive` is also enabled so the driver uses the operating system's TCP keepalive policy; no custom connection test query replaces driver validation.
 
 ## Frontend Static Asset Caching
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,6 +64,8 @@ export SPRING_DATASOURCE_PASSWORD="<pass>"
 
 Startup now fails fast with a clear error when database-required profiles are active and no datasource URL is configured. Set one of `SPRING_DATASOURCE_URL`, `DATABASE_URL`, `POSTGRES_URL`, or `JDBC_DATABASE_URL`. For explicit database-less startup, set `SPRING_PROFILES_ACTIVE=nodb`.
 
+The base Hikari pool sends a PostgreSQL TCP keepalive after 60 seconds while retaining the 30-minute connection lifetime. This keeps idle pooled connections observable to the network path without replacing driver validation with a custom test query.
+
 ## Frontend Static Asset Caching
 
 - The Spring resource handler serves `/frontend/**` with `Cache-Control: no-cache, must-revalidate`.

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,8 +18,11 @@ spring:
       connection-timeout: 2000
       validation-timeout: 1000
       idle-timeout: 600000
+      keepalive-time: 60000
       max-lifetime: 1800000
       leak-detection-threshold: 60000
+      data-source-properties:
+        tcpKeepAlive: true
   main:
     allow-bean-definition-overriding: true
 

--- a/src/test/java/net/findmybook/config/HikariConfigurationTest.java
+++ b/src/test/java/net/findmybook/config/HikariConfigurationTest.java
@@ -1,0 +1,34 @@
+package net.findmybook.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.zaxxer.hikari.HikariConfig;
+import java.io.IOException;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.mock.env.MockEnvironment;
+
+class HikariConfigurationTest {
+
+    @Test
+    void should_BindPoolLivenessSettings_When_LoadingBaseApplicationConfiguration() throws IOException {
+        var propertySources = new YamlPropertySourceLoader().load(
+            "application", new ClassPathResource("application.yml"));
+        var environment = new MockEnvironment();
+        environment.getPropertySources().addFirst(propertySources.getFirst());
+        var hikariConfig = new HikariConfig();
+
+        Binder.get(environment).bind("spring.datasource.hikari", Bindable.ofInstance(hikariConfig));
+
+        assertThat(hikariConfig.getKeepaliveTime()).isEqualTo(Duration.ofMinutes(1).toMillis());
+        assertThat(hikariConfig.getKeepaliveTime()).isLessThan(hikariConfig.getMaxLifetime());
+        assertThat(hikariConfig.getMaxLifetime()).isEqualTo(Duration.ofMinutes(30).toMillis());
+        assertThat(hikariConfig.getDataSourceProperties().getProperty("tcpKeepAlive"))
+            .isEqualTo(Boolean.TRUE.toString());
+        assertThat(hikariConfig.getConnectionTestQuery()).isNull();
+    }
+}


### PR DESCRIPTION
Fixes the recurring closed-idle-connection failures by enabling Hikari idle validation every 60 seconds and pgjdbc TCP keepalive while preserving the 30-minute max lifetime. Adds a binding regression test and documents the distinct JDBC and OS keepalive roles.\n\nVerification:\n- ./gradlew clean test (875 tests completed, 44 skipped)\n- pre-push frontend check/lint/test (103 tests)\n- pre-push Gradle check