### PR TITLE
fix(ai): book AI content tolerates blank list entries, and reasoning effort is configurable via OPENAI_REASONING_EFFORT for AI content and SEO metadata generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ OPENAI_API_KEY=lgw-your-gateway-client-key
 OPENAI_BASE_URL=https://api.llm-gateway.iocloudhost.net
 # Generation model served through the shared OpenAI-compatible gateway
 OPENAI_MODEL=gemma-4-26b-a4b
+# Optional gateway reasoning override. Leave unset to preserve the model default.
+# Supported values: none, minimal, low, medium, high, xhigh, max.
+# OPENAI_REASONING_EFFORT=max
 OPENAI_EMBEDDINGS_MODEL=qwen/qwen3-embedding-4b
 
 # Google Books API configuration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,7 @@ Key variables in `.env`:
 | `OPENAI_API_KEY` | OpenAI-compatible API key for generation and embeddings |
 | `OPENAI_BASE_URL` | OpenAI-compatible base URL for generation and embeddings |
 | `OPENAI_MODEL` | Canonical inference model for AI book content and SEO metadata generation |
+| `OPENAI_REASONING_EFFORT` | Optional standard gateway reasoning effort: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`; leave unset to use the model default |
 | `OPENAI_EMBEDDINGS_MODEL` | Canonical embeddings model for vector calculations |
 | `AI_DEFAULT_MAX_PARALLEL` | Global outbound AI queue executor cap, coerced to `2..20`; background work may occupy at most `cap - 1` so one slot remains available for foreground generation |
 | `APP_AI_QUEUE_BACKGROUND_MAX_PENDING` | Max pending background ingestion AI jobs (default `100`) |

--- a/src/main/java/net/findmybook/application/ai/AiContentJsonParser.java
+++ b/src/main/java/net/findmybook/application/ai/AiContentJsonParser.java
@@ -154,12 +154,6 @@ class AiContentJsonParser {
         if (!fieldNode.isArray()) {
             throw invalidFieldType(field, "an array of JSON strings");
         }
-        if (fieldNode.size() > maxSize) {
-            throw new IllegalStateException(
-                "AI response field exceeds maximum item count for %s: %d > %d"
-                    .formatted(field, fieldNode.size(), maxSize)
-            );
-        }
         List<String> values = new ArrayList<>(fieldNode.size());
         for (int index = 0; index < fieldNode.size(); index++) {
             JsonNode elementNode = fieldNode.get(index);
@@ -168,11 +162,15 @@ class AiContentJsonParser {
             }
             String text = elementNode.stringValue();
             if (!StringUtils.hasText(text)) {
-                throw new IllegalStateException(
-                    "AI response field item must be nonblank: %s[%d]".formatted(field, index)
-                );
+                continue;
             }
             values.add(text.trim());
+            if (values.size() > maxSize) {
+                throw new IllegalStateException(
+                    "AI response field exceeds maximum item count for %s: %d > %d"
+                        .formatted(field, values.size(), maxSize)
+                );
+            }
         }
         return List.copyOf(values);
     }

--- a/src/main/java/net/findmybook/application/ai/BookAiContentService.java
+++ b/src/main/java/net/findmybook/application/ai/BookAiContentService.java
@@ -12,6 +12,7 @@ import com.openai.errors.OpenAIRetryableException;
 import com.openai.errors.OpenAIServiceException;
 import com.openai.errors.SseException;
 import com.openai.models.ChatModel;
+import com.openai.models.ReasoningEffort;
 import com.openai.models.chat.completions.ChatCompletionChunk;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.models.chat.completions.ChatCompletionMessageParam;
@@ -82,6 +83,7 @@ public class BookAiContentService {
     private final Map<LlmGatewayTier, OpenAIClient> clientsByTier;
     private final boolean available;
     private final String configuredModel;
+    private final Optional<ReasoningEffort> configuredReasoningEffort;
     private final long requestTimeoutSeconds;
     private final long readTimeoutSeconds;
 
@@ -100,6 +102,7 @@ public class BookAiContentService {
         this.bookDataOrchestrator = bookDataOrchestrator;
         this.jsonParser = new AiContentJsonParser(objectMapper);
         this.configuredModel = openAiProperties.model();
+        this.configuredReasoningEffort = openAiProperties.reasoningEffort();
         this.requestTimeoutSeconds = openAiProperties.requestTimeoutSeconds();
         this.readTimeoutSeconds = openAiProperties.readTimeoutSeconds();
 
@@ -291,15 +294,16 @@ public class BookAiContentService {
             throw new BookAiGenerationException(BookAiGenerationException.ErrorCode.GENERATION_FAILED,
                 "No AI content client configured for tier %s".formatted(tier));
         }
-        ChatCompletionCreateParams params = ChatCompletionCreateParams.builder()
+        ChatCompletionCreateParams.Builder paramsBuilder = ChatCompletionCreateParams.builder()
             .model(ChatModel.of(configuredModel))
             .messages(List.of(
                 ChatCompletionMessageParam.ofSystem(ChatCompletionSystemMessageParam.builder().content(SYSTEM_PROMPT).build()),
                 ChatCompletionMessageParam.ofUser(ChatCompletionUserMessageParam.builder().content(prompt).build())
             ))
             .maxCompletionTokens(tier.maxCompletionTokens())
-            .temperature(SAMPLING_TEMPERATURE)
-            .build();
+            .temperature(SAMPLING_TEMPERATURE);
+        configuredReasoningEffort.ifPresent(paramsBuilder::reasoningEffort);
+        ChatCompletionCreateParams params = paramsBuilder.build();
 
         long effectiveRequestTimeoutSeconds = tier == LlmGatewayTier.LIVE_RENDER
             ? Math.min(requestTimeoutSeconds, tier.callTimeoutSeconds())

--- a/src/main/java/net/findmybook/application/seo/BookSeoMetadataClient.java
+++ b/src/main/java/net/findmybook/application/seo/BookSeoMetadataClient.java
@@ -2,12 +2,12 @@ package net.findmybook.application.seo;
 
 import com.openai.client.OpenAIClient;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
-import com.openai.core.JsonValue;
 import com.openai.core.RequestOptions;
 import com.openai.core.Timeout;
 import com.openai.errors.OpenAIException;
 import com.openai.errors.OpenAIInvalidDataException;
 import com.openai.models.ChatModel;
+import com.openai.models.ReasoningEffort;
 import com.openai.models.chat.completions.ChatCompletion;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.models.chat.completions.ChatCompletionMessageParam;
@@ -17,6 +17,7 @@ import java.time.Duration;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import net.findmybook.application.ai.BookAiGenerationException;
 import net.findmybook.boot.OpenAiProperties;
@@ -37,8 +38,6 @@ class BookSeoMetadataClient {
     private static final String DEFAULT_PROVIDER = "openai";
     private static final int SDK_MAX_RETRIES = 2;
     private static final double SAMPLING_TEMPERATURE = 0.2;
-    static final long THINKING_BUDGET_TOKENS = 2_048L;
-    private static final String THINKING_BUDGET_BODY_PROPERTY = "thinking_budget_tokens";
     private static final String RETRY_RECOVERY_INSTRUCTION = "\n\nRecovery attempt %d: the prior response was empty or invalid. "
         + "Return only the exact canonical JSON object with seoTitle and seoDescription string fields.";
 
@@ -58,6 +57,7 @@ class BookSeoMetadataClient {
     private final Map<LlmGatewayTier, OpenAIClient> clientsByTier;
     private final boolean available;
     private final String configuredModel;
+    private final Optional<ReasoningEffort> configuredReasoningEffort;
     private final long requestTimeoutSeconds;
     private final long readTimeoutSeconds;
 
@@ -71,6 +71,7 @@ class BookSeoMetadataClient {
     ) {
         this.parser = new SeoMetadataJsonParser(objectMapper);
         this.configuredModel = openAiProperties.model();
+        this.configuredReasoningEffort = openAiProperties.reasoningEffort();
         this.requestTimeoutSeconds = openAiProperties.requestTimeoutSeconds();
         this.readTimeoutSeconds = openAiProperties.readTimeoutSeconds();
 
@@ -181,19 +182,18 @@ class BookSeoMetadataClient {
         if (tieredClient == null) {
             throw new BookSeoGenerationException("No SEO metadata client configured for tier " + tier);
         }
-        ChatCompletionCreateParams params = ChatCompletionCreateParams.builder()
+        ChatCompletionCreateParams.Builder paramsBuilder = ChatCompletionCreateParams.builder()
             .model(ChatModel.of(configuredModel))
             .messages(List.of(
                 ChatCompletionMessageParam.ofSystem(ChatCompletionSystemMessageParam.builder().content(SYSTEM_PROMPT).build()),
                 ChatCompletionMessageParam.ofUser(ChatCompletionUserMessageParam.builder().content(prompt).build())
             ))
             .maxCompletionTokens(tier.maxCompletionTokens())
-            .temperature(SAMPLING_TEMPERATURE)
-            .putAdditionalBodyProperty(
-                THINKING_BUDGET_BODY_PROPERTY,
-                JsonValue.from(THINKING_BUDGET_TOKENS)
-            )
-            .build();
+            .temperature(SAMPLING_TEMPERATURE);
+        if (configuredReasoningEffort.isPresent()) {
+            paramsBuilder.reasoningEffort(configuredReasoningEffort.get());
+        }
+        ChatCompletionCreateParams params = paramsBuilder.build();
 
         long effectiveRequestTimeoutSeconds = tier == LlmGatewayTier.LIVE_RENDER
             ? Math.min(requestTimeoutSeconds, tier.callTimeoutSeconds())

--- a/src/main/java/net/findmybook/application/seo/BookSeoMetadataClient.java
+++ b/src/main/java/net/findmybook/application/seo/BookSeoMetadataClient.java
@@ -2,6 +2,7 @@ package net.findmybook.application.seo;
 
 import com.openai.client.OpenAIClient;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
+import com.openai.core.JsonValue;
 import com.openai.core.RequestOptions;
 import com.openai.core.Timeout;
 import com.openai.errors.OpenAIException;
@@ -36,6 +37,8 @@ class BookSeoMetadataClient {
     private static final String DEFAULT_PROVIDER = "openai";
     private static final int SDK_MAX_RETRIES = 2;
     private static final double SAMPLING_TEMPERATURE = 0.2;
+    static final long THINKING_BUDGET_TOKENS = 2_048L;
+    private static final String THINKING_BUDGET_BODY_PROPERTY = "thinking_budget_tokens";
     private static final String RETRY_RECOVERY_INSTRUCTION = "\n\nRecovery attempt %d: the prior response was empty or invalid. "
         + "Return only the exact canonical JSON object with seoTitle and seoDescription string fields.";
 
@@ -186,6 +189,10 @@ class BookSeoMetadataClient {
             ))
             .maxCompletionTokens(tier.maxCompletionTokens())
             .temperature(SAMPLING_TEMPERATURE)
+            .putAdditionalBodyProperty(
+                THINKING_BUDGET_BODY_PROPERTY,
+                JsonValue.from(THINKING_BUDGET_TOKENS)
+            )
             .build();
 
         long effectiveRequestTimeoutSeconds = tier == LlmGatewayTier.LIVE_RENDER

--- a/src/main/java/net/findmybook/boot/OpenAiProperties.java
+++ b/src/main/java/net/findmybook/boot/OpenAiProperties.java
@@ -1,5 +1,7 @@
 package net.findmybook.boot;
 
+import com.openai.models.ReasoningEffort;
+import java.util.Optional;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -20,6 +22,8 @@ public class OpenAiProperties {
     private static final String BASE_URL_PROPERTY = "openai.base.url";
     private static final String MODEL_ENVIRONMENT_VARIABLE = "OPENAI_MODEL";
     private static final String MODEL_PROPERTY = "openai.model";
+    private static final String REASONING_EFFORT_ENVIRONMENT_VARIABLE = "OPENAI_REASONING_EFFORT";
+    private static final String REASONING_EFFORT_PROPERTY = "openai.reasoning-effort";
     private static final String EMBEDDINGS_MODEL_ENVIRONMENT_VARIABLE = "OPENAI_EMBEDDINGS_MODEL";
     private static final String EMBEDDINGS_MODEL_PROPERTY = "openai.embeddings.model";
     private static final long DEFAULT_REQUEST_TIMEOUT_SECONDS = 120L;
@@ -30,6 +34,7 @@ public class OpenAiProperties {
     private Base base = new Base();
     private Embeddings embeddings = new Embeddings();
     private String model = "";
+    private String reasoningEffort = "";
     private long requestTimeoutSeconds = DEFAULT_REQUEST_TIMEOUT_SECONDS;
     private long readTimeoutSeconds = DEFAULT_READ_TIMEOUT_SECONDS;
 
@@ -47,6 +52,7 @@ public class OpenAiProperties {
         projectSystemProperty(API_KEY_PROPERTY, API_KEY_ENVIRONMENT_VARIABLE);
         projectSystemProperty(BASE_URL_PROPERTY, BASE_URL_ENVIRONMENT_VARIABLE);
         projectSystemProperty(MODEL_PROPERTY, MODEL_ENVIRONMENT_VARIABLE);
+        projectSystemProperty(REASONING_EFFORT_PROPERTY, REASONING_EFFORT_ENVIRONMENT_VARIABLE);
         projectSystemProperty(EMBEDDINGS_MODEL_PROPERTY, EMBEDDINGS_MODEL_ENVIRONMENT_VARIABLE);
     }
 
@@ -156,6 +162,26 @@ public class OpenAiProperties {
      */
     public void setModel(String model) {
         this.model = textOrEmpty(model);
+    }
+
+    /**
+     * Returns an optional standard reasoning effort for OpenAI-compatible chat completions.
+     *
+     * @return configured gateway reasoning effort, or empty when the model default should apply
+     */
+    public Optional<ReasoningEffort> reasoningEffort() {
+        return StringUtils.hasText(reasoningEffort)
+            ? Optional.of(ReasoningEffort.of(reasoningEffort))
+            : Optional.empty();
+    }
+
+    /**
+     * Binds an optional standard reasoning effort from {@code OPENAI_REASONING_EFFORT}.
+     *
+     * @param reasoningEffort gateway reasoning effort, or blank to use the model default
+     */
+    public void setReasoningEffort(String reasoningEffort) {
+        this.reasoningEffort = textOrEmpty(reasoningEffort);
     }
 
     /**

--- a/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -305,6 +305,12 @@
       "description": "Inference model for AI book content and SEO metadata generation"
     },
     {
+      "name": "openai.reasoning-effort",
+      "type": "java.lang.String",
+      "sourceType": "net.findmybook.boot.OpenAiProperties",
+      "description": "Optional standard gateway reasoning effort; unset preserves the model default"
+    },
+    {
       "name": "openai.embeddings.model",
       "type": "java.lang.String",
       "sourceType": "net.findmybook.boot.OpenAiProperties",

--- a/src/test/java/net/findmybook/application/ai/BookAiContentServiceTest.java
+++ b/src/test/java/net/findmybook/application/ai/BookAiContentServiceTest.java
@@ -511,6 +511,17 @@ class BookAiContentServiceTest {
     }
 
     @Test
+    void should_SkipBlankListItems_When_ResponseContainsOtherwiseValidContent() {
+        AiContentJsonParser parser = new AiContentJsonParser(new ObjectMapper());
+        String response = validAiContentJson()
+            .replace("[\"reliability\"]", "[\"reliability\", \"  \", \"evidence\"]");
+
+        BookAiContent content = parser.parse(response);
+
+        assertThat(content.keyThemes()).containsExactly("reliability", "evidence");
+    }
+
+    @Test
     void should_RejectAliasField_When_ResponseOmitsCanonicalFieldName() {
         AiContentJsonParser parser = new AiContentJsonParser(new ObjectMapper());
         String response = validAiContentJson().replace("\"readerFit\":", "\"reader_fit\":");

--- a/src/test/java/net/findmybook/application/seo/BookSeoMetadataClientWireTest.java
+++ b/src/test/java/net/findmybook/application/seo/BookSeoMetadataClientWireTest.java
@@ -34,6 +34,8 @@ import net.findmybook.support.llm.LlmGatewayTier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -132,7 +134,7 @@ class BookSeoMetadataClientWireTest {
     }
 
     @Test
-    void should_SendBoundedThinkingBudgetWithoutDisablingReasoning_When_GeneratingSeoMetadata() throws Exception {
+    void should_OmitThinkingBudgetWhen_ReasoningEffortIsUnset() throws Exception {
         server.enqueueJson(chatCompletion("stop", seoJson()));
 
         seoClient().generate(BOOK_ID, "Grounded prompt", LlmGatewayTier.BACKGROUND_BATCH);
@@ -140,20 +142,26 @@ class BookSeoMetadataClientWireTest {
         assertThat(server.requestBodies()).hasSize(1);
         String requestBody = server.requestBodies().getFirst();
         JsonNode request = new ObjectMapper().readTree(requestBody);
-        long maxCompletionTokens = request.path("max_completion_tokens").asLong();
-        long thinkingBudgetTokens = request.path("thinking_budget_tokens").asLong();
 
-        assertThat(request.has("thinking_budget_tokens")).isTrue();
-        assertThat(thinkingBudgetTokens)
-            .isEqualTo(BookSeoMetadataClient.THINKING_BUDGET_TOKENS)
-            .isPositive()
-            .isLessThan(maxCompletionTokens);
-        assertThat(maxCompletionTokens - thinkingBudgetTokens).isGreaterThan(thinkingBudgetTokens);
+        assertThat(request.has("thinking_budget_tokens")).isFalse();
         assertThat(requestBody)
-            .doesNotContain("\"thinking_budget_tokens\":0")
-            .doesNotContain("\"reasoning_effort\":\"none\"")
+            .doesNotContain("\"reasoning_effort\":")
             .doesNotContain("\"enable_thinking\":false")
             .doesNotContain("\"disable_reasoning\":true");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"none", "minimal", "low", "medium", "high", "xhigh", "max"})
+    void should_SendEveryConfiguredStandardReasoningEffortWithoutThinkingBudget_When_GeneratingSeoMetadata(
+        String reasoningEffort
+    ) throws Exception {
+        server.enqueueJson(chatCompletion("stop", seoJson()));
+
+        seoClient(reasoningEffort).generate(BOOK_ID, "Grounded prompt", LlmGatewayTier.BACKGROUND_BATCH);
+
+        JsonNode request = new ObjectMapper().readTree(server.requestBodies().getFirst());
+        assertThat(request.path("reasoning_effort").asString()).isEqualTo(reasoningEffort);
+        assertThat(request.has("thinking_budget_tokens")).isFalse();
     }
 
     @Test
@@ -233,6 +241,12 @@ class BookSeoMetadataClientWireTest {
 
     private BookSeoMetadataClient seoClient() {
         return new BookSeoMetadataClient(new ObjectMapper(), server.openAiProperties());
+    }
+
+    private BookSeoMetadataClient seoClient(String reasoningEffort) {
+        OpenAiProperties properties = server.openAiProperties();
+        properties.setReasoningEffort(reasoningEffort);
+        return new BookSeoMetadataClient(new ObjectMapper(), properties);
     }
 
     private BookDetail bookDetail() {

--- a/src/test/java/net/findmybook/application/seo/BookSeoMetadataClientWireTest.java
+++ b/src/test/java/net/findmybook/application/seo/BookSeoMetadataClientWireTest.java
@@ -1,0 +1,332 @@
+package net.findmybook.application.seo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.CopyOnWriteArrayList;
+import net.findmybook.adapters.persistence.BookSeoMetadataRepository;
+import net.findmybook.boot.OpenAiProperties;
+import net.findmybook.domain.seo.BookSeoMetadataSnapshot;
+import net.findmybook.dto.BookDetail;
+import net.findmybook.service.BookDataOrchestrator;
+import net.findmybook.service.BookSearchService;
+import net.findmybook.support.llm.LlmGatewayTier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+class BookSeoMetadataClientWireTest {
+
+    private static final UUID BOOK_ID = UUID.fromString("019da3e5-3838-703e-9112-bad4a489239e");
+    private static final String DESCRIPTION =
+        "A detailed source description with enough grounded context for reliable AI generation and metadata tests.";
+
+    private OpenAiTestServer server;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new OpenAiTestServer();
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.close();
+    }
+
+    @Test
+    void should_NotPersistSeoMetadata_When_RepeatedBlankResponsesExhaustRetries() {
+        server.enqueueJson(chatCompletion("stop", ""));
+        server.enqueueJson(chatCompletion("stop", ""));
+        server.enqueueJson(chatCompletion("stop", ""));
+        BookSeoMetadataRepository repository = mock(BookSeoMetadataRepository.class);
+
+        BookSeoMetadataGenerationService service = seoService(repository);
+        assertThatThrownBy(() -> service.generateAndPersistIfPromptChanged(BOOK_ID))
+            .isInstanceOf(BookSeoGenerationException.class)
+            .hasMessageContaining("response was empty");
+        verify(repository, never()).insertNewCurrentVersion(any(), anyString(), anyString(), anyString(), anyString(), anyString());
+        assertThat(server.requestBodies()).hasSize(3).allSatisfy(body ->
+            assertThat(body).contains("\"max_completion_tokens\":" + LlmGatewayTier.BACKGROUND_BATCH.maxCompletionTokens()));
+    }
+
+    @Test
+    void should_RetryLegacyFallback_When_GemmaReturnsValidSeoForUnchangedPrompt() {
+        server.enqueueJson(chatCompletion("stop", seoJson()));
+        server.enqueueJson(chatCompletion("stop", seoJson()));
+        BookSeoMetadataRepository repository = mock(BookSeoMetadataRepository.class);
+        BookSeoMetadataSnapshot generatedSnapshot = new BookSeoMetadataSnapshot(
+            BOOK_ID,
+            2,
+            Instant.EPOCH,
+            "gemma-4-26b-a4b",
+            "openai",
+            "Test Book - Book Details | findmybook.net",
+            "A specific grounded description helps readers understand this test book and decide whether its practical focus matches their interests and reading goals.",
+            "current-prompt-hash"
+        );
+        when(repository.insertNewCurrentVersion(any(), anyString(), anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(generatedSnapshot);
+        BookSeoMetadataGenerationService service = seoService(repository);
+        BookSeoMetadataGenerationService.GenerationOutcome initialGeneration = service.generateAndPersist(BOOK_ID);
+        BookSeoMetadataSnapshot legacyFallback = new BookSeoMetadataSnapshot(
+            BOOK_ID,
+            1,
+            Instant.EPOCH,
+            "gemma-4-26b-a4b",
+            BookSeoMetadataGenerationService.LEGACY_FALLBACK_PROVIDER,
+            "Test Book - Book Details | findmybook.net",
+            "A legacy deterministic SEO description that exists only to make this row retry eligible for replacement.",
+            initialGeneration.promptHash()
+        );
+        when(repository.fetchCurrent(BOOK_ID)).thenReturn(Optional.of(legacyFallback));
+
+        BookSeoMetadataGenerationService.GenerationOutcome outcome = service.generateAndPersistIfPromptChanged(BOOK_ID);
+
+        assertThat(outcome.generated()).isTrue();
+        assertThat(outcome.promptHash()).isEqualTo(initialGeneration.promptHash());
+        assertThat(outcome.snapshot()).contains(generatedSnapshot);
+        verify(repository, times(2))
+            .insertNewCurrentVersion(any(), anyString(), anyString(), anyString(), anyString(), anyString());
+        assertThat(server.requestBodies()).hasSize(2);
+    }
+
+    @Test
+    void should_RetryBlankSeoResponse_When_SecondGemmaResponseIsValid() {
+        server.enqueueJson(chatCompletion("stop", ""));
+        server.enqueueJson(chatCompletion("stop", seoJson()));
+
+        SeoMetadataCandidate candidate = seoClient().generate(BOOK_ID, "Grounded prompt", LlmGatewayTier.BACKGROUND_BATCH);
+
+        assertThat(candidate.seoTitle()).isEqualTo("Test Book - Book Details | findmybook.net");
+        List<String> requestBodies = server.requestBodies();
+        assertThat(requestBodies).hasSize(2);
+        assertThat(requestBodies.get(0)).doesNotContain("Recovery attempt");
+        assertThat(requestBodies.get(1))
+            .isNotEqualTo(requestBodies.get(0))
+            .contains("Recovery attempt 2")
+            .contains("prior response was empty or invalid")
+            .contains("exact canonical JSON");
+        assertThat(server.requestTiers()).containsOnly(LlmGatewayTier.BACKGROUND_BATCH.headerValue());
+    }
+
+    @Test
+    void should_SendBoundedThinkingBudgetWithoutDisablingReasoning_When_GeneratingSeoMetadata() throws Exception {
+        server.enqueueJson(chatCompletion("stop", seoJson()));
+
+        seoClient().generate(BOOK_ID, "Grounded prompt", LlmGatewayTier.BACKGROUND_BATCH);
+
+        assertThat(server.requestBodies()).hasSize(1);
+        String requestBody = server.requestBodies().getFirst();
+        JsonNode request = new ObjectMapper().readTree(requestBody);
+        long maxCompletionTokens = request.path("max_completion_tokens").asLong();
+        long thinkingBudgetTokens = request.path("thinking_budget_tokens").asLong();
+
+        assertThat(request.has("thinking_budget_tokens")).isTrue();
+        assertThat(thinkingBudgetTokens)
+            .isEqualTo(BookSeoMetadataClient.THINKING_BUDGET_TOKENS)
+            .isPositive()
+            .isLessThan(maxCompletionTokens);
+        assertThat(maxCompletionTokens - thinkingBudgetTokens).isGreaterThan(thinkingBudgetTokens);
+        assertThat(requestBody)
+            .doesNotContain("\"thinking_budget_tokens\":0")
+            .doesNotContain("\"reasoning_effort\":\"none\"")
+            .doesNotContain("\"enable_thinking\":false")
+            .doesNotContain("\"disable_reasoning\":true");
+    }
+
+    @Test
+    void should_RetryMalformedSuccessfulSeoResponse_When_SecondGemmaResponseIsValid() {
+        server.enqueueJson("{\"id\":\"chat-1\",\"object\":\"chat.completion\",\"created\":0,\"model\":\"gemma-4-26b-a4b\","
+            + "\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":" + OpenAiTestServer.jsonString(seoJson())
+            + "}}]}");
+        server.enqueueJson(chatCompletion("stop", seoJson()));
+
+        SeoMetadataCandidate candidate = seoClient().generate(BOOK_ID, "Grounded prompt", LlmGatewayTier.BACKGROUND_BATCH);
+
+        assertThat(candidate.seoDescription()).hasSizeBetween(140, 160);
+        assertThat(server.requestBodies()).hasSize(2);
+    }
+
+    @Test
+    void should_ThrowTypedFailure_When_SeoResponseMissesCanonicalField() {
+        SeoMetadataJsonParser parser = new SeoMetadataJsonParser(new ObjectMapper());
+
+        assertThatThrownBy(() -> parser.parse("{\"seoTitle\":\"Title only\"}"))
+            .isInstanceOf(BookSeoGenerationException.class)
+            .hasMessageContaining("fields must exactly match the canonical contract");
+    }
+
+    @Test
+    void should_AcceptWholeResponseFencedSeoJson_When_GemmaReturnsCanonicalJson() {
+        SeoMetadataJsonParser parser = new SeoMetadataJsonParser(new ObjectMapper());
+        SeoMetadataCandidate expected = new SeoMetadataCandidate(
+            "Test Book - Book Details | findmybook.net",
+            "A specific grounded description helps readers understand this test book and decide whether its practical focus matches their interests and reading goals."
+        );
+
+        assertThat(parser.parse(fencedSeoJson("```"))).isEqualTo(expected);
+        assertThat(parser.parse(fencedSeoJson("```json"))).isEqualTo(expected);
+    }
+
+    @Test
+    void should_RejectNonCanonicalSeoResponse_When_GemmaDriftsFromJsonContract() {
+        SeoMetadataJsonParser parser = new SeoMetadataJsonParser(new ObjectMapper());
+        String fencedResponse = fencedSeoJson("```json");
+
+        assertThatThrownBy(() -> parser.parse("SEO title: Test Book; description: useful details"))
+            .isInstanceOf(BookSeoGenerationException.class)
+            .hasMessageContaining("valid JSON object");
+        assertThatThrownBy(() -> parser.parse("{\"title\":\"Test Book\",\"description\":\"Useful details\"}"))
+            .isInstanceOf(BookSeoGenerationException.class)
+            .hasMessageContaining("exactly match the canonical contract");
+        assertThatThrownBy(() -> parser.parse("{\"seoTitle\":42,\"seoDescription\":true}"))
+            .isInstanceOf(BookSeoGenerationException.class)
+            .hasMessageContaining("field must be a string: seoTitle");
+        assertThatThrownBy(() -> parser.parse(
+            "{\"seoTitle\":\"Test Book\",\"seoDescription\":\"Useful details\",\"extra\":true}"
+        )).isInstanceOf(BookSeoGenerationException.class)
+            .hasMessageContaining("exactly match the canonical contract");
+        assertThatThrownBy(() -> parser.parse("Here is the requested JSON:\n" + fencedResponse))
+            .isInstanceOf(BookSeoGenerationException.class)
+            .hasMessageContaining("valid JSON object");
+        assertThatThrownBy(() -> parser.parse(fencedResponse + "\nA trailing note"))
+            .isInstanceOf(BookSeoGenerationException.class)
+            .hasMessageContaining("whole-response");
+        assertThatThrownBy(() -> parser.parse(fencedSeoJson("```markdown")))
+            .isInstanceOf(BookSeoGenerationException.class)
+            .hasMessageContaining("whole-response");
+        assertThatThrownBy(() -> parser.parse(fencedResponse + "\n" + fencedResponse))
+            .isInstanceOf(BookSeoGenerationException.class);
+    }
+
+    private BookSeoMetadataGenerationService seoService(BookSeoMetadataRepository repository) {
+        BookSearchService searchService = mock(BookSearchService.class);
+        BookDataOrchestrator orchestrator = mock(BookDataOrchestrator.class);
+        BookDetail detail = bookDetail();
+        when(searchService.fetchBookDetail(BOOK_ID)).thenReturn(Optional.of(detail));
+        when(orchestrator.enrichDescriptionForAiIfNeeded(BOOK_ID, detail, DESCRIPTION, 50)).thenReturn(DESCRIPTION);
+        return new BookSeoMetadataGenerationService(
+            repository, searchService, orchestrator, seoClient(), new SeoMetadataNormalizationPolicy());
+    }
+
+    private BookSeoMetadataClient seoClient() {
+        return new BookSeoMetadataClient(new ObjectMapper(), server.openAiProperties());
+    }
+
+    private BookDetail bookDetail() {
+        return new BookDetail(BOOK_ID.toString(), "test-book", "Test Book", DESCRIPTION, "Test Publisher",
+            LocalDate.of(2020, 1, 1), "en", 200, List.of("Author One"), List.of("Category One"),
+            "https://example.com/cover.jpg", null, "https://example.com/fallback.jpg",
+            "https://example.com/thumbnail.jpg", 600, 900, true, "GOOGLE_BOOKS", 4.5, 42,
+            "1234567890", "1234567890123", "https://example.com/preview", "https://example.com/info",
+            Map.of("source", "test"), List.of());
+    }
+
+    private static String seoJson() {
+        SeoMetadataCandidate candidate = new SeoMetadataCandidate(
+            "Test Book - Book Details | findmybook.net",
+            "A specific grounded description helps readers understand this test book and decide whether its practical focus matches their interests and reading goals."
+        );
+        return new ObjectMapper().valueToTree(candidate).toString();
+    }
+
+    private static String fencedSeoJson(String fenceOpener) {
+        return fenceOpener + "\n" + seoJson() + "\n```";
+    }
+
+    private static String chatCompletion(String finishReason, String content) {
+        return "{\"id\":\"chat-1\",\"object\":\"chat.completion\",\"created\":0,\"model\":\"gemma-4-26b-a4b\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":"
+            + OpenAiTestServer.jsonString(content) + ",\"refusal\":null},\"finish_reason\":\"" + finishReason + "\"}]}";
+    }
+
+    static final class OpenAiTestServer implements AutoCloseable {
+        private final HttpServer httpServer;
+        private final Deque<Response> responses = new ConcurrentLinkedDeque<>();
+        private final List<String> requestBodies = new CopyOnWriteArrayList<>();
+        private final List<String> requestTiers = new CopyOnWriteArrayList<>();
+
+        OpenAiTestServer() throws IOException {
+            httpServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            httpServer.createContext("/v1/chat/completions", this::handle);
+            httpServer.start();
+        }
+
+        void enqueueJson(String body) {
+            enqueueJson(200, body);
+        }
+
+        void enqueueJson(int statusCode, String body) {
+            responses.addLast(new Response(statusCode, "application/json", body));
+        }
+
+        void enqueueSse(String body) {
+            responses.addLast(new Response(200, "text/event-stream", body + "data: [DONE]\n\n"));
+        }
+
+        List<String> requestBodies() {
+            return List.copyOf(requestBodies);
+        }
+
+        List<String> requestTiers() {
+            return List.copyOf(requestTiers);
+        }
+
+        OpenAiProperties openAiProperties() {
+            OpenAiProperties properties = new OpenAiProperties();
+            properties.getApi().setKey("test-key");
+            properties.getBase().setUrl(baseUrl());
+            properties.setModel("gemma-4-26b-a4b");
+            properties.setRequestTimeoutSeconds(5);
+            properties.setReadTimeoutSeconds(5);
+            return properties;
+        }
+
+        static String jsonString(String value) {
+            return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n") + "\"";
+        }
+
+        private String baseUrl() {
+            return "http://127.0.0.1:" + httpServer.getAddress().getPort() + "/v1";
+        }
+
+        private void handle(HttpExchange exchange) throws IOException {
+            requestBodies.add(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            requestTiers.add(exchange.getRequestHeaders().getFirst(LlmGatewayTier.HEADER_NAME));
+            Response response = responses.removeFirst();
+            byte[] body = response.body().getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", response.contentType());
+            exchange.sendResponseHeaders(response.statusCode(), body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        }
+
+        @Override
+        public void close() {
+            httpServer.stop(0);
+        }
+
+        private record Response(int statusCode, String contentType, String body) { }
+    }
+}

--- a/src/test/java/net/findmybook/application/seo/GemmaInferenceReliabilityTest.java
+++ b/src/test/java/net/findmybook/application/seo/GemmaInferenceReliabilityTest.java
@@ -6,35 +6,24 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import net.findmybook.adapters.persistence.BookAiContentRepository;
-import net.findmybook.adapters.persistence.BookSeoMetadataRepository;
 import net.findmybook.application.ai.BookAiContentService;
 import net.findmybook.application.ai.BookAiGenerationException;
-import net.findmybook.boot.OpenAiProperties;
 import net.findmybook.domain.ai.BookAiContent;
 import net.findmybook.domain.ai.BookAiContentSnapshot;
-import net.findmybook.domain.seo.BookSeoMetadataSnapshot;
 import net.findmybook.dto.BookDetail;
 import net.findmybook.repository.BookQueryRepository;
 import net.findmybook.service.BookLookupService;
@@ -61,104 +50,16 @@ class GemmaInferenceReliabilityTest {
     );
     private static final String AI_JSON = new ObjectMapper().valueToTree(AI_CONTENT).toString();
 
-    private OpenAiTestServer server;
+    private BookSeoMetadataClientWireTest.OpenAiTestServer server;
 
     @BeforeEach
     void setUp() throws IOException {
-        server = new OpenAiTestServer();
+        server = new BookSeoMetadataClientWireTest.OpenAiTestServer();
     }
 
     @AfterEach
     void tearDown() {
         server.close();
-    }
-
-    @Test
-    void should_NotPersistSeoMetadata_When_RepeatedBlankResponsesExhaustRetries() {
-        server.enqueueJson(chatCompletion("stop", ""));
-        server.enqueueJson(chatCompletion("stop", ""));
-        server.enqueueJson(chatCompletion("stop", ""));
-        BookSeoMetadataRepository repository = mock(BookSeoMetadataRepository.class);
-
-        BookSeoMetadataGenerationService service = seoService(repository);
-        assertThatThrownBy(() -> service.generateAndPersistIfPromptChanged(BOOK_ID))
-            .isInstanceOf(BookSeoGenerationException.class)
-            .hasMessageContaining("response was empty");
-        verify(repository, never()).insertNewCurrentVersion(any(), anyString(), anyString(), anyString(), anyString(), anyString());
-        assertThat(server.requestBodies()).hasSize(3).allSatisfy(body ->
-            assertThat(body).contains("\"max_completion_tokens\":" + LlmGatewayTier.BACKGROUND_BATCH.maxCompletionTokens()));
-    }
-
-    @Test
-    void should_RetryLegacyFallback_When_GemmaReturnsValidSeoForUnchangedPrompt() {
-        server.enqueueJson(chatCompletion("stop", seoJson()));
-        server.enqueueJson(chatCompletion("stop", seoJson()));
-        BookSeoMetadataRepository repository = mock(BookSeoMetadataRepository.class);
-        BookSeoMetadataSnapshot generatedSnapshot = new BookSeoMetadataSnapshot(
-            BOOK_ID,
-            2,
-            Instant.EPOCH,
-            "gemma-4-26b-a4b",
-            "openai",
-            "Test Book - Book Details | findmybook.net",
-            "A specific grounded description helps readers understand this test book and decide whether its practical focus matches their interests and reading goals.",
-            "current-prompt-hash"
-        );
-        when(repository.insertNewCurrentVersion(any(), anyString(), anyString(), anyString(), anyString(), anyString()))
-            .thenReturn(generatedSnapshot);
-        BookSeoMetadataGenerationService service = seoService(repository);
-        BookSeoMetadataGenerationService.GenerationOutcome initialGeneration = service.generateAndPersist(BOOK_ID);
-        BookSeoMetadataSnapshot legacyFallback = new BookSeoMetadataSnapshot(
-            BOOK_ID,
-            1,
-            Instant.EPOCH,
-            "gemma-4-26b-a4b",
-            BookSeoMetadataGenerationService.LEGACY_FALLBACK_PROVIDER,
-            "Test Book - Book Details | findmybook.net",
-            "A legacy deterministic SEO description that exists only to make this row retry eligible for replacement.",
-            initialGeneration.promptHash()
-        );
-        when(repository.fetchCurrent(BOOK_ID)).thenReturn(Optional.of(legacyFallback));
-
-        BookSeoMetadataGenerationService.GenerationOutcome outcome = service.generateAndPersistIfPromptChanged(BOOK_ID);
-
-        assertThat(outcome.generated()).isTrue();
-        assertThat(outcome.promptHash()).isEqualTo(initialGeneration.promptHash());
-        assertThat(outcome.snapshot()).contains(generatedSnapshot);
-        verify(repository, times(2))
-            .insertNewCurrentVersion(any(), anyString(), anyString(), anyString(), anyString(), anyString());
-        assertThat(server.requestBodies()).hasSize(2);
-    }
-
-    @Test
-    void should_RetryBlankSeoResponse_When_SecondGemmaResponseIsValid() {
-        server.enqueueJson(chatCompletion("stop", ""));
-        server.enqueueJson(chatCompletion("stop", seoJson()));
-
-        SeoMetadataCandidate candidate = seoClient().generate(BOOK_ID, "Grounded prompt", LlmGatewayTier.BACKGROUND_BATCH);
-
-        assertThat(candidate.seoTitle()).isEqualTo("Test Book - Book Details | findmybook.net");
-        List<String> requestBodies = server.requestBodies();
-        assertThat(requestBodies).hasSize(2);
-        assertThat(requestBodies.get(0)).doesNotContain("Recovery attempt");
-        assertThat(requestBodies.get(1))
-            .isNotEqualTo(requestBodies.get(0))
-            .contains("Recovery attempt 2")
-            .contains("prior response was empty or invalid")
-            .contains("exact canonical JSON");
-        assertThat(server.requestTiers()).containsOnly(LlmGatewayTier.BACKGROUND_BATCH.headerValue());
-    }
-
-    @Test
-    void should_RetryMalformedSuccessfulSeoResponse_When_SecondGemmaResponseIsValid() {
-        server.enqueueJson("{\"id\":\"chat-1\",\"object\":\"chat.completion\",\"created\":0,\"model\":\"gemma-4-26b-a4b\","
-            + "\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":" + jsonString(seoJson()) + "}}]}");
-        server.enqueueJson(chatCompletion("stop", seoJson()));
-
-        SeoMetadataCandidate candidate = seoClient().generate(BOOK_ID, "Grounded prompt", LlmGatewayTier.BACKGROUND_BATCH);
-
-        assertThat(candidate.seoDescription()).hasSizeBetween(140, 160);
-        assertThat(server.requestBodies()).hasSize(2);
     }
 
     @Test
@@ -290,58 +191,6 @@ class GemmaInferenceReliabilityTest {
     }
 
     @Test
-    void should_ThrowTypedFailure_When_SeoResponseMissesCanonicalField() {
-        SeoMetadataJsonParser parser = new SeoMetadataJsonParser(new ObjectMapper());
-
-        assertThatThrownBy(() -> parser.parse("{\"seoTitle\":\"Title only\"}"))
-            .isInstanceOf(BookSeoGenerationException.class)
-            .hasMessageContaining("fields must exactly match the canonical contract");
-    }
-
-    @Test
-    void should_AcceptWholeResponseFencedSeoJson_When_GemmaReturnsCanonicalJson() {
-        SeoMetadataJsonParser parser = new SeoMetadataJsonParser(new ObjectMapper());
-        SeoMetadataCandidate expected = new SeoMetadataCandidate(
-            "Test Book - Book Details | findmybook.net",
-            "A specific grounded description helps readers understand this test book and decide whether its practical focus matches their interests and reading goals."
-        );
-
-        assertThat(parser.parse(fencedSeoJson("```"))).isEqualTo(expected);
-        assertThat(parser.parse(fencedSeoJson("```json"))).isEqualTo(expected);
-    }
-
-    @Test
-    void should_RejectNonCanonicalSeoResponse_When_GemmaDriftsFromJsonContract() {
-        SeoMetadataJsonParser parser = new SeoMetadataJsonParser(new ObjectMapper());
-        String fencedResponse = fencedSeoJson("```json");
-
-        assertThatThrownBy(() -> parser.parse("SEO title: Test Book; description: useful details"))
-            .isInstanceOf(BookSeoGenerationException.class)
-            .hasMessageContaining("valid JSON object");
-        assertThatThrownBy(() -> parser.parse("{\"title\":\"Test Book\",\"description\":\"Useful details\"}"))
-            .isInstanceOf(BookSeoGenerationException.class)
-            .hasMessageContaining("exactly match the canonical contract");
-        assertThatThrownBy(() -> parser.parse("{\"seoTitle\":42,\"seoDescription\":true}"))
-            .isInstanceOf(BookSeoGenerationException.class)
-            .hasMessageContaining("field must be a string: seoTitle");
-        assertThatThrownBy(() -> parser.parse(
-            "{\"seoTitle\":\"Test Book\",\"seoDescription\":\"Useful details\",\"extra\":true}"
-        )).isInstanceOf(BookSeoGenerationException.class)
-            .hasMessageContaining("exactly match the canonical contract");
-        assertThatThrownBy(() -> parser.parse("Here is the requested JSON:\n" + fencedResponse))
-            .isInstanceOf(BookSeoGenerationException.class)
-            .hasMessageContaining("valid JSON object");
-        assertThatThrownBy(() -> parser.parse(fencedResponse + "\nA trailing note"))
-            .isInstanceOf(BookSeoGenerationException.class)
-            .hasMessageContaining("whole-response");
-        assertThatThrownBy(() -> parser.parse(fencedSeoJson("```markdown")))
-            .isInstanceOf(BookSeoGenerationException.class)
-            .hasMessageContaining("whole-response");
-        assertThatThrownBy(() -> parser.parse(fencedResponse + "\n" + fencedResponse))
-            .isInstanceOf(BookSeoGenerationException.class);
-    }
-
-    @Test
     void should_PreserveDisplayedBookIdentity_When_ResolvingReaderGuideTarget() {
         BookIdentifierResolver identifierResolver = mock(BookIdentifierResolver.class);
         when(identifierResolver.resolveExactBookUuid("test-book")).thenReturn(Optional.of(BOOK_ID));
@@ -354,7 +203,7 @@ class GemmaInferenceReliabilityTest {
             searchService,
             orchestrator,
             new ObjectMapper(),
-            openAiProperties()
+            server.openAiProperties()
         );
 
         assertThat(service.resolveBookId("test-book")).contains(BOOK_ID);
@@ -393,20 +242,6 @@ class GemmaInferenceReliabilityTest {
         verifyNoInteractions(lookupService, jdbcTemplate);
     }
 
-    private BookSeoMetadataGenerationService seoService(BookSeoMetadataRepository repository) {
-        BookSearchService searchService = mock(BookSearchService.class);
-        BookDataOrchestrator orchestrator = mock(BookDataOrchestrator.class);
-        BookDetail detail = bookDetail();
-        when(searchService.fetchBookDetail(BOOK_ID)).thenReturn(Optional.of(detail));
-        when(orchestrator.enrichDescriptionForAiIfNeeded(BOOK_ID, detail, DESCRIPTION, 50)).thenReturn(DESCRIPTION);
-        return new BookSeoMetadataGenerationService(
-            repository, searchService, orchestrator, seoClient(), new SeoMetadataNormalizationPolicy());
-    }
-
-    private BookSeoMetadataClient seoClient() {
-        return new BookSeoMetadataClient(new ObjectMapper(), openAiProperties());
-    }
-
     private BookAiContentService aiService(BookAiContentRepository repository) {
         BookSearchService searchService = mock(BookSearchService.class);
         BookDataOrchestrator orchestrator = mock(BookDataOrchestrator.class);
@@ -414,17 +249,8 @@ class GemmaInferenceReliabilityTest {
         when(searchService.fetchBookDetail(BOOK_ID)).thenReturn(Optional.of(detail));
         when(orchestrator.enrichDescriptionForAiIfNeeded(BOOK_ID, detail, DESCRIPTION, 50)).thenReturn(DESCRIPTION);
         return new BookAiContentService(
-            repository, mock(BookIdentifierResolver.class), searchService, orchestrator, new ObjectMapper(), openAiProperties());
-    }
-
-    private OpenAiProperties openAiProperties() {
-        OpenAiProperties properties = new OpenAiProperties();
-        properties.getApi().setKey("test-key");
-        properties.getBase().setUrl(server.baseUrl());
-        properties.setModel("gemma-4-26b-a4b");
-        properties.setRequestTimeoutSeconds(5);
-        properties.setReadTimeoutSeconds(5);
-        return properties;
+            repository, mock(BookIdentifierResolver.class), searchService, orchestrator, new ObjectMapper(),
+            server.openAiProperties());
     }
 
     private BookDetail bookDetail() {
@@ -436,91 +262,17 @@ class GemmaInferenceReliabilityTest {
             Map.of("source", "test"), List.of());
     }
 
-    private static String seoJson() {
-        SeoMetadataCandidate candidate = new SeoMetadataCandidate(
-            "Test Book - Book Details | findmybook.net",
-            "A specific grounded description helps readers understand this test book and decide whether its practical focus matches their interests and reading goals."
-        );
-        return new ObjectMapper().valueToTree(candidate).toString();
-    }
-
-    private static String fencedSeoJson(String fenceOpener) {
-        return fenceOpener + "\n" + seoJson() + "\n```";
-    }
-
-    private static String chatCompletion(String finishReason, String content) {
-        return "{\"id\":\"chat-1\",\"object\":\"chat.completion\",\"created\":0,\"model\":\"gemma-4-26b-a4b\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":"
-            + jsonString(content) + ",\"refusal\":null},\"finish_reason\":\"" + finishReason + "\"}]}";
-    }
-
     private static String streamChunk(String content, String finishReason) {
         String reason = finishReason == null ? "null" : "\"" + finishReason + "\"";
         return "data: {\"id\":\"chunk-1\",\"object\":\"chat.completion.chunk\",\"created\":0,\"model\":\"gemma-4-26b-a4b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":"
-            + jsonString(content) + "},\"finish_reason\":" + reason + "}]}\n\n";
+            + BookSeoMetadataClientWireTest.OpenAiTestServer.jsonString(content)
+            + "},\"finish_reason\":" + reason + "}]}\n\n";
     }
 
     private static String streamRefusalChunk(String refusal, String finishReason) {
         return "data: {\"id\":\"chunk-1\",\"object\":\"chat.completion.chunk\",\"created\":0,\"model\":\"gemma-4-26b-a4b\","
-            + "\"choices\":[{\"index\":0,\"delta\":{\"refusal\":" + jsonString(refusal)
+            + "\"choices\":[{\"index\":0,\"delta\":{\"refusal\":"
+            + BookSeoMetadataClientWireTest.OpenAiTestServer.jsonString(refusal)
             + "},\"finish_reason\":\"" + finishReason + "\"}]}\n\n";
-    }
-
-    private static String jsonString(String value) {
-        return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n") + "\"";
-    }
-
-    private static final class OpenAiTestServer implements AutoCloseable {
-        private final HttpServer httpServer;
-        private final Deque<Response> responses = new ConcurrentLinkedDeque<>();
-        private final List<String> requestBodies = new CopyOnWriteArrayList<>();
-        private final List<String> requestTiers = new CopyOnWriteArrayList<>();
-
-        private OpenAiTestServer() throws IOException {
-            httpServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
-            httpServer.createContext("/v1/chat/completions", this::handle);
-            httpServer.start();
-        }
-
-        private void enqueueJson(String body) {
-            enqueueJson(200, body);
-        }
-
-        private void enqueueJson(int statusCode, String body) {
-            responses.addLast(new Response(statusCode, "application/json", body));
-        }
-
-        private void enqueueSse(String body) {
-            responses.addLast(new Response(200, "text/event-stream", body + "data: [DONE]\n\n"));
-        }
-
-        private List<String> requestBodies() {
-            return List.copyOf(requestBodies);
-        }
-
-        private List<String> requestTiers() {
-            return List.copyOf(requestTiers);
-        }
-
-        private String baseUrl() {
-            return "http://127.0.0.1:" + httpServer.getAddress().getPort() + "/v1";
-        }
-
-        private void handle(HttpExchange exchange) throws IOException {
-            requestBodies.add(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
-            requestTiers.add(exchange.getRequestHeaders().getFirst(LlmGatewayTier.HEADER_NAME));
-            Response response = responses.removeFirst();
-            byte[] body = response.body().getBytes(StandardCharsets.UTF_8);
-            exchange.getResponseHeaders().set("Content-Type", response.contentType());
-            exchange.sendResponseHeaders(response.statusCode(), body.length);
-            exchange.getResponseBody().write(body);
-            exchange.close();
-        }
-
-        @Override
-        public void close() {
-            httpServer.stop(0);
-        }
-
-        private record Response(int statusCode, String contentType, String body) { }
     }
 }

--- a/src/test/java/net/findmybook/boot/OpenAiPropertiesTest.java
+++ b/src/test/java/net/findmybook/boot/OpenAiPropertiesTest.java
@@ -2,6 +2,7 @@ package net.findmybook.boot;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.openai.models.ReasoningEffort;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -18,10 +19,12 @@ class OpenAiPropertiesTest {
         "OPENAI_API_KEY",
         "OPENAI_BASE_URL",
         "OPENAI_MODEL",
+        "OPENAI_REASONING_EFFORT",
         "OPENAI_EMBEDDINGS_MODEL",
         "openai.api.key",
         "openai.base.url",
         "openai.model",
+        "openai.reasoning-effort",
         "openai.embeddings.model"
     };
 
@@ -32,6 +35,7 @@ class OpenAiPropertiesTest {
             "OPENAI_API_KEY=  test-key  ",
             "OPENAI_BASE_URL=https://llm.example.test/v1/embeddings/",
             "OPENAI_MODEL=  gpt-test  ",
+            "OPENAI_REASONING_EFFORT=  max  ",
             "OPENAI_EMBEDDINGS_MODEL=  embedding-test  "
         ).applyTo(environment, TestPropertyValues.Type.SYSTEM_ENVIRONMENT);
 
@@ -44,6 +48,7 @@ class OpenAiPropertiesTest {
         assertThat(properties.apiKey()).isEqualTo("test-key");
         assertThat(properties.baseUrl()).isEqualTo("https://llm.example.test/v1");
         assertThat(properties.model()).isEqualTo("gpt-test");
+        assertThat(properties.reasoningEffort()).map(ReasoningEffort::asString).contains("max");
         assertThat(properties.embeddingsModel()).isEqualTo("embedding-test");
     }
 
@@ -53,6 +58,7 @@ class OpenAiPropertiesTest {
             System.setProperty("OPENAI_API_KEY", "  dot-env-key  ");
             System.setProperty("OPENAI_BASE_URL", "https://dotenv.example.test/v1/");
             System.setProperty("OPENAI_MODEL", "  dotenv-inference  ");
+            System.setProperty("OPENAI_REASONING_EFFORT", "  none  ");
             System.setProperty("OPENAI_EMBEDDINGS_MODEL", "  dotenv-embeddings  ");
 
             OpenAiProperties.projectEnvironmentVariablesToSystemProperties();
@@ -66,6 +72,7 @@ class OpenAiPropertiesTest {
             assertThat(properties.apiKey()).isEqualTo("dot-env-key");
             assertThat(properties.baseUrl()).isEqualTo("https://dotenv.example.test/v1");
             assertThat(properties.model()).isEqualTo("dotenv-inference");
+            assertThat(properties.reasoningEffort()).map(ReasoningEffort::asString).contains("none");
             assertThat(properties.embeddingsModel()).isEqualTo("dotenv-embeddings");
         });
     }
@@ -90,6 +97,7 @@ class OpenAiPropertiesTest {
         properties.getApi().setKey(" ");
         properties.getBase().setUrl(" ");
         properties.setModel(" ");
+        properties.setReasoningEffort(" ");
         properties.getEmbeddings().setModel(" ");
 
         assertThat(properties.isConfigured()).isFalse();
@@ -97,6 +105,7 @@ class OpenAiPropertiesTest {
         assertThat(properties.apiKey()).isEmpty();
         assertThat(properties.baseUrl()).isEmpty();
         assertThat(properties.model()).isEmpty();
+        assertThat(properties.reasoningEffort()).isEmpty();
         assertThat(properties.embeddingsModel()).isEmpty();
     }
 


### PR DESCRIPTION
## Summary
Book AI content generation no longer aborts when Gemma emits blank entries inside list fields, and the reasoning effort applied to both AI content and SEO metadata generation is now configurable through a single standard gateway property (`OPENAI_REASONING_EFFORT`) instead of being fixed by the application — letting operators bound Gemma 4 reasoning so it stops consuming the completion allowance before canonical output is emitted.

## Changes

### Bug Fixes
- **AI content survives blank list entries**: Previously, a single blank string inside an AI list field (e.g. `keyThemes`) threw `IllegalStateException` ("AI response field item must be nonblank") and discarded the entire generated book content. Blank entries are now skipped, and only nonblank values count toward the per-field maximum, so a well-formed response with stray whitespace entries parses successfully (`AiContentJsonParser.extractStringList` / `src/main/java/net/findmybook/application/ai/AiContentJsonParser.java`).
- **SEO metadata no longer lost to unbounded reasoning**: Gemma 4 reasoning could consume the entire SEO completion allowance before emitting the canonical `seoTitle`/`seoDescription` JSON, yielding an empty or truncated response and a failed generation. Reasoning effort can now be bounded through the standard gateway contract so output budget is preserved for the structured response (`BookSeoMetadataClient.buildRequest` / `src/main/java/net/findmybook/application/seo/BookSeoMetadataClient.java`).

### Features
- **Configurable reasoning effort**: A new `OPENAI_REASONING_EFFORT` setting (and `openai.reasoning-effort` property) lets operators choose `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max` for both AI content and SEO metadata generation. When unset, the application omits the field entirely so the model default applies — no fixed native thinking budget is imposed (`OpenAiProperties.reasoningEffort` / `src/main/java/net/findmybook/boot/OpenAiProperties.java`, `BookAiContentService` and `BookSeoMetadataClient` forward it via `ChatCompletionCreateParams.Builder.reasoningEffort`).

### Refactoring
- **SEO wire tests consolidated under a single owner**: The in-process OpenAI test server and SEO reliability tests were extracted from the overgrown `GemmaInferenceReliabilityTest` into a new `BookSeoMetadataClientWireTest`, which is now the canonical owner of `OpenAiTestServer`. `GemmaInferenceReliabilityTest` imports and reuses that server instead of restating it, removing ~265 lines of duplicated test infrastructure and bringing both files within the repository LOC ceiling (`src/test/java/net/findmybook/application/seo/BookSeoMetadataClientWireTest.java`, `src/test/java/net/findmybook/application/seo/GemmaInferenceReliabilityTest.java`).

### Tests
- **Blank-list-item coverage**: `should_SkipBlankListItems_When_ResponseContainsOtherwiseValidContent` proves a list with an embedded whitespace entry parses to the nonblank values only (`BookAiContentServiceTest`).
- **Reasoning-effort wire coverage**: `should_OmitThinkingBudgetWhen_ReasoningEffortIsUnset` asserts no `thinking_budget_tokens` or `reasoning_effort` is sent when the property is unset, and `should_SendEveryConfiguredStandardReasoningEffortWithoutThinkingBudget_When_GeneratingSeoMetadata` parameterizes over all seven values (`none`…`max`) to confirm each is forwarded exactly with no native thinking budget attached (`BookSeoMetadataClientWireTest`).
- **Properties binding coverage**: `OpenAiPropertiesTest` verifies `OPENAI_REASONING_EFFORT` binds from env, from system properties, and trims to empty when blank so `isConfigured()` stays false (`OpenAiPropertiesTest`).

### Documentation
- **Configuration reference**: `OPENAI_REASONING_EFFORT` documented in `.env.example` (with supported values and an example) and the `docs/configuration.md` env table so operators know how to bound reasoning (`docs/configuration.md`, `.env.example`); `spring-configuration-metadata.json` updated for IDE tooling (`src/main/resources/META-INF/spring-configuration-metadata.json`).

## Breaking Changes
None — reasoning effort is optional and defaults to the model's behavior when unset.

## Related Issues
None