### PR TITLE
fix(migrations): preserve legacy author identity

### DIFF
--- a/migrations/53_contract_canonical_author_identity.sql
+++ b/migrations/53_contract_canonical_author_identity.sql
@@ -28,8 +28,11 @@ CREATE TEMP TABLE canonical_author_upgrade ON COMMIT DROP AS
 WITH projected_authors AS (
   SELECT
     authors.*,
-    public.canonical_author_name(
-      regexp_replace(authors.name, '^[[:space:]]+', '')
+    COALESCE(
+      public.canonical_author_name(
+        regexp_replace(authors.name, '^[[:space:]]+', '')
+      ),
+      public.canonical_author_name(authors.normalized_name)
     ) AS canonical_name
   FROM public.authors
 ),

--- a/src/test/java/net/findmybook/service/BookAuthorUpsertIntegrationTest.java
+++ b/src/test/java/net/findmybook/service/BookAuthorUpsertIntegrationTest.java
@@ -362,7 +362,8 @@ class BookAuthorUpsertIntegrationTest {
             """
             INSERT INTO authors (id, name, normalized_name, biography, nationality, created_at, updated_at)
             VALUES
-                ('legacy-one', 'JANE DOE', 'jane doe', 'Biography', NULL, now() - interval '1 day', now()),
+                ('legacy-one', 'JANE' || chr(146) || ' DOE', 'jane doe',
+                    'Biography', NULL, now() - interval '1 day', now()),
                 ('legacy-two', 'Jane Doe', 'jane doe', NULL, 'US', now(), now())
             """
         );


### PR DESCRIPTION
## Summary
Allow the canonical author contraction to preserve deterministic identities for legacy rows whose display text contains rejected control or bidi characters.

## Changes by Category

### Bug Fixes
- **Legacy author contraction**: Use the existing normalized identity only when the raw display name cannot be safely canonicalized; rows still fail closed when neither source is usable.

### Testing
- **Corrupt legacy data**: Exercise a control-byte display name through merge, relationship, metadata, and external-ID contraction.

## Test plan
- [x] Run the PostgreSQL author-upsert integration suite
- [x] Run the full pre-push frontend and backend gates
- [ ] Apply migration 53 under the quiesced production maintenance window

## Breaking changes
None.

## Related issues
Follow-up to #122.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches migration 53’s full-table author identity contraction and merge logic; incorrect fallback could mis-merge or fail production cutover under the required quiesced window.
> 
> **Overview**
> Migration **53** now derives each author’s canonical display name with **`COALESCE`**: try `canonical_author_name` on the trimmed `name`, and only if that is null fall back to `canonical_author_name(normalized_name)`. Legacy rows whose display text still contains characters the canonicalizer rejects can therefore keep a **deterministic** merge key instead of being dropped from the upgrade set (which would fail the migration with an empty identity).
> 
> The author-upsert integration fixture was updated so **`legacy-one`** uses a display name built with **`chr(146)`** (a problematic apostrophe) while **`normalized_name`** stays `jane doe`, so the contraction path through merge, joins, metadata, and external IDs is covered end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c22240ba1c9e9c5aacea7ae2f22e090c9e7655a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->