### PR TITLE
fix(migrations): production-scale author contraction

### DIFF
--- a/migrations/53_contract_canonical_author_identity.sql
+++ b/migrations/53_contract_canonical_author_identity.sql
@@ -14,7 +14,7 @@
 BEGIN;
 
 SET LOCAL lock_timeout = '5s';
-SET LOCAL statement_timeout = '60s';
+SET LOCAL statement_timeout = '15min';
 
 SELECT pg_advisory_xact_lock(
   hashtextextended('findmybook.author-contract-rollout', 0)
@@ -54,6 +54,14 @@ ranked_authors AS (
   FROM valid_authors
 )
 SELECT * FROM ranked_authors;
+
+CREATE UNIQUE INDEX canonical_author_upgrade_id_idx
+  ON canonical_author_upgrade (id);
+
+CREATE INDEX canonical_author_upgrade_canonical_author_id_idx
+  ON canonical_author_upgrade (canonical_author_id);
+
+ANALYZE canonical_author_upgrade;
 
 DO $$
 BEGIN

--- a/src/test/java/net/findmybook/service/BookAuthorUpsertIntegrationTest.java
+++ b/src/test/java/net/findmybook/service/BookAuthorUpsertIntegrationTest.java
@@ -190,8 +190,17 @@ class BookAuthorUpsertIntegrationTest {
             "drop function if exists public.generate_slug(text, text)"
         );
         assertThat(callerContract).contains(
+            "SET LOCAL statement_timeout = '15min'",
             "DROP FUNCTION IF EXISTS public.ensure_unique_slug(text)",
             "DROP FUNCTION IF EXISTS public.generate_slug(text, text)"
+        );
+        assertThat(callerContract).containsSubsequence(
+            "CREATE UNIQUE INDEX canonical_author_upgrade_id_idx\n  ON canonical_author_upgrade (id);",
+            "CREATE INDEX canonical_author_upgrade_canonical_author_id_idx\n"
+                + "  ON canonical_author_upgrade (canonical_author_id);",
+            "ANALYZE canonical_author_upgrade;",
+            "FROM public.authors AS authors",
+            "LEFT JOIN canonical_author_upgrade AS upgrade ON upgrade.id = authors.id"
         );
     }
     @Test


### PR DESCRIPTION
## Summary
Prevent the canonical author migration from timing out on production-sized identity sets.

## Changes by Category

### Bug Fixes
- **Author contraction**: Index and analyze the temporary canonical identity relation before validation and allow bounded full-table maintenance work.

### Testing
- **Migration regression**: Guard exact index definitions and their placement before the failing join.

## Test plan
- [x] Run the PostgreSQL author-upsert integration suite
- [x] Run the full pre-push frontend and backend gates
- [ ] Apply migration 53 under the quiesced production maintenance window

## Breaking changes
None.

## Related issues
Follow-up to #122.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a quiesced, full-table author identity migration under table locks; behavior is unchanged except performance and timeout bounds, but failed or partial runs still block production author writes until rollback or success.
> 
> **Overview**
> **Migration 53** is tuned so canonical author contraction can finish on large production datasets instead of hitting the old **60s** statement limit.
> 
> The transaction **`statement_timeout`** is raised to **`15min`**, matching other long-running maintenance migrations. After building the temp **`canonical_author_upgrade`** table, the migration now creates a **unique index on `id`**, an index on **`canonical_author_id`**, runs **`ANALYZE`**, and only then runs the **`authors` LEFT JOIN** empty-identity check so the planner can use indexed joins.
> 
> **`BookAuthorUpsertIntegrationTest`** asserts the new timeout, index DDL, **`ANALYZE`**, and that those steps appear **before** the validation join in the migration source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c6814ffada5f6d184ee0aa6cec9c82a9e65c75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->