### PR TITLE
fix(reliability): fail-fast AI config and safe provider/sitemap reads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,8 @@ OPENAI_API_KEY=lgw-your-gateway-client-key
 OPENAI_BASE_URL=https://api.llm-gateway.iocloudhost.net
 # Generation model served through the shared OpenAI-compatible gateway
 OPENAI_MODEL=gemma-4-26b-a4b
-# Optional gateway reasoning override. Leave unset to preserve the model default.
-# Supported values: none, minimal, low, medium, high, xhigh, max.
+# Optional canonical gateway reasoning override. Leave unset to preserve the model default.
+# Invalid values fail startup and report the accepted tokens.
 # Note: OFF (`none`) is honored only for GENERAL-class gateway keys; other key classes are clamped to reasoning-ON.
 # OPENAI_REASONING_EFFORT=max
 OPENAI_EMBEDDINGS_MODEL=qwen/qwen3-embedding-4b

--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ OPENAI_BASE_URL=https://api.llm-gateway.iocloudhost.net
 OPENAI_MODEL=gemma-4-26b-a4b
 # Optional gateway reasoning override. Leave unset to preserve the model default.
 # Supported values: none, minimal, low, medium, high, xhigh, max.
+# Note: OFF (`none`) is honored only for GENERAL-class gateway keys; other key classes are clamped to reasoning-ON.
 # OPENAI_REASONING_EFFORT=max
 OPENAI_EMBEDDINGS_MODEL=qwen/qwen3-embedding-4b
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,9 +111,9 @@
 - [GIT1f] **Repository-Local Writes Only**: NEVER commit or push to this repository from a temporary clone, alternate checkout/worktree, or any other directory copy of the same repo. All git writes must be executed from this exact working tree.
 
 ### [LOC1] File Size Ceiling (Blocking)
-- [LOC1a] Keep new source files under 350 lines.
-- [LOC1b] Start splitting files when they approach 350 lines.
-- [LOC1c] For touched legacy files over 350 lines, include a concrete split plan in the summary.
+- [LOC1a] Keep new source files under 500 lines.
+- [LOC1b] Start splitting files when they approach 500 lines.
+- [LOC1c] For touched legacy files over 500 lines, include a concrete split plan in the summary.
 - [LOC1d] One canonical type per domain concept: never overload files with unrelated types/records/interfaces; split by domain concept, not by convenience
 
 ## Architecture

--- a/docs/api.md
+++ b/docs/api.md
@@ -183,6 +183,7 @@
         - `service_unavailable`
         - `stream_timeout`
         - `empty_generation`
+        - `degenerate_content`
         - `cache_serialization_failed`
         - `queue_busy`
         - `description_too_short` (emitted only after canonical description enrichment attempts from Open Library and Google Books still fail to satisfy minimum content requirements)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@ Key variables in `.env`:
 | `OPENAI_API_KEY` | OpenAI-compatible API key for generation and embeddings |
 | `OPENAI_BASE_URL` | OpenAI-compatible base URL for generation and embeddings |
 | `OPENAI_MODEL` | Canonical inference model for AI book content and SEO metadata generation |
-| `OPENAI_REASONING_EFFORT` | Optional standard gateway reasoning effort: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`; leave unset to use the model default. OFF (`none`) is honored only for GENERAL-class gateway keys — other key classes are clamped to reasoning-ON |
+| `OPENAI_REASONING_EFFORT` | Optional canonical gateway reasoning effort; leave unset to use the model default. Invalid values fail startup and report the accepted tokens. OFF (`none`) is honored only for GENERAL-class gateway keys — other key classes are clamped to reasoning-ON |
 | `OPENAI_EMBEDDINGS_MODEL` | Canonical embeddings model for vector calculations |
 | `AI_DEFAULT_MAX_PARALLEL` | Global outbound AI queue executor cap, coerced to `2..20`; background work may occupy at most `cap - 1` so one slot remains available for foreground generation |
 | `APP_AI_QUEUE_BACKGROUND_MAX_PENDING` | Max pending background ingestion AI jobs (default `100`) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@ Key variables in `.env`:
 | `OPENAI_API_KEY` | OpenAI-compatible API key for generation and embeddings |
 | `OPENAI_BASE_URL` | OpenAI-compatible base URL for generation and embeddings |
 | `OPENAI_MODEL` | Canonical inference model for AI book content and SEO metadata generation |
-| `OPENAI_REASONING_EFFORT` | Optional standard gateway reasoning effort: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`; leave unset to use the model default |
+| `OPENAI_REASONING_EFFORT` | Optional standard gateway reasoning effort: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`; leave unset to use the model default. OFF (`none`) is honored only for GENERAL-class gateway keys — other key classes are clamped to reasoning-ON |
 | `OPENAI_EMBEDDINGS_MODEL` | Canonical embeddings model for vector calculations |
 | `AI_DEFAULT_MAX_PARALLEL` | Global outbound AI queue executor cap, coerced to `2..20`; background work may occupy at most `cap - 1` so one slot remains available for foreground generation |
 | `APP_AI_QUEUE_BACKGROUND_MAX_PENDING` | Max pending background ingestion AI jobs (default `100`) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,7 +32,7 @@ Key variables in `.env`:
 | `APP_NYT_SCHEDULER_STANDALONE_ENABLED` | Enables standalone NYT `@Scheduled` execution when not using the weekly orchestrator |
 | `GOOGLE_BOOKS_API_KEY` | Book data source |
 | `S3_*` | S3 storage configuration (credentials, bucket, CDN URLs) |
-| `S3_ENABLED` | When `false`, S3 cover storage and CDN URL resolution are disabled; bare S3 keys do not count as usable covers, and supplied external fallback URLs are used (default `true`) |
+| `S3_ENABLED` | When `false`, S3 cover storage and CDN URL resolution are disabled; bare S3 keys do not count as usable covers for URL resolution, and supplied external fallback URLs are used. Backfill candidate selection is independent of this flag (see `docs/troubleshooting.md`). (default `true`) |
 | `S3_WRITE_ENABLED` | Enables/disables S3 cover uploads at runtime (`false` skips upload attempts without disabling S3 cover URL resolution) |
 | `APP_ADMIN_PASSWORD` | Admin user password |
 | `APP_USER_PASSWORD` | Basic user password |

--- a/docs/edition_clustering.md
+++ b/docs/edition_clustering.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The book database uses a **work_clusters** system to group different editions of the same book (hardcover, paperback, audio, etc.) for display in the frontend "Other Editions" dropdown.
+The book database uses a **work_clusters** system to group different editions of the same book (hardcover, paperback, audio, etc.) for display in the frontend Editions card grid.
 
 ## Architecture
 

--- a/src/main/java/net/findmybook/boot/OpenAiProperties.java
+++ b/src/main/java/net/findmybook/boot/OpenAiProperties.java
@@ -26,8 +26,7 @@ public class OpenAiProperties {
     private static final String MODEL_PROPERTY = "openai.model";
     private static final String REASONING_EFFORT_ENVIRONMENT_VARIABLE = "OPENAI_REASONING_EFFORT";
     private static final String REASONING_EFFORT_PROPERTY = "openai.reasoning-effort";
-    /** Canonical gateway reasoning effort tokens; bind-time tests iterate this single owner list. */
-    static final List<String> SUPPORTED_REASONING_EFFORTS =
+    private static final List<String> SUPPORTED_REASONING_EFFORTS =
         List.of("none", "minimal", "low", "medium", "high", "xhigh", "max");
     private static final String EMBEDDINGS_MODEL_ENVIRONMENT_VARIABLE = "OPENAI_EMBEDDINGS_MODEL";
     private static final String EMBEDDINGS_MODEL_PROPERTY = "openai.embeddings.model";
@@ -178,6 +177,18 @@ public class OpenAiProperties {
         return StringUtils.hasText(reasoningEffort)
             ? Optional.of(ReasoningEffort.of(reasoningEffort))
             : Optional.empty();
+    }
+
+    /**
+     * Returns the canonical gateway reasoning-effort tokens accepted at configuration bind time.
+     *
+     * <p>Consumers use this immutable projection so tests and other typed surfaces cannot create
+     * independent token inventories.</p>
+     *
+     * @return immutable supported reasoning-effort tokens
+     */
+    public static List<String> supportedReasoningEfforts() {
+        return SUPPORTED_REASONING_EFFORTS;
     }
 
     /**

--- a/src/main/java/net/findmybook/boot/OpenAiProperties.java
+++ b/src/main/java/net/findmybook/boot/OpenAiProperties.java
@@ -1,6 +1,8 @@
 package net.findmybook.boot;
 
 import com.openai.models.ReasoningEffort;
+import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -24,6 +26,9 @@ public class OpenAiProperties {
     private static final String MODEL_PROPERTY = "openai.model";
     private static final String REASONING_EFFORT_ENVIRONMENT_VARIABLE = "OPENAI_REASONING_EFFORT";
     private static final String REASONING_EFFORT_PROPERTY = "openai.reasoning-effort";
+    /** Canonical gateway reasoning effort tokens; bind-time tests iterate this single owner list. */
+    static final List<String> SUPPORTED_REASONING_EFFORTS =
+        List.of("none", "minimal", "low", "medium", "high", "xhigh", "max");
     private static final String EMBEDDINGS_MODEL_ENVIRONMENT_VARIABLE = "OPENAI_EMBEDDINGS_MODEL";
     private static final String EMBEDDINGS_MODEL_PROPERTY = "openai.embeddings.model";
     private static final long DEFAULT_REQUEST_TIMEOUT_SECONDS = 120L;
@@ -178,10 +183,15 @@ public class OpenAiProperties {
     /**
      * Binds an optional standard reasoning effort from {@code OPENAI_REASONING_EFFORT}.
      *
+     * <p>Validation happens here, at bind time, so a typo fails startup with a clear message
+     * instead of reaching the gateway and 4xxing every generation call. Tokens are matched
+     * case-insensitively and normalized to lowercase.</p>
+     *
      * @param reasoningEffort gateway reasoning effort, or blank to use the model default
+     * @throws IllegalArgumentException when the token is not one of {@link #SUPPORTED_REASONING_EFFORTS}
      */
     public void setReasoningEffort(String reasoningEffort) {
-        this.reasoningEffort = textOrEmpty(reasoningEffort);
+        this.reasoningEffort = normalizeReasoningEffort(reasoningEffort);
     }
 
     /**
@@ -263,6 +273,20 @@ public class OpenAiProperties {
             }
         }
         return "";
+    }
+
+    private static String normalizeReasoningEffort(String reasoningEffort) {
+        if (!StringUtils.hasText(reasoningEffort)) {
+            return "";
+        }
+        String normalized = reasoningEffort.trim().toLowerCase(Locale.ROOT);
+        if (!SUPPORTED_REASONING_EFFORTS.contains(normalized)) {
+            throw new IllegalArgumentException(
+                "Unsupported " + REASONING_EFFORT_ENVIRONMENT_VARIABLE + " value '" + normalized + "' for "
+                    + REASONING_EFFORT_PROPERTY + "; supported values: "
+                    + String.join(", ", SUPPORTED_REASONING_EFFORTS));
+        }
+        return normalized;
     }
 
     private static String textOrEmpty(String value) {

--- a/src/main/java/net/findmybook/controller/BackfillAdminController.java
+++ b/src/main/java/net/findmybook/controller/BackfillAdminController.java
@@ -21,8 +21,7 @@ import org.springframework.web.server.ResponseStatusException;
 /**
  * Admin endpoints for Google volume and cover image backfill operations.
  *
- * <p>Separated from {@link AdminController} to keep both controllers under the
- * 350-line file-size ceiling while reusing the shared {@code /admin/**} security rule.</p>
+ * <p>Shares the {@code /admin/**} security rule with {@link AdminController}.</p>
  */
 @RestController
 @RequestMapping("/admin")

--- a/src/main/java/net/findmybook/repository/SitemapRepository.java
+++ b/src/main/java/net/findmybook/repository/SitemapRepository.java
@@ -144,6 +144,16 @@ public class SitemapRepository {
         }, params);
     }
 
+    /**
+     * Computes XML sitemap metadata for all book listing pages in one database round trip.
+     *
+     * <p>The read transaction disables PostgreSQL gather workers before this global aggregate
+     * to avoid dynamic shared-memory exhaustion in constrained database containers.</p>
+     *
+     * @param pageSize number of books in one XML sitemap page
+     * @return page metadata ordered by XML sitemap page number
+     */
+    @Transactional(readOnly = true)
     public List<PageMetadata> fetchBookPageMetadata(int pageSize) {
         if (pageSize <= 0) {
             throw new IllegalArgumentException("Page size must be positive, got: " + pageSize);
@@ -159,6 +169,7 @@ public class SitemapRepository {
                 "SELECT CAST(FLOOR((rn - 1) / ?::numeric) AS bigint) + 1 AS page_number, " +
                 "       MAX(" + BOOK_UPDATED_AT_ALIAS + ") AS last_modified " +
                 "FROM ordered GROUP BY page_number ORDER BY page_number";
+        disableParallelWorkersForTransaction();
         return jdbcTemplate.query(sql, (rs, rowNum) -> new PageMetadata(
                 rs.getInt("page_number"),
                 rs.getTimestamp("last_modified").toInstant()
@@ -170,12 +181,15 @@ public class SitemapRepository {
      *
      * <p>Author XML pages contain links to HTML author listing pages rather than individual
      * authors. This query preserves that listing order while aggregating author and canonical
-     * book last-modified timestamps in the database.</p>
+     * book last-modified timestamps in the database. The read transaction disables PostgreSQL
+     * gather workers before the aggregate to avoid dynamic shared-memory exhaustion in
+     * constrained database containers.</p>
      *
      * @param htmlPageSize number of authors in one HTML listing page
      * @param xmlPageSize number of HTML listing pages in one XML sitemap page
      * @return page metadata ordered by XML sitemap page number
      */
+    @Transactional(readOnly = true)
     public List<PageMetadata> fetchAuthorPageMetadata(int htmlPageSize, int xmlPageSize) {
         if (htmlPageSize <= 0) {
             throw new IllegalArgumentException("HTML page size must be positive, got: " + htmlPageSize);
@@ -238,10 +252,15 @@ public class SitemapRepository {
                 AUTHOR_PAGE_NUMBER_ALIAS,
                 AUTHOR_PAGE_NUMBER_ALIAS
         );
+        disableParallelWorkersForTransaction();
         return jdbcTemplate.query(sql, (rs, rowNum) -> new PageMetadata(
                 rs.getInt("page_number"),
                 rs.getTimestamp("last_modified").toInstant()
         ), htmlPageSize, xmlPageSize);
+    }
+
+    private void disableParallelWorkersForTransaction() {
+        jdbcTemplate.execute(DISABLE_PARALLEL_QUERY_FOR_TRANSACTION);
     }
 
     /**
@@ -252,7 +271,7 @@ public class SitemapRepository {
      */
     @Transactional(readOnly = true)
     public DatasetFingerprint fetchBookFingerprint() {
-        jdbcTemplate.execute(DISABLE_PARALLEL_QUERY_FOR_TRANSACTION);
+        disableParallelWorkersForTransaction();
         return jdbcTemplate.queryForObject(BOOK_FINGERPRINT_QUERY, (rs, rowNum) -> new DatasetFingerprint(
                 rs.getInt("total_records"),
                 rs.getTimestamp(BOOK_UPDATED_AT_ALIAS).toInstant()

--- a/src/main/java/net/findmybook/repository/SitemapRepository.java
+++ b/src/main/java/net/findmybook/repository/SitemapRepository.java
@@ -278,6 +278,13 @@ public class SitemapRepository {
         ));
     }
 
+    /**
+     * Reads the hourly author fingerprint without parallel workers so constrained
+     * PostgreSQL containers never need dynamic shared memory for this maintenance query.
+     *
+     * @return current sitemap author count and latest related-data timestamp
+     */
+    @Transactional(readOnly = true)
     public DatasetFingerprint fetchAuthorFingerprint() {
         String sql = "SELECT COUNT(DISTINCT a.id) AS total_records, " +
                 "GREATEST(" +
@@ -287,6 +294,7 @@ public class SitemapRepository {
                 "FROM authors a " +
                 "LEFT JOIN book_authors_join baj ON baj.author_id = a.id " +
                 "LEFT JOIN books b ON b.id = baj.book_id AND b.slug IS NOT NULL";
+        disableParallelWorkersForTransaction();
         return jdbcTemplate.queryForObject(sql, (rs, rowNum) -> new DatasetFingerprint(
                 rs.getInt("total_records"),
                 rs.getTimestamp("last_modified").toInstant()

--- a/src/main/java/net/findmybook/service/BookDataOrchestrator.java
+++ b/src/main/java/net/findmybook/service/BookDataOrchestrator.java
@@ -1,5 +1,6 @@
 package net.findmybook.service;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -23,11 +24,16 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Flux;
+import reactor.netty.http.client.PrematureCloseException;
+import reactor.util.retry.Retry;
 
 @Service
 public class BookDataOrchestrator {
@@ -43,8 +49,11 @@ public class BookDataOrchestrator {
     private static final long SEARCH_VIEW_REFRESH_INTERVAL_MS = 60_000L;
     private static final int DESCRIPTION_ENRICHMENT_LIMIT = 6;
     private static final Duration DESCRIPTION_ENRICHMENT_TIMEOUT = Duration.ofSeconds(8);
+    private static final int OPEN_LIBRARY_TRANSIENT_RETRY_LIMIT = 1;
     private static final String DESCRIPTION_ENRICHMENT_SORT = "relevance";
     private static final String ISBN_QUERY_PREFIX = "isbn:";
+    private static final String OPEN_LIBRARY_PROVIDER = "Open Library";
+    private static final String GOOGLE_BOOKS_PROVIDER = "Google Books";
     private final AtomicLong lastSearchViewRefresh = new AtomicLong(0L);
     private final AtomicBoolean searchViewRefreshInProgress = new AtomicBoolean(false);
 
@@ -162,17 +171,61 @@ public class BookDataOrchestrator {
             || SearchQueryUtils.isWildcard(openLibraryQuery)) {
             return List.of();
         }
-        return collectWithTimeout(openLibraryBookDataService.get()
-            .queryBooksByEverything(openLibraryQuery, DESCRIPTION_ENRICHMENT_SORT, 0, DESCRIPTION_ENRICHMENT_LIMIT));
+        Flux<Book> candidates = openLibraryBookDataService.get()
+            .queryBooksByEverything(openLibraryQuery, DESCRIPTION_ENRICHMENT_SORT, 0, DESCRIPTION_ENRICHMENT_LIMIT);
+        return collectOpenLibraryCandidates(candidates);
     }
 
     private List<Book> fetchGoogleCandidates(String query) {
-        return collectWithTimeout(googleExternalSearchFlow
-            .streamCandidates(query, DESCRIPTION_ENRICHMENT_SORT, null, DESCRIPTION_ENRICHMENT_LIMIT));
+        Flux<Book> candidates = googleExternalSearchFlow
+            .streamCandidates(query, DESCRIPTION_ENRICHMENT_SORT, null, DESCRIPTION_ENRICHMENT_LIMIT);
+        return collectGoogleCandidates(candidates);
     }
 
-    private List<Book> collectWithTimeout(Flux<Book> source) {
-        return source.timeout(DESCRIPTION_ENRICHMENT_TIMEOUT).collectList().block();
+    private List<Book> collectOpenLibraryCandidates(Flux<Book> candidates) {
+        Mono<List<Book>> retriedCandidates = candidates.collectList()
+            .retryWhen(Retry.max(OPEN_LIBRARY_TRANSIENT_RETRY_LIMIT)
+                .filter(this::isTransientProviderFailure)
+                .doBeforeRetry(retrySignal -> logger.info(
+                    "Retrying Open Library description enrichment after transient {} (retry={})",
+                    retrySignal.failure().getClass().getSimpleName(),
+                    retrySignal.totalRetries() + 1
+                ))
+                .onRetryExhaustedThrow((retrySpec, retrySignal) -> retrySignal.failure()));
+        return collectWithDescriptionEnrichmentDeadline(OPEN_LIBRARY_PROVIDER, retriedCandidates);
+    }
+
+    private List<Book> collectGoogleCandidates(Flux<Book> candidates) {
+        return collectWithDescriptionEnrichmentDeadline(GOOGLE_BOOKS_PROVIDER, candidates.collectList());
+    }
+
+    private List<Book> collectWithDescriptionEnrichmentDeadline(String providerName, Mono<List<Book>> candidates) {
+        return candidates
+            .timeout(DESCRIPTION_ENRICHMENT_TIMEOUT)
+            .onErrorMap(TimeoutException.class, timeoutFailure -> new IllegalStateException(
+                providerName + " description enrichment exceeded its "
+                    + DESCRIPTION_ENRICHMENT_TIMEOUT.toSeconds() + "s total deadline",
+                timeoutFailure
+            ))
+            .block();
+    }
+
+    private boolean isTransientProviderFailure(Throwable failure) {
+        Throwable currentFailure = failure;
+        while (currentFailure != null) {
+            if (currentFailure instanceof WebClientResponseException responseException
+                && responseException.getStatusCode().is5xxServerError()) {
+                return true;
+            }
+            if (currentFailure instanceof TimeoutException
+                || currentFailure instanceof IOException
+                || currentFailure instanceof WebClientRequestException
+                || currentFailure instanceof PrematureCloseException) {
+                return true;
+            }
+            currentFailure = currentFailure.getCause();
+        }
+        return false;
     }
 
     private String persistEnrichedDescription(UUID bookId,

--- a/src/main/java/net/findmybook/service/BookDataOrchestrator.java
+++ b/src/main/java/net/findmybook/service/BookDataOrchestrator.java
@@ -135,11 +135,9 @@ public class BookDataOrchestrator {
     private List<Book> fetchDescriptionEnrichmentCandidates(UUID bookId, String query) {
         List<Book> candidates = new ArrayList<>();
         RuntimeException firstProviderFailure = null;
-        boolean providerSucceeded = false;
         if (openLibraryBookDataService.isPresent()) {
             try {
                 candidates.addAll(fetchOpenLibraryCandidates(query));
-                providerSucceeded = true;
             } catch (RuntimeException openLibraryFailure) {
                 firstProviderFailure = openLibraryFailure;
                 logger.warn("Open Library description enrichment failed for bookId={} (continuing with Google Books): {}",
@@ -149,7 +147,6 @@ public class BookDataOrchestrator {
         if (googleExternalSearchFlow.isAvailable()) {
             try {
                 candidates.addAll(fetchGoogleCandidates(query));
-                providerSucceeded = true;
             } catch (RuntimeException googleFailure) {
                 if (firstProviderFailure != null) {
                     firstProviderFailure.addSuppressed(googleFailure);
@@ -158,7 +155,7 @@ public class BookDataOrchestrator {
                 }
             }
         }
-        if (!providerSucceeded && firstProviderFailure != null) {
+        if (candidates.isEmpty() && firstProviderFailure != null) {
             throw firstProviderFailure;
         }
         return candidates;

--- a/src/main/java/net/findmybook/service/GoogleApiFetcher.java
+++ b/src/main/java/net/findmybook/service/GoogleApiFetcher.java
@@ -121,9 +121,9 @@ public class GoogleApiFetcher {
                 .retrieve()
                 .toEntity(JsonNode.class)
                 .doOnSubscribe(s -> log.debug("Fetching from Google API: {}", url))
-                .timeout(Duration.ofSeconds(5))
                 .retryWhen(authenticated
-                    ? Retry.max(0) // NO RETRIES for authenticated calls - fail fast to trigger circuit breaker
+                    ? Retry.max(0)
+                        .onRetryExhaustedThrow((retrySpec, retrySignal) -> retrySignal.failure())
                     : Retry.backoff(1, Duration.ofSeconds(1))
                         .filter(throwable -> {
                             if (throwable instanceof WebClientResponseException wcre) {
@@ -245,7 +245,7 @@ public class GoogleApiFetcher {
         }
         if (!circuitBreakerService.isFallbackAllowed()) {
             log.info("Fallback circuit is OPEN - skipping unauthenticated search for query '{}'", query);
-            return Mono.empty();
+            return Mono.error(new IllegalStateException("Fallback circuit OPEN for unauthenticated Google Books search"));
         }
         return searchVolumesInternal(query, startIndex, orderBy, langCode, false, pageSize);
     }
@@ -271,9 +271,13 @@ public class GoogleApiFetcher {
         final int effectiveMax = maxResultsToFetch > 0 ? maxResultsToFetch : maxResultsPerPage;
         final int pageCount = (effectiveMax + maxResultsPerPage - 1) / maxResultsPerPage;
 
-        if (!authenticated && (!googleFallbackEnabled || !circuitBreakerService.isFallbackAllowed())) {
-            log.debug("Skipping unauthenticated stream for query '{}' because fallback is disabled or blocked", query);
+        if (!authenticated && !googleFallbackEnabled) {
+            log.debug("Skipping unauthenticated stream for query '{}' because fallback is disabled", query);
             return Flux.empty();
+        }
+        if (!authenticated && !circuitBreakerService.isFallbackAllowed()) {
+            log.info("Fallback circuit is OPEN - skipping unauthenticated stream for query '{}'", query);
+            return Flux.error(new IllegalStateException("Fallback circuit OPEN for unauthenticated Google Books search"));
         }
 
         return Flux.range(0, pageCount)
@@ -364,9 +368,9 @@ public class GoogleApiFetcher {
                 .retrieve()
                 .toEntity(JsonNode.class)
                 .doOnSubscribe(s -> log.debug("Making Google Books API search call ({}) for query: {}, startIndex: {}", authStatus, query, startIndex))
-                .timeout(Duration.ofSeconds(5))
                 .retryWhen(authenticated
-                    ? Retry.max(0) // NO RETRIES for authenticated calls - fail fast to trigger circuit breaker
+                    ? Retry.max(0)
+                        .onRetryExhaustedThrow((retrySpec, retrySignal) -> retrySignal.failure())
                     : Retry.backoff(1, Duration.ofSeconds(1)) // One retry for unauthenticated
                         .filter(throwable -> {
                             if (throwable instanceof WebClientResponseException wcre) {

--- a/src/main/java/net/findmybook/service/OpenLibraryBookDataService.java
+++ b/src/main/java/net/findmybook/service/OpenLibraryBookDataService.java
@@ -240,7 +240,6 @@ public class OpenLibraryBookDataService {
             })
             .retrieve()
             .bodyToMono(JsonNode.class)
-            .timeout(Duration.ofSeconds(5))
             .onErrorMap(PrematureCloseException.class, e -> {
                 log.debug("OpenLibrary {} search connection closed early for '{}': {}", queryParamName, queryValue, e.toString());
                 return new IllegalStateException("OpenLibrary " + queryParamName + " search connection closed early for '" + queryValue + "'", e);

--- a/src/main/java/net/findmybook/support/search/GoogleExternalSearchFlow.java
+++ b/src/main/java/net/findmybook/support/search/GoogleExternalSearchFlow.java
@@ -39,10 +39,12 @@ public final class GoogleExternalSearchFlow {
     /**
      * Indicates whether Google fallback dependencies are available.
      *
-     * @return true when both fetcher and mapper are present
+     * @return true when both dependencies are present and an authenticated or fallback tier is enabled
      */
     public boolean isAvailable() {
-        return googleApiFetcher.isPresent() && googleBooksMapper.isPresent();
+        return googleApiFetcher.isPresent()
+            && googleBooksMapper.isPresent()
+            && (googleApiFetcher.get().isApiKeyAvailable() || googleApiFetcher.get().isGoogleFallbackEnabled());
     }
 
     /**
@@ -69,15 +71,27 @@ public final class GoogleExternalSearchFlow {
         GoogleBooksMapper mapper = googleBooksMapper.get();
         String externalOrderBy = SearchExternalProviderUtils.normalizeGoogleOrderBy(orderBy);
 
-        Flux<JsonNode> authenticated = fetcher.isApiKeyAvailable()
-            ? fetcher.streamSearchItems(query, maxResults, externalOrderBy, null, true)
-                .onErrorResume(ex -> fetcher.isFallbackAllowed() ? Flux.empty() : Flux.error(ex))
-            : Flux.empty();
-        Flux<JsonNode> unauthenticated = fetcher.isFallbackAllowed()
-            ? fetcher.streamSearchItems(query, maxResults, externalOrderBy, null, false)
-            : Flux.empty();
+        Flux<JsonNode> providerItems;
+        if (!fetcher.isApiKeyAvailable()) {
+            providerItems = fetcher.isGoogleFallbackEnabled()
+                ? fetcher.streamSearchItems(query, maxResults, externalOrderBy, null, false)
+                : Flux.empty();
+        } else {
+            Flux<JsonNode> authenticated = fetcher.streamSearchItems(query, maxResults, externalOrderBy, null, true);
+            if (!fetcher.isGoogleFallbackEnabled()) {
+                providerItems = authenticated;
+            } else if (!fetcher.isFallbackAllowed()) {
+                providerItems = authenticated.onErrorMap(failure -> new IllegalStateException(
+                    "Google Books authenticated search failed while unauthenticated fallback is unavailable",
+                    failure
+                ));
+            } else {
+                Flux<JsonNode> unauthenticated = fetcher.streamSearchItems(query, maxResults, externalOrderBy, null, false);
+                providerItems = Flux.concat(authenticated.onErrorResume(ex -> Flux.empty()), unauthenticated);
+            }
+        }
 
-        return Flux.concat(authenticated, unauthenticated)
+        return providerItems
             .map(mapper::map)
             .filter(Objects::nonNull)
             .map(BookDomainMapper::fromAggregate)

--- a/src/main/java/net/findmybook/support/search/GoogleExternalSearchFlow.java
+++ b/src/main/java/net/findmybook/support/search/GoogleExternalSearchFlow.java
@@ -12,6 +12,7 @@ import reactor.core.publisher.Flux;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Shared Google Books fallback flow used by paginated and realtime search pipelines.
@@ -87,7 +88,7 @@ public final class GoogleExternalSearchFlow {
                 ));
             } else {
                 Flux<JsonNode> unauthenticated = fetcher.streamSearchItems(query, maxResults, externalOrderBy, null, false);
-                providerItems = Flux.concat(authenticated.onErrorResume(ex -> Flux.empty()), unauthenticated);
+                providerItems = streamAuthenticatedThenFallback(authenticated, unauthenticated);
             }
         }
 
@@ -100,5 +101,22 @@ public final class GoogleExternalSearchFlow {
             .map(SearchExternalProviderUtils::tagGoogleFallback)
             .filter(book -> SearchExternalProviderUtils.matchesPublishedYear(book, publishedYear))
             .take(maxResults);
+    }
+
+    private Flux<JsonNode> streamAuthenticatedThenFallback(Flux<JsonNode> authenticated,
+                                                            Flux<JsonNode> unauthenticated) {
+        return Flux.defer(() -> {
+            AtomicBoolean fallbackConsumed = new AtomicBoolean(false);
+            Flux<JsonNode> authenticatedOrFallback = authenticated.onErrorResume(authenticatedFailure -> {
+                fallbackConsumed.set(true);
+                return unauthenticated.onErrorMap(fallbackFailure -> {
+                    authenticatedFailure.addSuppressed(fallbackFailure);
+                    return authenticatedFailure;
+                });
+            });
+            return authenticatedOrFallback.concatWith(Flux.defer(
+                () -> fallbackConsumed.get() ? Flux.empty() : unauthenticated
+            ));
+        });
     }
 }

--- a/src/test/java/net/findmybook/application/seo/BookSeoMetadataClientWireTest.java
+++ b/src/test/java/net/findmybook/application/seo/BookSeoMetadataClientWireTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -151,7 +151,7 @@ class BookSeoMetadataClientWireTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"none", "minimal", "low", "medium", "high", "xhigh", "max"})
+    @MethodSource("net.findmybook.boot.OpenAiProperties#supportedReasoningEfforts")
     void should_SendEveryConfiguredStandardReasoningEffortWithoutThinkingBudget_When_GeneratingSeoMetadata(
         String reasoningEffort
     ) throws Exception {

--- a/src/test/java/net/findmybook/boot/OpenAiPropertiesTest.java
+++ b/src/test/java/net/findmybook/boot/OpenAiPropertiesTest.java
@@ -121,14 +121,17 @@ class OpenAiPropertiesTest {
     void should_FailBindFast_When_ReasoningEffortIsNotACanonicalToken() {
         MapConfigurationPropertySource source = new MapConfigurationPropertySource();
         source.put("openai.reasoning-effort", "ultra");
+        String supportedReasoningEfforts = String.join(", ", OpenAiProperties.supportedReasoningEfforts());
 
         assertThatThrownBy(() -> new Binder(source).bind("openai", Bindable.ofInstance(new OpenAiProperties())))
-            .hasStackTraceContaining("Unsupported OPENAI_REASONING_EFFORT value 'ultra'")
-            .hasStackTraceContaining("none, minimal, low, medium, high, xhigh, max");
+            .hasRootCauseMessage(
+                "Unsupported OPENAI_REASONING_EFFORT value 'ultra' for openai.reasoning-effort; "
+                    + "supported values: " + supportedReasoningEfforts
+            );
     }
 
     private static Stream<String> canonicalReasoningEfforts() {
-        return OpenAiProperties.SUPPORTED_REASONING_EFFORTS.stream();
+        return OpenAiProperties.supportedReasoningEfforts().stream();
     }
 
     @Test

--- a/src/test/java/net/findmybook/boot/OpenAiPropertiesTest.java
+++ b/src/test/java/net/findmybook/boot/OpenAiPropertiesTest.java
@@ -1,11 +1,15 @@
 package net.findmybook.boot;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.openai.models.ReasoningEffort;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
@@ -88,6 +92,43 @@ class OpenAiPropertiesTest {
 
         assertThat(properties.requestTimeoutSeconds()).isEqualTo(1);
         assertThat(properties.readTimeoutSeconds()).isEqualTo(1);
+    }
+
+    @ParameterizedTest
+    @MethodSource("canonicalReasoningEfforts")
+    void should_BindEveryCanonicalReasoningEffort_When_TokenIsSupported(String reasoningEffort) {
+        MapConfigurationPropertySource source = new MapConfigurationPropertySource();
+        source.put("openai.reasoning-effort", reasoningEffort);
+        OpenAiProperties properties = new OpenAiProperties();
+
+        new Binder(source).bind("openai", Bindable.ofInstance(properties));
+
+        assertThat(properties.reasoningEffort()).map(ReasoningEffort::asString).contains(reasoningEffort);
+    }
+
+    @Test
+    void should_NormalizeReasoningEffort_When_TokenHasMixedCaseAndWhitespace() {
+        MapConfigurationPropertySource source = new MapConfigurationPropertySource();
+        source.put("openai.reasoning-effort", "  MaX  ");
+        OpenAiProperties properties = new OpenAiProperties();
+
+        new Binder(source).bind("openai", Bindable.ofInstance(properties));
+
+        assertThat(properties.reasoningEffort()).map(ReasoningEffort::asString).contains("max");
+    }
+
+    @Test
+    void should_FailBindFast_When_ReasoningEffortIsNotACanonicalToken() {
+        MapConfigurationPropertySource source = new MapConfigurationPropertySource();
+        source.put("openai.reasoning-effort", "ultra");
+
+        assertThatThrownBy(() -> new Binder(source).bind("openai", Bindable.ofInstance(new OpenAiProperties())))
+            .hasStackTraceContaining("Unsupported OPENAI_REASONING_EFFORT value 'ultra'")
+            .hasStackTraceContaining("none, minimal, low, medium, high, xhigh, max");
+    }
+
+    private static Stream<String> canonicalReasoningEfforts() {
+        return OpenAiProperties.SUPPORTED_REASONING_EFFORTS.stream();
     }
 
     @Test

--- a/src/test/java/net/findmybook/repository/SitemapBookLastModifiedSqlSupportTest.java
+++ b/src/test/java/net/findmybook/repository/SitemapBookLastModifiedSqlSupportTest.java
@@ -211,4 +211,27 @@ class SitemapBookLastModifiedSqlSupportTest {
             .contains("MAX(change_events.changed_at)")
             .doesNotContain("GROUP BY");
     }
+
+    @Test
+    void should_DisableParallelWorkersBeforeQuery_When_AuthorFingerprintIsRequested() {
+        JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+        SitemapRepository sitemapRepository = new SitemapRepository(jdbcTemplate);
+        SitemapRepository.DatasetFingerprint expected = new SitemapRepository.DatasetFingerprint(
+            17,
+            Instant.parse("2026-07-16T00:00:00Z")
+        );
+        when(jdbcTemplate.queryForObject(
+            anyString(),
+            org.mockito.ArgumentMatchers.<RowMapper<SitemapRepository.DatasetFingerprint>>any()
+        )).thenReturn(expected);
+
+        assertThat(sitemapRepository.fetchAuthorFingerprint()).isEqualTo(expected);
+
+        InOrder inOrder = inOrder(jdbcTemplate);
+        inOrder.verify(jdbcTemplate).execute("SET LOCAL max_parallel_workers_per_gather = 0");
+        inOrder.verify(jdbcTemplate).queryForObject(
+            anyString(),
+            org.mockito.ArgumentMatchers.<RowMapper<SitemapRepository.DatasetFingerprint>>any()
+        );
+    }
 }

--- a/src/test/java/net/findmybook/repository/SitemapBookLastModifiedSqlSupportTest.java
+++ b/src/test/java/net/findmybook/repository/SitemapBookLastModifiedSqlSupportTest.java
@@ -4,6 +4,7 @@ import net.findmybook.support.sitemap.SitemapBookLastModifiedSqlSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 
@@ -17,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -101,7 +103,7 @@ class SitemapBookLastModifiedSqlSupportTest {
     }
 
     @Test
-    void should_UseOneBulkQuery_When_AuthorPageMetadataIsRequested() {
+    void should_DisableParallelWorkersBeforeBulkQuery_When_AuthorPageMetadataIsRequested() {
         JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
         SitemapRepository sitemapRepository = new SitemapRepository(jdbcTemplate);
         List<SitemapRepository.PageMetadata> expected = List.of(
@@ -117,7 +119,9 @@ class SitemapBookLastModifiedSqlSupportTest {
         assertThat(sitemapRepository.fetchAuthorPageMetadata(100, 5000)).isEqualTo(expected);
 
         ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-        verify(jdbcTemplate).query(
+        InOrder inOrder = inOrder(jdbcTemplate);
+        inOrder.verify(jdbcTemplate).execute("SET LOCAL max_parallel_workers_per_gather = 0");
+        inOrder.verify(jdbcTemplate).query(
                 sqlCaptor.capture(),
                 org.mockito.ArgumentMatchers.<RowMapper<SitemapRepository.PageMetadata>>any(),
                 eq(100),
@@ -130,6 +134,30 @@ class SitemapBookLastModifiedSqlSupportTest {
                 .contains("ROW_NUMBER() OVER")
                 .contains("ORDER BY CASE bucket")
                 .doesNotContain("%s");
+    }
+
+    @Test
+    void should_DisableParallelWorkersBeforeQuery_When_BookPageMetadataIsRequested() {
+        JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+        SitemapRepository sitemapRepository = new SitemapRepository(jdbcTemplate);
+        List<SitemapRepository.PageMetadata> expected = List.of(
+                new SitemapRepository.PageMetadata(1, Instant.parse("2024-02-01T00:00:00Z"))
+        );
+        when(jdbcTemplate.query(
+                anyString(),
+                org.mockito.ArgumentMatchers.<RowMapper<SitemapRepository.PageMetadata>>any(),
+                eq(5000)
+        )).thenReturn(expected);
+
+        assertThat(sitemapRepository.fetchBookPageMetadata(5000)).isEqualTo(expected);
+
+        InOrder inOrder = inOrder(jdbcTemplate);
+        inOrder.verify(jdbcTemplate).execute("SET LOCAL max_parallel_workers_per_gather = 0");
+        inOrder.verify(jdbcTemplate).query(
+                anyString(),
+                org.mockito.ArgumentMatchers.<RowMapper<SitemapRepository.PageMetadata>>any(),
+                eq(5000)
+        );
     }
 
     @Test

--- a/src/test/java/net/findmybook/service/ApiRequestMonitorTest.java
+++ b/src/test/java/net/findmybook/service/ApiRequestMonitorTest.java
@@ -19,6 +19,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.test.StepVerifier;
 
 import java.time.LocalDate;
@@ -29,7 +30,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ApiRequestMonitorTest {
 
@@ -105,7 +109,11 @@ public class ApiRequestMonitorTest {
         fetcherLogger.addAppender(logEvents);
         try {
             StepVerifier.create(fetcher.streamSearchItems("failure query", 1, "relevance", null, true))
-                    .expectError(IllegalStateException.class)
+                    .expectErrorSatisfies(failure -> {
+                        assertInstanceOf(IllegalStateException.class, failure);
+                        assertThat(failure)
+                                .hasRootCauseInstanceOf(WebClientResponseException.ServiceUnavailable.class);
+                    })
                     .verify();
 
             List<ILoggingEvent> warnings = logEvents.list.stream()
@@ -122,6 +130,32 @@ public class ApiRequestMonitorTest {
             fetcherLogger.detachAppender(logEvents);
             logEvents.stop();
         }
+    }
+
+    @Test
+    void should_CompleteEmpty_When_GoogleFallbackFeatureIsDisabled() {
+        GoogleApiFetcher fetcher = googleFetcherWithFallback(false, mock(ApiCircuitBreakerService.class));
+
+        StepVerifier.create(fetcher.streamSearchItems("disabled fallback", 1, "relevance", null, false))
+                .verifyComplete();
+    }
+
+    @Test
+    void should_PropagateFailure_When_GoogleFallbackCircuitIsOpen() {
+        ApiCircuitBreakerService circuitBreaker = mock(ApiCircuitBreakerService.class);
+        when(circuitBreaker.isFallbackAllowed()).thenReturn(false);
+        GoogleApiFetcher fetcher = googleFetcherWithFallback(true, circuitBreaker);
+
+        StepVerifier.create(fetcher.streamSearchItems("blocked fallback", 1, "relevance", null, false))
+                .expectErrorMatches(failure -> failure instanceof IllegalStateException
+                        && failure.getMessage().contains("Fallback circuit OPEN"))
+                .verify();
+
+        StepVerifier.create(fetcher.searchVolumesUnauthenticated(
+                        "blocked fallback", 0, "relevance", null, 1))
+                .expectErrorMatches(failure -> failure instanceof IllegalStateException
+                        && failure.getMessage().contains("Fallback circuit OPEN"))
+                .verify();
     }
 
     @Test
@@ -160,6 +194,19 @@ public class ApiRequestMonitorTest {
         assertEquals(2L, (Long) apiRequestMonitor.getMetricsMap().get("total_requests"));
         assertEquals(1L, (Long) apiRequestMonitor.getMetricsMap().get("total_successful"));
         assertEquals(1L, (Long) apiRequestMonitor.getMetricsMap().get("total_failed"));
+    }
+
+    private GoogleApiFetcher googleFetcherWithFallback(
+            boolean fallbackEnabled,
+            ApiCircuitBreakerService circuitBreaker
+    ) {
+        GoogleApiFetcher fetcher = new GoogleApiFetcher(
+                WebClient.builder(),
+                apiRequestMonitor,
+                circuitBreaker
+        );
+        ReflectionTestUtils.setField(fetcher, "googleFallbackEnabled", fallbackEnabled);
+        return fetcher;
     }
 
     @Test

--- a/src/test/java/net/findmybook/service/BookDataOrchestratorPersistenceScenariosTest.java
+++ b/src/test/java/net/findmybook/service/BookDataOrchestratorPersistenceScenariosTest.java
@@ -1,11 +1,11 @@
 package net.findmybook.service;
 
 import tools.jackson.databind.ObjectMapper;
-import tools.jackson.databind.JsonNode;
 import net.findmybook.dto.BookAggregate;
 import net.findmybook.dto.BookDetail;
 import net.findmybook.model.Book;
 import net.findmybook.util.ApplicationConstants;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -15,8 +15,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import java.time.LocalDate;
 import java.time.Instant;
@@ -24,15 +27,19 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import reactor.core.publisher.Flux;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -42,6 +49,14 @@ import static org.mockito.Mockito.when;
  */
 @ExtendWith(MockitoExtension.class)
 class BookDataOrchestratorPersistenceScenariosTest {
+
+    private static final UUID ENRICHMENT_BOOK_ID = UUID.fromString("019cb5e1-d100-719e-8194-f6f5af0af7a8");
+    private static final String ENRICHMENT_ISBN_13 = "9781234567890";
+    private static final String ENRICHMENT_QUERY = "isbn:" + ENRICHMENT_ISBN_13;
+    private static final String OPEN_LIBRARY_ENRICHMENT_QUERY = ENRICHMENT_ISBN_13;
+    private static final String DESCRIPTION_ENRICHMENT_SORT = "relevance";
+    private static final int DESCRIPTION_ENRICHMENT_LIMIT = 6;
+    private static final String SHORT_DESCRIPTION = "short description";
 
     @Mock
     private BookSearchService bookSearchService;
@@ -178,48 +193,167 @@ class BookDataOrchestratorPersistenceScenariosTest {
     }
 
     @Test
-    void enrichDescription_continuesWithGoogle_When_OpenLibraryFails() {
-        UUID bookId = UUID.randomUUID();
+    void should_ReturnCurrentDescription_When_BothProvidersReturnNoCandidates() {
         OpenLibraryBookDataService openLibrary = mock(OpenLibraryBookDataService.class);
         GoogleApiFetcher googleApiFetcher = mock(GoogleApiFetcher.class);
-        JsonNode googlePayload = mock(JsonNode.class);
-        BookDetail detail = new BookDetail(
-            bookId.toString(), "canonical-title", "Canonical title", "", "Canonical publisher",
-            LocalDate.of(2020, 1, 1), "en", 250, List.of("Canonical author"), List.of("Fiction"),
-            "https://example.com/cover.jpg", "covers/canonical.jpg", "https://example.com/fallback.jpg",
-            "https://example.com/thumbnail.jpg", 600, 900, true, "GOOGLE_BOOKS", 4.0, 10,
-            "1234567890", "9781234567890", "https://example.com/preview", "https://example.com/info",
-            java.util.Map.of("source", "test"), List.of()
-        );
-        when(openLibrary.queryBooksByEverything("isbn:9781234567890", "relevance", 0, 6))
-            .thenReturn(Flux.error(new IllegalStateException("Open Library unavailable")));
-        when(googleApiFetcher.isApiKeyAvailable()).thenReturn(false);
-        when(googleApiFetcher.isFallbackAllowed()).thenReturn(true);
+        AtomicInteger openLibrarySubscriptions = new AtomicInteger();
+        when(openLibrary.queryBooksByEverything(OPEN_LIBRARY_ENRICHMENT_QUERY, DESCRIPTION_ENRICHMENT_SORT, 0, DESCRIPTION_ENRICHMENT_LIMIT))
+            .thenReturn(Flux.<Book>defer(() -> {
+                openLibrarySubscriptions.incrementAndGet();
+                return Flux.empty();
+            }));
+        configureGoogleFallback(googleApiFetcher);
         when(googleApiFetcher.streamSearchItems(
-                eq("isbn:9781234567890"), eq(6), eq("relevance"), isNull(), eq(false)))
-            .thenReturn(Flux.just(googlePayload));
-        when(googleBooksMapper.map(googlePayload)).thenReturn(BookAggregate.builder()
-            .title("Different title")
-            .identifiers(BookAggregate.ExternalIdentifiers.builder()
-                .source("GOOGLE_BOOKS")
-                .externalId("google-candidate")
-                .build())
-            .build());
-        BookDataOrchestrator enrichmentOrchestrator = new BookDataOrchestrator(
-            bookSearchService,
-            postgresBookRepository,
-            batchPersistenceService,
-            Optional.of(openLibrary),
-            Optional.of(googleApiFetcher),
-            Optional.of(googleBooksMapper),
-            bookUpsertService
-        );
+                eq(ENRICHMENT_QUERY), eq(DESCRIPTION_ENRICHMENT_LIMIT), eq(DESCRIPTION_ENRICHMENT_SORT), isNull(), eq(false)))
+            .thenReturn(Flux.empty());
 
-        String description = enrichmentOrchestrator.enrichDescriptionForAiIfNeeded(bookId, detail, null, 50);
+        String description = enrichmentOrchestrator(Optional.of(openLibrary), Optional.of(googleApiFetcher))
+            .enrichDescriptionForAiIfNeeded(ENRICHMENT_BOOK_ID, enrichmentDetail(), SHORT_DESCRIPTION, 50);
 
-        assertThat(description).isNull();
+        assertThat(description).isEqualTo(SHORT_DESCRIPTION);
+        assertThat(openLibrarySubscriptions.get()).isEqualTo(1);
         verify(googleApiFetcher).streamSearchItems(
-            eq("isbn:9781234567890"), eq(6), eq("relevance"), isNull(), eq(false));
+            eq(ENRICHMENT_QUERY), eq(DESCRIPTION_ENRICHMENT_LIMIT), eq(DESCRIPTION_ENRICHMENT_SORT), isNull(), eq(false));
+    }
+
+    @Test
+    void should_ReturnCurrentDescription_When_OpenLibraryIsEmptyAndGoogleFails() {
+        OpenLibraryBookDataService openLibrary = mock(OpenLibraryBookDataService.class);
+        GoogleApiFetcher googleApiFetcher = mock(GoogleApiFetcher.class);
+        IllegalStateException googleFailure = new IllegalStateException("Google Books unavailable");
+        when(openLibrary.queryBooksByEverything(OPEN_LIBRARY_ENRICHMENT_QUERY, DESCRIPTION_ENRICHMENT_SORT, 0, DESCRIPTION_ENRICHMENT_LIMIT))
+            .thenReturn(Flux.empty());
+        configureGoogleFallback(googleApiFetcher);
+        when(googleApiFetcher.streamSearchItems(
+                eq(ENRICHMENT_QUERY), eq(DESCRIPTION_ENRICHMENT_LIMIT), eq(DESCRIPTION_ENRICHMENT_SORT), isNull(), eq(false)))
+            .thenReturn(Flux.error(googleFailure));
+
+        String description = enrichmentOrchestrator(Optional.of(openLibrary), Optional.of(googleApiFetcher))
+            .enrichDescriptionForAiIfNeeded(ENRICHMENT_BOOK_ID, enrichmentDetail(), SHORT_DESCRIPTION, 50);
+
+        assertThat(description).isEqualTo(SHORT_DESCRIPTION);
+        verify(googleApiFetcher).streamSearchItems(
+            eq(ENRICHMENT_QUERY), eq(DESCRIPTION_ENRICHMENT_LIMIT), eq(DESCRIPTION_ENRICHMENT_SORT), isNull(), eq(false));
+    }
+
+    @Test
+    void should_PreserveSecondaryFailure_When_AllProvidersFail() {
+        OpenLibraryBookDataService openLibrary = mock(OpenLibraryBookDataService.class);
+        GoogleApiFetcher googleApiFetcher = mock(GoogleApiFetcher.class);
+        IllegalStateException openLibraryFailure = new IllegalStateException("Open Library unavailable");
+        IllegalStateException googleFailure = new IllegalStateException("Google fallback circuit is open");
+        when(openLibrary.queryBooksByEverything(OPEN_LIBRARY_ENRICHMENT_QUERY, DESCRIPTION_ENRICHMENT_SORT, 0, DESCRIPTION_ENRICHMENT_LIMIT))
+            .thenReturn(Flux.error(openLibraryFailure));
+        configureGoogleFallback(googleApiFetcher);
+        when(googleApiFetcher.streamSearchItems(
+                eq(ENRICHMENT_QUERY), eq(DESCRIPTION_ENRICHMENT_LIMIT), eq(DESCRIPTION_ENRICHMENT_SORT), isNull(), eq(false)))
+            .thenReturn(Flux.error(googleFailure));
+
+        assertThatThrownBy(() -> enrichmentOrchestrator(Optional.of(openLibrary), Optional.of(googleApiFetcher))
+            .enrichDescriptionForAiIfNeeded(ENRICHMENT_BOOK_ID, enrichmentDetail(), SHORT_DESCRIPTION, 50))
+            .isSameAs(openLibraryFailure)
+            .satisfies(failure -> assertThat(failure.getSuppressed()).contains(googleFailure));
+        verify(googleApiFetcher).streamSearchItems(
+            eq(ENRICHMENT_QUERY), eq(DESCRIPTION_ENRICHMENT_LIMIT), eq(DESCRIPTION_ENRICHMENT_SORT), isNull(), eq(false));
+    }
+
+    @Test
+    void should_ReturnCurrentDescription_When_GoogleFallbackIsDisabled() {
+        GoogleApiFetcher googleApiFetcher = mock(GoogleApiFetcher.class);
+        when(googleApiFetcher.isApiKeyAvailable()).thenReturn(false);
+        when(googleApiFetcher.isGoogleFallbackEnabled()).thenReturn(false);
+
+        String description = enrichmentOrchestrator(Optional.empty(), Optional.of(googleApiFetcher))
+            .enrichDescriptionForAiIfNeeded(ENRICHMENT_BOOK_ID, enrichmentDetail(), SHORT_DESCRIPTION, 50);
+
+        assertThat(description).isEqualTo(SHORT_DESCRIPTION);
+    }
+
+    @Test
+    void should_PropagateOpenLibraryFailure_When_GoogleFallbackIsDisabled() {
+        OpenLibraryBookDataService openLibrary = mock(OpenLibraryBookDataService.class);
+        GoogleApiFetcher googleApiFetcher = mock(GoogleApiFetcher.class);
+        IllegalStateException openLibraryFailure = new IllegalStateException("Open Library unavailable");
+        when(openLibrary.queryBooksByEverything(OPEN_LIBRARY_ENRICHMENT_QUERY, DESCRIPTION_ENRICHMENT_SORT, 0, DESCRIPTION_ENRICHMENT_LIMIT))
+            .thenReturn(Flux.error(openLibraryFailure));
+        when(googleApiFetcher.isApiKeyAvailable()).thenReturn(false);
+        when(googleApiFetcher.isGoogleFallbackEnabled()).thenReturn(false);
+
+        assertThatThrownBy(() -> enrichmentOrchestrator(Optional.of(openLibrary), Optional.of(googleApiFetcher))
+            .enrichDescriptionForAiIfNeeded(ENRICHMENT_BOOK_ID, enrichmentDetail(), SHORT_DESCRIPTION, 50))
+            .isSameAs(openLibraryFailure);
+    }
+
+    @Test
+    void should_PropagateAuthenticatedGoogleFailure_When_FallbackCircuitIsOpen() {
+        GoogleApiFetcher googleApiFetcher = mock(GoogleApiFetcher.class);
+        IllegalStateException authenticatedFailure = new IllegalStateException("Google Books unavailable");
+        when(googleApiFetcher.isApiKeyAvailable()).thenReturn(true);
+        when(googleApiFetcher.isGoogleFallbackEnabled()).thenReturn(true);
+        when(googleApiFetcher.isFallbackAllowed()).thenReturn(false);
+        when(googleApiFetcher.streamSearchItems(
+                eq(ENRICHMENT_QUERY), eq(DESCRIPTION_ENRICHMENT_LIMIT), eq(DESCRIPTION_ENRICHMENT_SORT), isNull(), eq(true)))
+            .thenReturn(Flux.error(authenticatedFailure));
+
+        assertThatThrownBy(() -> enrichmentOrchestrator(Optional.empty(), Optional.of(googleApiFetcher))
+            .enrichDescriptionForAiIfNeeded(ENRICHMENT_BOOK_ID, enrichmentDetail(), SHORT_DESCRIPTION, 50))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("fallback is unavailable")
+            .hasCause(authenticatedFailure);
+        verify(googleApiFetcher, never()).streamSearchItems(
+            eq(ENRICHMENT_QUERY), eq(DESCRIPTION_ENRICHMENT_LIMIT), eq(DESCRIPTION_ENRICHMENT_SORT), isNull(), eq(false));
+    }
+
+    @Test
+    void should_RetryOpenLibraryOnce_When_TransientFailureThenEmptyResult() {
+        OpenLibraryBookDataService openLibrary = mock(OpenLibraryBookDataService.class);
+        WebClientResponseException transientFailure = providerFailure(HttpStatus.SERVICE_UNAVAILABLE);
+        AtomicInteger openLibrarySubscriptions = new AtomicInteger();
+        when(openLibrary.queryBooksByEverything(OPEN_LIBRARY_ENRICHMENT_QUERY, DESCRIPTION_ENRICHMENT_SORT, 0, DESCRIPTION_ENRICHMENT_LIMIT))
+            .thenReturn(Flux.<Book>defer(() -> openLibrarySubscriptions.incrementAndGet() == 1
+                ? Flux.error(transientFailure)
+                : Flux.empty()));
+
+        String description = enrichmentOrchestrator(Optional.of(openLibrary), Optional.empty())
+            .enrichDescriptionForAiIfNeeded(ENRICHMENT_BOOK_ID, enrichmentDetail(), SHORT_DESCRIPTION, 50);
+
+        assertThat(description).isEqualTo(SHORT_DESCRIPTION);
+        assertThat(openLibrarySubscriptions.get()).isEqualTo(2);
+    }
+
+    @Test
+    void should_PreserveTransientFailure_When_OpenLibraryOutagePersists() {
+        OpenLibraryBookDataService openLibrary = mock(OpenLibraryBookDataService.class);
+        WebClientResponseException transientFailure = providerFailure(HttpStatus.SERVICE_UNAVAILABLE);
+        AtomicInteger openLibrarySubscriptions = new AtomicInteger();
+        when(openLibrary.queryBooksByEverything(OPEN_LIBRARY_ENRICHMENT_QUERY, DESCRIPTION_ENRICHMENT_SORT, 0, DESCRIPTION_ENRICHMENT_LIMIT))
+            .thenReturn(Flux.<Book>defer(() -> {
+                openLibrarySubscriptions.incrementAndGet();
+                return Flux.error(transientFailure);
+            }));
+
+        assertThatThrownBy(() -> enrichmentOrchestrator(Optional.of(openLibrary), Optional.empty())
+            .enrichDescriptionForAiIfNeeded(ENRICHMENT_BOOK_ID, enrichmentDetail(), SHORT_DESCRIPTION, 50))
+            .isSameAs(transientFailure);
+        assertThat(openLibrarySubscriptions.get()).isEqualTo(2);
+    }
+
+    @Test
+    void should_MapOpenLibraryTimeout_When_RetryBudgetIsExhausted() {
+        OpenLibraryBookDataService openLibrary = mock(OpenLibraryBookDataService.class);
+        TimeoutException timeoutFailure = new TimeoutException("Open Library timed out");
+        AtomicInteger openLibrarySubscriptions = new AtomicInteger();
+        when(openLibrary.queryBooksByEverything(OPEN_LIBRARY_ENRICHMENT_QUERY, DESCRIPTION_ENRICHMENT_SORT, 0, DESCRIPTION_ENRICHMENT_LIMIT))
+            .thenReturn(Flux.<Book>defer(() -> {
+                openLibrarySubscriptions.incrementAndGet();
+                return Flux.error(timeoutFailure);
+            }));
+
+        assertThatThrownBy(() -> enrichmentOrchestrator(Optional.of(openLibrary), Optional.empty())
+            .enrichDescriptionForAiIfNeeded(ENRICHMENT_BOOK_ID, enrichmentDetail(), SHORT_DESCRIPTION, 50))
+            .isInstanceOf(IllegalStateException.class)
+            .hasCause(timeoutFailure);
+        assertThat(openLibrarySubscriptions.get()).isEqualTo(2);
     }
 
     @Test
@@ -302,5 +436,40 @@ class BookDataOrchestratorPersistenceScenariosTest {
                 eq(ApplicationConstants.Provider.GOOGLE_BOOKS),
                 any()
         )).thenReturn(bookId);
+    }
+
+    private BookDataOrchestrator enrichmentOrchestrator(Optional<OpenLibraryBookDataService> openLibrary,
+                                                         Optional<GoogleApiFetcher> googleApiFetcher) {
+        return new BookDataOrchestrator(
+            bookSearchService,
+            postgresBookRepository,
+            batchPersistenceService,
+            openLibrary,
+            googleApiFetcher,
+            Optional.of(googleBooksMapper),
+            bookUpsertService
+        );
+    }
+
+    private void configureGoogleFallback(GoogleApiFetcher googleApiFetcher) {
+        when(googleApiFetcher.isApiKeyAvailable()).thenReturn(false);
+        when(googleApiFetcher.isGoogleFallbackEnabled()).thenReturn(true);
+    }
+
+    private BookDetail enrichmentDetail() {
+        return new BookDetail(
+            ENRICHMENT_BOOK_ID.toString(), "canonical-title", "Canonical title", "", "Canonical publisher",
+            LocalDate.of(2020, 1, 1), "en", 250, List.of("Canonical author"), List.of("Fiction"),
+            "https://example.com/cover.jpg", "covers/canonical.jpg", "https://example.com/fallback.jpg",
+            "https://example.com/thumbnail.jpg", 600, 900, true, "GOOGLE_BOOKS", 4.0, 10,
+            "1234567890", ENRICHMENT_ISBN_13, "https://example.com/preview", "https://example.com/info",
+            java.util.Map.of("source", "test"), List.of()
+        );
+    }
+
+    private WebClientResponseException providerFailure(HttpStatus status) {
+        return WebClientResponseException.create(
+            status.value(), "provider failure", HttpHeaders.EMPTY, new byte[0], StandardCharsets.UTF_8
+        );
     }
 }

--- a/src/test/java/net/findmybook/service/BookDataOrchestratorPersistenceScenariosTest.java
+++ b/src/test/java/net/findmybook/service/BookDataOrchestratorPersistenceScenariosTest.java
@@ -34,6 +34,7 @@ import reactor.core.publisher.Flux;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -52,10 +53,6 @@ class BookDataOrchestratorPersistenceScenariosTest {
 
     private static final UUID ENRICHMENT_BOOK_ID = UUID.fromString("019cb5e1-d100-719e-8194-f6f5af0af7a8");
     private static final String ENRICHMENT_ISBN_13 = "9781234567890";
-    private static final String ENRICHMENT_QUERY = "isbn:" + ENRICHMENT_ISBN_13;
-    private static final String OPEN_LIBRARY_ENRICHMENT_QUERY = ENRICHMENT_ISBN_13;
-    private static final String DESCRIPTION_ENRICHMENT_SORT = "relevance";
-    private static final int DESCRIPTION_ENRICHMENT_LIMIT = 6;
     private static final String SHORT_DESCRIPTION = "short description";
 
     @Mock
@@ -197,14 +194,14 @@ class BookDataOrchestratorPersistenceScenariosTest {
         OpenLibraryBookDataService openLibrary = mock(OpenLibraryBookDataService.class);
         GoogleApiFetcher googleApiFetcher = mock(GoogleApiFetcher.class);
         AtomicInteger openLibrarySubscriptions = new AtomicInteger();
-        when(openLibrary.queryBooksByEverything(OPEN_LIBRARY_ENRICHMENT_QUERY, DESCRIPTION_ENRICHMENT_SORT, 0, DESCRIPTION_ENRICHMENT_LIMIT))
+        when(openLibrary.queryBooksByEverything(anyString(), anyString(), eq(0), anyInt()))
             .thenReturn(Flux.<Book>defer(() -> {
                 openLibrarySubscriptions.incrementAndGet();
                 return Flux.empty();
             }));
         configureGoogleFallback(googleApiFetcher);
         when(googleApiFetcher.streamSearchItems(
-                eq(ENRICHMENT_QUERY), eq(DESCRIPTION_ENRICHMENT_LIMIT), eq(DESCRIPTION_ENRICHMENT_SORT), isNull(), eq(false)))
+                anyString(), anyInt(), anyString(), isNull(), eq(false)))
             .thenReturn(Flux.empty());
 
         String description = enrichmentOrchestrator(Optional.of(openLibrary), Optional.of(googleApiFetcher))
@@ -213,27 +210,26 @@ class BookDataOrchestratorPersistenceScenariosTest {
         assertThat(description).isEqualTo(SHORT_DESCRIPTION);
         assertThat(openLibrarySubscriptions.get()).isEqualTo(1);
         verify(googleApiFetcher).streamSearchItems(
-            eq(ENRICHMENT_QUERY), eq(DESCRIPTION_ENRICHMENT_LIMIT), eq(DESCRIPTION_ENRICHMENT_SORT), isNull(), eq(false));
+            anyString(), anyInt(), anyString(), isNull(), eq(false));
     }
 
     @Test
-    void should_ReturnCurrentDescription_When_OpenLibraryIsEmptyAndGoogleFails() {
+    void should_PropagateGoogleFailure_When_OpenLibraryReturnsNoCandidates() {
         OpenLibraryBookDataService openLibrary = mock(OpenLibraryBookDataService.class);
         GoogleApiFetcher googleApiFetcher = mock(GoogleApiFetcher.class);
         IllegalStateException googleFailure = new IllegalStateException("Google Books unavailable");
-        when(openLibrary.queryBooksByEverything(OPEN_LIBRARY_ENRICHMENT_QUERY, DESCRIPTION_ENRICHMENT_SORT, 0, DESCRIPTION_ENRICHMENT_LIMIT))
+        when(openLibrary.queryBooksByEverything(anyString(), anyString(), eq(0), anyInt()))
             .thenReturn(Flux.empty());
         configureGoogleFallback(googleApiFetcher);
         when(googleApiFetcher.streamSearchItems(
-                eq(ENRICHMENT_QUERY), eq(DESCRIPTION_ENRICHMENT_LIMIT), eq(DESCRIPTION_ENRICHMENT_SORT), isNull(), eq(false)))
+                anyString(), anyInt(), anyString(), isNull(), eq(false)))
             .thenReturn(Flux.error(googleFailure));
 
-        String description = enrichmentOrchestrator(Optional.of(openLibrary), Optional.of(googleApiFetcher))
-            .enrichDescriptionForAiIfNeeded(ENRICHMENT_BOOK_ID, enrichmentDetail(), SHORT_DESCRIPTION, 50);
-
-        assertThat(description).isEqualTo(SHORT_DESCRIPTION);
+        assertThatThrownBy(() -> enrichmentOrchestrator(Optional.of(openLibrary), Optional.of(googleApiFetcher))
+            .enrichDescriptionForAiIfNeeded(ENRICHMENT_BOOK_ID, enrichmentDetail(), SHORT_DESCRIPTION, 50))
+            .isSameAs(googleFailure);
         verify(googleApiFetcher).streamSearchItems(
-            eq(ENRICHMENT_QUERY), eq(DESCRIPTION_ENRICHMENT_LIMIT), eq(DESCRIPTION_ENRICHMENT_SORT), isNull(), eq(false));
+            anyString(), anyInt(), anyString(), isNull(), eq(false));
     }
 
     @Test
@@ -241,20 +237,29 @@ class BookDataOrchestratorPersistenceScenariosTest {
         OpenLibraryBookDataService openLibrary = mock(OpenLibraryBookDataService.class);
         GoogleApiFetcher googleApiFetcher = mock(GoogleApiFetcher.class);
         IllegalStateException openLibraryFailure = new IllegalStateException("Open Library unavailable");
-        IllegalStateException googleFailure = new IllegalStateException("Google fallback circuit is open");
-        when(openLibrary.queryBooksByEverything(OPEN_LIBRARY_ENRICHMENT_QUERY, DESCRIPTION_ENRICHMENT_SORT, 0, DESCRIPTION_ENRICHMENT_LIMIT))
+        IllegalStateException authenticatedFailure = new IllegalStateException("Authenticated Google Books unavailable");
+        IllegalStateException fallbackFailure = new IllegalStateException("Unauthenticated Google Books unavailable");
+        when(openLibrary.queryBooksByEverything(anyString(), anyString(), eq(0), anyInt()))
             .thenReturn(Flux.error(openLibraryFailure));
-        configureGoogleFallback(googleApiFetcher);
+        when(googleApiFetcher.isApiKeyAvailable()).thenReturn(true);
+        when(googleApiFetcher.isGoogleFallbackEnabled()).thenReturn(true);
+        when(googleApiFetcher.isFallbackAllowed()).thenReturn(true);
         when(googleApiFetcher.streamSearchItems(
-                eq(ENRICHMENT_QUERY), eq(DESCRIPTION_ENRICHMENT_LIMIT), eq(DESCRIPTION_ENRICHMENT_SORT), isNull(), eq(false)))
-            .thenReturn(Flux.error(googleFailure));
+                anyString(), anyInt(), anyString(), isNull(), eq(true)))
+            .thenReturn(Flux.error(authenticatedFailure));
+        when(googleApiFetcher.streamSearchItems(
+                anyString(), anyInt(), anyString(), isNull(), eq(false)))
+            .thenReturn(Flux.error(fallbackFailure));
 
         assertThatThrownBy(() -> enrichmentOrchestrator(Optional.of(openLibrary), Optional.of(googleApiFetcher))
             .enrichDescriptionForAiIfNeeded(ENRICHMENT_BOOK_ID, enrichmentDetail(), SHORT_DESCRIPTION, 50))
             .isSameAs(openLibraryFailure)
-            .satisfies(failure -> assertThat(failure.getSuppressed()).contains(googleFailure));
+            .satisfies(failure -> {
+                assertThat(failure.getSuppressed()).contains(authenticatedFailure);
+                assertThat(authenticatedFailure.getSuppressed()).contains(fallbackFailure);
+            });
         verify(googleApiFetcher).streamSearchItems(
-            eq(ENRICHMENT_QUERY), eq(DESCRIPTION_ENRICHMENT_LIMIT), eq(DESCRIPTION_ENRICHMENT_SORT), isNull(), eq(false));
+            anyString(), anyInt(), anyString(), isNull(), eq(false));
     }
 
     @Test
@@ -274,7 +279,7 @@ class BookDataOrchestratorPersistenceScenariosTest {
         OpenLibraryBookDataService openLibrary = mock(OpenLibraryBookDataService.class);
         GoogleApiFetcher googleApiFetcher = mock(GoogleApiFetcher.class);
         IllegalStateException openLibraryFailure = new IllegalStateException("Open Library unavailable");
-        when(openLibrary.queryBooksByEverything(OPEN_LIBRARY_ENRICHMENT_QUERY, DESCRIPTION_ENRICHMENT_SORT, 0, DESCRIPTION_ENRICHMENT_LIMIT))
+        when(openLibrary.queryBooksByEverything(anyString(), anyString(), eq(0), anyInt()))
             .thenReturn(Flux.error(openLibraryFailure));
         when(googleApiFetcher.isApiKeyAvailable()).thenReturn(false);
         when(googleApiFetcher.isGoogleFallbackEnabled()).thenReturn(false);
@@ -292,7 +297,7 @@ class BookDataOrchestratorPersistenceScenariosTest {
         when(googleApiFetcher.isGoogleFallbackEnabled()).thenReturn(true);
         when(googleApiFetcher.isFallbackAllowed()).thenReturn(false);
         when(googleApiFetcher.streamSearchItems(
-                eq(ENRICHMENT_QUERY), eq(DESCRIPTION_ENRICHMENT_LIMIT), eq(DESCRIPTION_ENRICHMENT_SORT), isNull(), eq(true)))
+                anyString(), anyInt(), anyString(), isNull(), eq(true)))
             .thenReturn(Flux.error(authenticatedFailure));
 
         assertThatThrownBy(() -> enrichmentOrchestrator(Optional.empty(), Optional.of(googleApiFetcher))
@@ -301,7 +306,7 @@ class BookDataOrchestratorPersistenceScenariosTest {
             .hasMessageContaining("fallback is unavailable")
             .hasCause(authenticatedFailure);
         verify(googleApiFetcher, never()).streamSearchItems(
-            eq(ENRICHMENT_QUERY), eq(DESCRIPTION_ENRICHMENT_LIMIT), eq(DESCRIPTION_ENRICHMENT_SORT), isNull(), eq(false));
+            anyString(), anyInt(), anyString(), isNull(), eq(false));
     }
 
     @Test
@@ -309,7 +314,7 @@ class BookDataOrchestratorPersistenceScenariosTest {
         OpenLibraryBookDataService openLibrary = mock(OpenLibraryBookDataService.class);
         WebClientResponseException transientFailure = providerFailure(HttpStatus.SERVICE_UNAVAILABLE);
         AtomicInteger openLibrarySubscriptions = new AtomicInteger();
-        when(openLibrary.queryBooksByEverything(OPEN_LIBRARY_ENRICHMENT_QUERY, DESCRIPTION_ENRICHMENT_SORT, 0, DESCRIPTION_ENRICHMENT_LIMIT))
+        when(openLibrary.queryBooksByEverything(anyString(), anyString(), eq(0), anyInt()))
             .thenReturn(Flux.<Book>defer(() -> openLibrarySubscriptions.incrementAndGet() == 1
                 ? Flux.error(transientFailure)
                 : Flux.empty()));
@@ -326,7 +331,7 @@ class BookDataOrchestratorPersistenceScenariosTest {
         OpenLibraryBookDataService openLibrary = mock(OpenLibraryBookDataService.class);
         WebClientResponseException transientFailure = providerFailure(HttpStatus.SERVICE_UNAVAILABLE);
         AtomicInteger openLibrarySubscriptions = new AtomicInteger();
-        when(openLibrary.queryBooksByEverything(OPEN_LIBRARY_ENRICHMENT_QUERY, DESCRIPTION_ENRICHMENT_SORT, 0, DESCRIPTION_ENRICHMENT_LIMIT))
+        when(openLibrary.queryBooksByEverything(anyString(), anyString(), eq(0), anyInt()))
             .thenReturn(Flux.<Book>defer(() -> {
                 openLibrarySubscriptions.incrementAndGet();
                 return Flux.error(transientFailure);
@@ -343,7 +348,7 @@ class BookDataOrchestratorPersistenceScenariosTest {
         OpenLibraryBookDataService openLibrary = mock(OpenLibraryBookDataService.class);
         TimeoutException timeoutFailure = new TimeoutException("Open Library timed out");
         AtomicInteger openLibrarySubscriptions = new AtomicInteger();
-        when(openLibrary.queryBooksByEverything(OPEN_LIBRARY_ENRICHMENT_QUERY, DESCRIPTION_ENRICHMENT_SORT, 0, DESCRIPTION_ENRICHMENT_LIMIT))
+        when(openLibrary.queryBooksByEverything(anyString(), anyString(), eq(0), anyInt()))
             .thenReturn(Flux.<Book>defer(() -> {
                 openLibrarySubscriptions.incrementAndGet();
                 return Flux.error(timeoutFailure);

--- a/src/test/java/net/findmybook/service/SearchPaginationServiceFallbackTest.java
+++ b/src/test/java/net/findmybook/service/SearchPaginationServiceFallbackTest.java
@@ -34,11 +34,9 @@ class SearchPaginationServiceFallbackTest extends AbstractSearchPaginationServic
 
         when(bookSearchService.searchBooks("fallback", 24)).thenReturn(List.of());
         when(googleApiFetcher.isApiKeyAvailable()).thenReturn(true);
+        when(googleApiFetcher.isGoogleFallbackEnabled()).thenReturn(true);
         when(googleApiFetcher.streamSearchItems("fallback", 24, "newest", null, true))
             .thenReturn(Flux.just(googleVolumeNode("google-vol-1", "Fallback Title")));
-        when(googleApiFetcher.streamSearchItems("fallback", 24, "newest", null, false))
-            .thenReturn(Flux.empty());
-        when(googleApiFetcher.isFallbackAllowed()).thenReturn(true);
 
         BookAggregate aggregate = BookAggregate.builder()
             .title("Fallback Title")
@@ -74,6 +72,7 @@ class SearchPaginationServiceFallbackTest extends AbstractSearchPaginationServic
         Book openLibraryTwo = buildOpenLibraryCandidate("OL-PRIMARY-2", "Open Primary Two");
 
         when(bookSearchService.searchBooks("fallback", 2)).thenReturn(List.of());
+        when(googleApiFetcher.isGoogleFallbackEnabled()).thenReturn(false);
         when(openLibraryBookDataService.queryBooksByEverything(eq("fallback"), anyString(), eq(0), eq(2)))
             .thenReturn(Flux.just(openLibraryOne, openLibraryTwo));
 
@@ -84,7 +83,8 @@ class SearchPaginationServiceFallbackTest extends AbstractSearchPaginationServic
         assertThat(page.totalUnique()).isEqualTo(2);
         assertThat(page.pageItems()).extracting(Book::getId).containsExactly("OL-PRIMARY-1");
         verify(openLibraryBookDataService).queryBooksByEverything("fallback", "newest", 0, 2);
-        verifyNoInteractions(googleApiFetcher);
+        verify(googleApiFetcher, never())
+            .streamSearchItems(anyString(), anyInt(), anyString(), any(), anyBoolean());
         verifyNoInteractions(googleBooksMapper);
     }
 
@@ -97,9 +97,9 @@ class SearchPaginationServiceFallbackTest extends AbstractSearchPaginationServic
         when(openLibraryBookDataService.queryBooksByEverything(eq("fallback"), anyString(), eq(0), eq(4)))
             .thenReturn(Flux.just(openLibraryOnly));
         when(googleApiFetcher.isApiKeyAvailable()).thenReturn(true);
+        when(googleApiFetcher.isGoogleFallbackEnabled()).thenReturn(false);
         when(googleApiFetcher.streamSearchItems("fallback", 4, "newest", null, true))
             .thenReturn(Flux.just(googleVolumeNode("google-vol-2", "Google Secondary")));
-        when(googleApiFetcher.isFallbackAllowed()).thenReturn(false);
         when(googleBooksMapper.map(argThat(node -> "google-vol-2".equals(node.path("id").asString("")))))
             .thenReturn(googleAggregate("GOOGLE-SECONDARY-1", "Google Secondary", "https://example.test/google-secondary.jpg"));
 
@@ -135,9 +135,9 @@ class SearchPaginationServiceFallbackTest extends AbstractSearchPaginationServic
         when(openLibraryBookDataService.queryBooksByEverything(eq("0061120081"), anyString(), eq(0), eq(4)))
             .thenReturn(Flux.just(openLibraryCandidate));
         when(googleApiFetcher.isApiKeyAvailable()).thenReturn(true);
+        when(googleApiFetcher.isGoogleFallbackEnabled()).thenReturn(false);
         when(googleApiFetcher.streamSearchItems("0061120081", 4, "newest", null, true))
             .thenReturn(Flux.just(googleVolumeNode("google-vol-isbn", "Provider Secondary Title")));
-        when(googleApiFetcher.isFallbackAllowed()).thenReturn(false);
         when(googleBooksMapper.map(argThat(node -> "google-vol-isbn".equals(node.path("id").asString("")))))
             .thenReturn(googleCandidate);
 
@@ -172,9 +172,9 @@ class SearchPaginationServiceFallbackTest extends AbstractSearchPaginationServic
         when(openLibraryBookDataService.queryBooksByEverything(eq("0061120081"), anyString(), eq(0), eq(4)))
             .thenReturn(Flux.just(openLibraryCandidate));
         when(googleApiFetcher.isApiKeyAvailable()).thenReturn(true);
+        when(googleApiFetcher.isGoogleFallbackEnabled()).thenReturn(false);
         when(googleApiFetcher.streamSearchItems("0061120081", 4, "newest", null, true))
             .thenReturn(Flux.just(googleVolumeNode("google-vol-title-author", "To Kill a Mockingbird")));
-        when(googleApiFetcher.isFallbackAllowed()).thenReturn(false);
         when(googleBooksMapper.map(argThat(node -> "google-vol-title-author".equals(node.path("id").asString("")))))
             .thenReturn(googleCandidate);
 
@@ -210,9 +210,9 @@ class SearchPaginationServiceFallbackTest extends AbstractSearchPaginationServic
         when(openLibraryBookDataService.queryBooksByEverything(eq("same title"), anyString(), eq(0), eq(4)))
             .thenReturn(Flux.just(openLibraryCandidate));
         when(googleApiFetcher.isApiKeyAvailable()).thenReturn(true);
+        when(googleApiFetcher.isGoogleFallbackEnabled()).thenReturn(false);
         when(googleApiFetcher.streamSearchItems("same title", 4, "newest", null, true))
             .thenReturn(Flux.just(googleVolumeNode("google-vol-different-isbn", "Same Title")));
-        when(googleApiFetcher.isFallbackAllowed()).thenReturn(false);
         when(googleBooksMapper.map(argThat(node -> "google-vol-different-isbn".equals(node.path("id").asString("")))))
             .thenReturn(googleCandidate);
 
@@ -250,6 +250,7 @@ class SearchPaginationServiceFallbackTest extends AbstractSearchPaginationServic
         duplicateFallback.setAuthors(List.of("John Grisham"));
         Book distinctFallback = buildOpenLibraryCandidate("OL37836170W", "Camino Ghosts");
         distinctFallback.setAuthors(List.of("John Grisham"));
+        when(googleApiFetcher.isGoogleFallbackEnabled()).thenReturn(false);
         when(openLibraryBookDataService.queryBooksByEverything(eq("john grisham"), anyString(), eq(0), eq(4)))
             .thenReturn(Flux.just(duplicateFallback, distinctFallback));
 
@@ -273,6 +274,7 @@ class SearchPaginationServiceFallbackTest extends AbstractSearchPaginationServic
         openLibraryCandidate.setLanguage("eng");
 
         when(bookSearchService.searchBooks("john grisham", 2)).thenReturn(List.of());
+        when(googleApiFetcher.isGoogleFallbackEnabled()).thenReturn(false);
         when(openLibraryBookDataService.queryBooksByEverything(eq("john grisham"), anyString(), eq(0), eq(2)))
             .thenReturn(Flux.just(openLibraryCandidate));
 
@@ -297,9 +299,9 @@ class SearchPaginationServiceFallbackTest extends AbstractSearchPaginationServic
         when(openLibraryBookDataService.queryBooksByEverything(eq("fallback"), anyString(), eq(0), eq(4)))
             .thenReturn(Flux.just(openLibraryOnly));
         when(googleApiFetcher.isApiKeyAvailable()).thenReturn(true);
+        when(googleApiFetcher.isGoogleFallbackEnabled()).thenReturn(false);
         when(googleApiFetcher.streamSearchItems("fallback", 4, "newest", null, true))
             .thenReturn(Flux.error(new IllegalStateException("rate limited")));
-        when(googleApiFetcher.isFallbackAllowed()).thenReturn(false);
 
         SearchPaginationService openLibraryPrimaryService = fallbackEnabledService();
         SearchPaginationService.SearchPage page = openLibraryPrimaryService.search(searchRequest("fallback", 0, 2, "newest")).block();
@@ -329,6 +331,7 @@ class SearchPaginationServiceFallbackTest extends AbstractSearchPaginationServic
         openLibraryCandidate.setCoverImageWidth(600);
         openLibraryCandidate.setCoverImageHeight(900);
         openLibraryCandidate.setIsCoverHighResolution(true);
+        when(googleApiFetcher.isGoogleFallbackEnabled()).thenReturn(false);
         when(openLibraryBookDataService.queryBooksByEverything(eq("john grisham"), anyString(), eq(0), eq(6)))
             .thenReturn(Flux.just(openLibraryCandidate));
 
@@ -361,6 +364,7 @@ class SearchPaginationServiceFallbackTest extends AbstractSearchPaginationServic
             )
         ));
 
+        when(googleApiFetcher.isGoogleFallbackEnabled()).thenReturn(false);
         when(openLibraryBookDataService.queryBooksByEverything(eq("john grisham"), anyString()))
             .thenReturn(Flux.never());
 
@@ -386,7 +390,7 @@ class SearchPaginationServiceFallbackTest extends AbstractSearchPaginationServic
             .thenReturn(Flux.empty());
 
         when(googleApiFetcher.isApiKeyAvailable()).thenReturn(false);
-        when(googleApiFetcher.isFallbackAllowed()).thenReturn(true);
+        when(googleApiFetcher.isGoogleFallbackEnabled()).thenReturn(true);
         when(googleApiFetcher.streamSearchItems("distributed systems", 24, "relevance", null, false))
             .thenReturn(Flux.just(googleVolumeNode("google-vol-unauth", "Pragmatic Distributed Systems")));
         when(googleBooksMapper.map(argThat(node -> "google-vol-unauth".equals(node.path("id").asString("")))))

--- a/src/test/java/net/findmybook/service/SearchPaginationServiceRealtimeTest.java
+++ b/src/test/java/net/findmybook/service/SearchPaginationServiceRealtimeTest.java
@@ -32,9 +32,9 @@ class SearchPaginationServiceRealtimeTest extends AbstractSearchPaginationServic
         stubCompletePostgresPage("distributed systems", 24, 12, null);
 
         when(googleApiFetcher.isApiKeyAvailable()).thenReturn(true);
+        when(googleApiFetcher.isGoogleFallbackEnabled()).thenReturn(false);
         when(googleApiFetcher.streamSearchItems("distributed systems", 12, "relevance", null, true))
             .thenReturn(Flux.just(googleVolumeNode("google-vol-realtime", "Realtime Systems")));
-        when(googleApiFetcher.isFallbackAllowed()).thenReturn(false);
         when(googleBooksMapper.map(argThat(node -> "google-vol-realtime".equals(node.path("id").asString("")))))
             .thenReturn(googleAggregate("google-vol-realtime", "Realtime Systems", "https://example.test/realtime.jpg"));
         when(openLibraryBookDataService.queryBooksByEverything(eq("distributed systems"), anyString(), eq(0), eq(24)))
@@ -77,6 +77,7 @@ class SearchPaginationServiceRealtimeTest extends AbstractSearchPaginationServic
         stubCompletePostgresPage("distributed systems", 24, 12, LocalDate.of(2024, 1, 1));
 
         when(googleApiFetcher.isApiKeyAvailable()).thenReturn(true);
+        when(googleApiFetcher.isGoogleFallbackEnabled()).thenReturn(false);
         when(googleApiFetcher.streamSearchItems("distributed systems", 12, "relevance", null, true))
             .thenReturn(Flux.just(googleVolumeNode("google-vol-filtered", "Filtered Systems")));
         when(googleBooksMapper.map(argThat(node -> "google-vol-filtered".equals(node.path("id").asString("")))))
@@ -125,6 +126,7 @@ class SearchPaginationServiceRealtimeTest extends AbstractSearchPaginationServic
         stubCompletePostgresPage("distributed systems", 200, 100, null);
 
         when(googleApiFetcher.isApiKeyAvailable()).thenReturn(true);
+        when(googleApiFetcher.isGoogleFallbackEnabled()).thenReturn(false);
         when(googleApiFetcher.streamSearchItems("distributed systems", 20, "relevance", null, true))
             .thenReturn(Flux.just(googleVolumeNode("google-vol-clamped", "Realtime Systems")));
         when(googleBooksMapper.map(argThat(node -> "google-vol-clamped".equals(node.path("id").asString("")))))


### PR DESCRIPTION
## Summary
Invalid AI configuration now fails during startup, provider outages remain observable through multi-tier fallback, and global sitemap aggregates avoid PostgreSQL shared-memory pressure. The release also aligns operator and API documentation with deployed behavior.

## Changes by Category

### Bug Fixes
- **Fail-fast AI configuration**: Invalid `OPENAI_REASONING_EFFORT` values stop startup with the accepted runtime tokens, while mixed-case valid values normalize consistently (`OpenAiProperties.setReasoningEffort`)
- **Observable provider outages**: Empty provider results remain valid, but Google or Open Library failures can no longer disappear behind an empty sibling result; authenticated and fallback Google failures retain their complete cause chain (`BookDataOrchestrator.fetchDescriptionEnrichmentCandidates`, `GoogleExternalSearchFlow.streamAuthenticatedThenFallback`)
- **Bounded external reads**: Google and Open Library clients inherit the shared five-second connector read timeout, while description enrichment applies its own eight-second total deadline and one bounded transient Open Library retry (`application.yml`, `BookDataOrchestrator.collectWithDescriptionEnrichmentDeadline`)
- **Safe sitemap aggregation**: Book and author page metadata plus both dataset fingerprints disable PostgreSQL gather workers inside read-only transactions before global aggregates (`SitemapRepository`)

### Documentation
- **Operator guidance**: Reasoning-effort validation, `S3_ENABLED` scope, SSE `degenerate_content`, and the Editions card-grid terminology now match runtime behavior (`.env.example`, `docs/configuration.md`, `docs/api.md`, `docs/edition_clustering.md`)
- **Repository policy**: The source-file ceiling is 500 lines, with touched legacy seams tracked below (`AGENTS.md`)

### Testing
- **Configuration and wire contracts**: Tests consume the one runtime-owned reasoning token inventory and assert stable bind failures plus serialized gateway requests (`OpenAiPropertiesTest`, `BookSeoMetadataClientWireTest`)
- **Provider failure matrix**: Tests cover empty results, total deadlines, transient retries, blocked fallback, and complete multi-provider failure context (`BookDataOrchestratorPersistenceScenariosTest`)
- **Sitemap query guard**: Tests verify the transaction-local gather-worker setting precedes every protected aggregate (`SitemapBookLastModifiedSqlSupportTest`)

## Legacy file split plan
- **OpenLibraryBookDataService (769 lines)**: Before its next behavior addition, separate search request execution from work/edition hydration, keeping the existing service as the orchestration boundary and migrating one cohesive call family at a time after explicit file-creation approval.
- **GoogleApiFetcher (487 lines)**: Before further growth, separate volume-by-ID retrieval from paginated search execution at the external-provider boundary, retaining the existing circuit and request-monitor owners.
- **BookDataOrchestratorPersistenceScenariosTest (480 lines)**: Move the enrichment failure matrix into a focused test owner before adding more persistence scenarios, after explicit file-creation approval.

## Test plan
- [x] Run focused backend tests for every changed configuration, provider, and sitemap path
- [x] Run pre-push Svelte checks, Oxlint, Vitest, and the full Gradle test lane
- [ ] Verify the exact deployed `dev` revision, readiness, browser workflows, and backing APIs

## Breaking changes
Invalid `OPENAI_REASONING_EFFORT` values now fail startup instead of allowing every generation call to fail later. Valid configurations are unchanged.

## Related issues
None.